### PR TITLE
[khmer_ankor] Add touch keyboard to keyboard package

### DIFF
--- a/release/k/khmer_angkor/HISTORY.md
+++ b/release/k/khmer_angkor/HISTORY.md
@@ -1,5 +1,8 @@
 Khmer Angkor Change History
 =======================
+1.0.2 (21 Mar 2018)
+-------------------
+* rebuilt to include touch keyboard in the keyboard package
 
 1.0.1 (24 Feb 2018)
 -------------------

--- a/release/k/khmer_angkor/khmer_angkor.kpj
+++ b/release/k/khmer_angkor/khmer_angkor.kpj
@@ -10,11 +10,11 @@
       <ID>id_f347675c33d2e6b1c705c787fad4941a</ID>
       <Filename>khmer_angkor.kmn</Filename>
       <Filepath>source\khmer_angkor.kmn</Filepath>
-      <FileVersion>1.0.1</FileVersion>
+      <FileVersion>1.0.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Khmer Angkor</Name>
-        <Copyright>© 2017 SIL International</Copyright>
+        <Copyright>© 2017-2018 SIL International</Copyright>
         <Message>More than just a Khmer Unicode keyboard.</Message>
       </Details>
     </File>
@@ -59,6 +59,14 @@
       <Filepath>source\..\build\khmer_angkor.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
+      <ParentFileID>id_8d4eb765f80c9f2b0f769cf4e4aaa456</ParentFileID>
+    </File>
+    <File>
+      <ID>id_8dc195db32d1fd0514de0ad51fff5df0</ID>
+      <Filename>khmer_angkor.js</Filename>
+      <Filepath>source\..\build\khmer_angkor.js</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.js</FileType>
       <ParentFileID>id_8d4eb765f80c9f2b0f769cf4e4aaa456</ParentFileID>
     </File>
     <File>

--- a/release/k/khmer_angkor/source/khmer_angkor.kmn
+++ b/release/k/khmer_angkor/source/khmer_angkor.kmn
@@ -1,11 +1,11 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) "Khmer Angkor"
-store(&COPYRIGHT) '© 2017 SIL International'
+store(&COPYRIGHT) '© 2017-2018 SIL International'
 store(&MESSAGE) "More than just a Khmer Unicode keyboard."
 store(&VISUALKEYBOARD) 'khmer_angkor.kvk'
 store(&TARGETS) 'any windows'
 store(&LAYOUTFILE) 'khmer_angkor-layout.js'
-store(&KEYBOARDVERSION) '1.0.1'
+store(&KEYBOARDVERSION) '1.0.2'
 store(&BITMAP) 'khmer_angkor.ico'
 
 begin Unicode > use(main)

--- a/release/k/khmer_angkor/source/khmer_angkor.kps
+++ b/release/k/khmer_angkor/source/khmer_angkor.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>10.0.1025.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>10.0.1049.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -45,6 +45,12 @@
       <FileType>.kmx</FileType>
     </File>
     <File>
+      <Name>..\build\khmer_angkor.js</Name>
+      <Description>File khmer_angkor.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.js</FileType>
+    </File>
+    <File>
       <Name>keyboard_layout.png</Name>
       <Description>File keyboard_layout.png</Description>
       <CopyLocation>0</CopyLocation>
@@ -67,7 +73,7 @@
     <Keyboard>
       <Name>Khmer Angkor</Name>
       <ID>khmer_angkor</ID>
-      <Version>1.0</Version>
+      <Version>1.0.2</Version>
       <Languages>
         <Language ID="km">Khmer</Language>
       </Languages>


### PR DESCRIPTION
In order to use `khmer_angkor.kmp` as an example for [mobile keyboard distribution documentation](https://help.keyman.com/developer/10.0/guides/distribute/mobile-packages), we should add the .js file to the keyboard package.

* Also rev version from 1.0.1 to 1.0.2