### PR TITLE
[gff_tigrinya_eritrea] add region to BCP47 tag in .keyboard_info

### DIFF
--- a/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.keyboard_info
+++ b/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.keyboard_info
@@ -1,7 +1,7 @@
 {
     "license": "mit",
     "languages": {
-        "ti": {
+        "ti-ER": {
             "example": {
                 "keys": "tgrNa",
                 "text": "\u1275\u130d\u122d\u129b",


### PR DESCRIPTION
address issue (fixes #158)