### PR TITLE
Make build script more robust for nearly-empty folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Linux, macOS:
   * `-s         Quieter build`
   * `-c         Clean instead of build`
   * `-d         Include debug information`
+  * `-w         Treat warnings as errors`
   * `[target]   Specific folder to build`
 
 * Each keyboard also includes a project file which can be used to build the project - either from the command line 

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 #
 
 function display_usage {
-  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-t project_target] [target]"
+  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-t project_target] [target]"
   exit 1
 }
 

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -51,6 +51,7 @@ function parse_args {
   DO_UPLOAD_ONLY=false
   DO_ZIP_ONLY=false
   DO_EXE=true
+  WARNINGS_AS_ERRORS=false
   TARGET=
   PROJECT_TARGET=
   FLAG_SILENT=
@@ -92,6 +93,9 @@ function parse_args {
         -c)
           FLAG_CLEAN=-c
           ;;
+        -w)
+          WARNINGS_AS_ERRORS=true
+          ;;          
         -h|-?)
           display_usage
           ;;
@@ -99,7 +103,7 @@ function parse_args {
           lastkey=$key
           ;;
         *)
-          TARGET="$1"
+          TARGET="$1" # should this be "$key"?
       esac
     else
       case "$lastkey" in


### PR DESCRIPTION
* Add build parameter `-w` to treat warnings as errors
* When building keyboards, skip if no .keyboard_info file exists or directory is empty