### PR TITLE
Deploy keyboard_info data as a zip to downloads.keyman.com for consumption by api.keyman.com

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -48,7 +48,7 @@ function run {
       mkdir "$CI_CACHE/upload"
     fi
     zip_keyboard_info
-    rsync_to_downloads_keyman_com "$CI_CACHE/data/" db/
+    rsync_to_downloads_keyman_com "$CI_CACHE/data/" data/
     exit 0
   fi
   
@@ -67,7 +67,7 @@ function run {
   upload_keyboards_by_target
 
   zip_keyboard_info
-  rsync_to_downloads_keyman_com "$CI_CACHE/data/" db/
+  rsync_to_downloads_keyman_com "$CI_CACHE/data/" data/
 }
 
 ##

--- a/ci.sh
+++ b/ci.sh
@@ -26,19 +26,49 @@ fi
 
 parse_args "$@"
 
-if [[ $DO_UPLOAD_ONLY == true ]]; then
-  rsync_to_downloads_keyman_com "$CI_CACHE/upload/" keyboards/
-  exit 0
-fi
+function run {
 
-if [ ! -d "$CI_CACHE" ]; then
-  mkdir "$CI_CACHE"
-fi
+  if [ ! -d "$CI_CACHE" ]; then
+    mkdir "$CI_CACHE"
+  fi
 
-if [ -d "$CI_CACHE/upload" ]; then
-  rm -rf "$CI_CACHE/upload"
+  if [[ $DO_UPLOAD_ONLY == true ]]; then
+    if [ ! -d "$CI_CACHE/upload" ]; then
+      mkdir "$CI_CACHE/upload"
+    fi
+    rsync_to_downloads_keyman_com "$CI_CACHE/upload/" keyboards/ true
+    exit 0
+  fi
+
+  if [[ $DO_ZIP_ONLY == true ]]; then
+    if [ ! -d "$CI_CACHE/data" ]; then
+      mkdir "$CI_CACHE/data"
+    fi
+    if [ ! -d "$CI_CACHE/upload" ]; then
+      mkdir "$CI_CACHE/upload"
+    fi
+    zip_keyboard_info
+    rsync_to_downloads_keyman_com "$CI_CACHE/data/" db/
+    exit 0
+  fi
+  
+  if [ -d "$CI_CACHE/upload" ]; then
+    rm -rf "$CI_CACHE/upload"
+  fi
   mkdir "$CI_CACHE/upload"
-fi
+
+  if [ -d "$CI_CACHE/data" ]; then
+    rm -rf "$CI_CACHE/data"
+  fi
+  mkdir "$CI_CACHE/data"
+
+  check_latest_stable_keymandesktop
+  check_and_download_keymandesktop_artifacts
+  upload_keyboards_by_target
+
+  zip_keyboard_info
+  rsync_to_downloads_keyman_com "$CI_CACHE/data/" db/
+}
 
 ##
 ## Calls the Keyman Desktop downloads API to determine latest stable Keyman Desktop version 
@@ -97,7 +127,7 @@ function upload_keyboards_by_target {
     upload_keyboards experimental
   fi
   
-  rsync_to_downloads_keyman_com "$CI_CACHE/upload/" keyboards/
+  rsync_to_downloads_keyman_com "$CI_CACHE/upload/" keyboards/ true
 }
 
 ##
@@ -295,11 +325,24 @@ function upload_keyboards {
   return 0
 }
 
+##
+## zips all .keyboard_info files from .cache/upload/ into .cache/data/keyboard_info.zip
+##
+
+function zip_keyboard_info {
+  # We use an @list file to give a specific list of files to
+  # 7z so that it does not include pathnames in the archive
+  # The "./" on the front of the search is also needed to force 7Z to not 
+  # include pathnames in the archive
+  local files=(./.cache/upload/*/*/*.keyboard_info)
+  printf "%s\n" "${files[@]}" > .cache/keyboard_info.list
+  "$APP7Z" a ".cache/data/keyboard_info.zip" @.cache/keyboard_info.list
+  rm .cache/keyboard_info.list
+}
+
 ############################################################################################
 
-check_latest_stable_keymandesktop
-check_and_download_keymandesktop_artifacts
-upload_keyboards_by_target
+run
 
 ############################################################################################
 # EOF

--- a/resources/rsync-tools.sh
+++ b/resources/rsync-tools.sh
@@ -6,7 +6,14 @@
 function rsync_to_downloads_keyman_com {
   local source=$1
   local dest=$2
+  local ignore=$3
 
+  if [[ $ignore == true ]]; then
+    ignore=--ignore-existing
+  else
+    ignore=
+  fi
+  
   #rsync_args = (
   #  '-vtrp',                                  # verbose, preserve times, recurse, permissions
   #  '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
@@ -19,7 +26,7 @@ function rsync_to_downloads_keyman_com {
   
   pushd $source
   
-  "$RSYNC" -vtrp --chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r --stats --rsync-path="$REMOTE_RSYNC_PATH" --rsh=ssh --ignore-existing . "$RSYNC_DEST/$dest"
+  "$RSYNC" -vtrp --chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r --stats --rsync-path="$REMOTE_RSYNC_PATH" --rsh=ssh $ignore . "$RSYNC_DEST/$dest"
   
   popd
 }

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -49,6 +49,7 @@ function parse_args {
   DO_BUILD=true
   DO_CODESIGN=false
   DO_UPLOAD_ONLY=false
+  DO_ZIP_ONLY=false
   TARGET=
   PROJECT_TARGET=
   FLAG_SILENT=
@@ -61,7 +62,6 @@ function parse_args {
   
   # Parse args
   for key in "$@"; do
-    echo "$key"
     if [[ -z "$lastkey" ]]; then
       case "$key" in
         -upload-only)
@@ -72,6 +72,9 @@ function parse_args {
           ;;
         -codesign)
           DO_CODESIGN=true
+          ;;
+        -zip-only)
+          DO_ZIP_ONLY=true
           ;;
         -start)
           lastkey=$key


### PR DESCRIPTION
This CI work takes all the .keyboard_info files and adds them into a ZIP so that api.keyman.com backend can easily grab them when it needs for building its search database.