### PR TITLE
Add keyboard name for NTL OneKey in keyboard_info file

### DIFF
--- a/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -1,6 +1,6 @@
 {
     "id": "ntl_onekey",
-    "name": "\u65B0\u50A3\u6587\u4E00\u952E"
+    "name": "\u65B0\u50A3\u6587\u4E00\u952E",
     "license": "mit",
     "languages": [
         "khb"

--- a/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -1,5 +1,6 @@
 {
     "id": "ntl_onekey",
+    "name": "\u65B0\u50A3\u6587\u4E00\u952E"
     "license": "mit",
     "languages": [
         "khb"


### PR DESCRIPTION
I've added a name (in Chinese) for the NTL OneKey keyboard to the keyboard_info file.