### PR TITLE
[arabic_izza] Improved phone layout

### DIFF
--- a/Izza3-layout.js
+++ b/Izza3-layout.js
@@ -1,0 +1,1220 @@
+{
+  "tablet": {
+    "font": "Tahoma",
+    "layer": [
+      {
+        "id": "default",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "K_BKQUOTE",
+                "text": "ِ"
+              },
+              {
+                "id": "K_1",
+                "text": "1"
+              },
+              {
+                "id": "K_2",
+                "text": "2"
+              },
+              {
+                "id": "K_3",
+                "text": "3"
+              },
+              {
+                "id": "K_4",
+                "text": "4"
+              },
+              {
+                "id": "K_5",
+                "text": "5"
+              },
+              {
+                "id": "K_6",
+                "text": "6"
+              },
+              {
+                "id": "K_7",
+                "text": "7"
+              },
+              {
+                "id": "K_8",
+                "text": "8"
+              },
+              {
+                "id": "K_9",
+                "text": "9"
+              },
+              {
+                "id": "K_0",
+                "text": "0"
+              },
+              {
+                "id": "K_HYPHEN",
+                "text": "َ"
+              },
+              {
+                "id": "K_EQUAL",
+                "text": "ّ"
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "K_Q",
+                "text": "ض",
+                "pad": 75
+              },
+              {
+                "id": "K_W",
+                "text": "ص"
+              },
+              {
+                "id": "K_E",
+                "text": "ث"
+              },
+              {
+                "id": "K_R",
+                "text": "ق"
+              },
+              {
+                "id": "K_T",
+                "text": "ف",
+                "sk": [
+                  {
+                    "text": "ڤ",
+                    "id": "K_T",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_Y",
+                "text": "غ"
+              },
+              {
+                "id": "K_U",
+                "text": "ع"
+              },
+              {
+                "id": "K_I",
+                "text": "ه"
+              },
+              {
+                "id": "K_O",
+                "text": "خ"
+              },
+              {
+                "id": "K_P",
+                "text": "ح"
+              },
+              {
+                "id": "K_LBRKT",
+                "text": "ج",
+                "sk": [
+                  {
+                    "text": "چ",
+                    "id": "K_LBRKT",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_RBRKT",
+                "text": "د"
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_A",
+                "text": "ش"
+              },
+              {
+                "id": "K_S",
+                "text": "س"
+              },
+              {
+                "id": "K_D",
+                "text": "ي"
+              },
+              {
+                "id": "K_F",
+                "text": "ب",
+                "sk": [
+                  {
+                    "text": "پ",
+                    "id": "K_F",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_G",
+                "text": "ا"
+              },
+              {
+                "id": "K_H",
+                "text": "ل"
+              },
+              {
+                "id": "K_J",
+                "text": "ت"
+              },
+              {
+                "id": "K_K",
+                "text": "ن"
+              },
+              {
+                "id": "K_L",
+                "text": "م"
+              },
+              {
+                "id": "K_COLON",
+                "text": "ك",
+                "sk": [
+                  {
+                    "text": "گ",
+                    "id": "K_COLON",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_QUOTE",
+                "text": "ط"
+              },
+              {
+                "id": "K_BKSLASH",
+                "text": "ذ"
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": "100",
+                "sp": "1"
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_SHIFT",
+                "text": "*Shift*",
+                "width": "160",
+                "sp": "1",
+                "nextlayer": "shift"
+              },
+              {
+                "id": "K_Z",
+                "text": "،"
+              },
+              {
+                "id": "K_X",
+                "text": "ُ"
+              },
+              {
+                "id": "K_C",
+                "text": "ر"
+              },
+              {
+                "id": "K_V",
+                "text": "ء"
+              },
+              {
+                "id": "K_B",
+                "text": "ال"
+              },
+              {
+                "id": "K_N",
+                "text": "ى"
+              },
+              {
+                "id": "K_M",
+                "text": "ة"
+              },
+              {
+                "id": "K_COMMA",
+                "text": "و"
+              },
+              {
+                "id": "K_PERIOD",
+                "text": "ز",
+                "sk": [
+                  {
+                    "text": "ژ",
+                    "id": "K_PERIOD",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_SLASH",
+                "text": "ظ"
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": "145",
+                "sp": "1"
+              }
+            ]
+          },
+          {
+            "id": 5,
+            "key": [
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": 119,
+                "sp": "1"
+              },
+              {
+                "id": "K_9",
+                "text": "(",
+                "layer": "shift"
+              },
+              {
+                "id": "K_0",
+                "text": ")",
+                "layer": "shift"
+              },
+              {
+                "id": "K_SLASH",
+                "text": "؟",
+                "layer": "shift"
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": "500",
+                "sp": "0"
+              },
+              {
+                "id": "K_V",
+                "text": "!",
+                "layer": "shift"
+              },
+              {
+                "id": "K_N",
+                "text": ":",
+                "layer": "shift"
+              },
+              {
+                "id": "K_B",
+                "text": "؛",
+                "layer": "shift"
+              },
+              {
+                "id": "K_COMMA",
+                "text": ".",
+                "layer": "shift"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "shift",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "K_BKQUOTE",
+                "text": "ٍ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_1",
+                "text": "©",
+                "layer": "shift"
+              },
+              {
+                "id": "K_2",
+                "text": "@",
+                "layer": "shift"
+              },
+              {
+                "id": "K_3",
+                "text": "#",
+                "layer": "shift"
+              },
+              {
+                "id": "K_4",
+                "text": "~",
+                "layer": "shift"
+              },
+              {
+                "id": "K_5",
+                "text": "%",
+                "layer": "shift"
+              },
+              {
+                "id": "K_6",
+                "text": "*",
+                "layer": "shift"
+              },
+              {
+                "id": "K_7",
+                "text": "&",
+                "layer": "shift"
+              },
+              {
+                "id": "K_8",
+                "text": "_",
+                "layer": "shift"
+              },
+              {
+                "id": "K_9",
+                "text": "(",
+                "layer": "shift"
+              },
+              {
+                "id": "K_0",
+                "text": ")",
+                "layer": "shift"
+              },
+              {
+                "id": "K_HYPHEN",
+                "text": "ً",
+                "layer": "shift"
+              },
+              {
+                "id": "K_EQUAL",
+                "text": "ّ",
+                "layer": "shift"
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "K_Q",
+                "text": "ُ",
+                "pad": 75,
+                "layer": "shift"
+              },
+              {
+                "id": "K_W",
+                "text": "ٌ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_E",
+                "text": "ٍ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_R",
+                "text": "ً",
+                "layer": "shift"
+              },
+              {
+                "id": "K_T",
+                "text": "ڤ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_Y",
+                "text": "=",
+                "layer": "shift"
+              },
+              {
+                "id": "K_U",
+                "text": "\\",
+                "layer": "shift"
+              },
+              {
+                "id": "K_I",
+                "text": "÷",
+                "layer": "shift"
+              },
+              {
+                "id": "K_O",
+                "text": "×",
+                "layer": "shift"
+              },
+              {
+                "id": "K_P",
+                "text": "-",
+                "layer": "shift"
+              },
+              {
+                "id": "K_LBRKT",
+                "text": "چ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_RBRKT",
+                "text": "+",
+                "layer": "shift"
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_A",
+                "text": "ّ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_S",
+                "text": "ْ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_D",
+                "text": "|",
+                "layer": "shift"
+              },
+              {
+                "id": "K_F",
+                "text": "پ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_G",
+                "text": "{",
+                "layer": "shift"
+              },
+              {
+                "id": "K_H",
+                "text": "}",
+                "layer": "shift"
+              },
+              {
+                "id": "K_J",
+                "text": "ـ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_K",
+                "text": "[",
+                "layer": "shift"
+              },
+              {
+                "id": "K_L",
+                "text": "]",
+                "layer": "shift"
+              },
+              {
+                "id": "K_COLON",
+                "text": "گ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_QUOTE",
+                "text": "<",
+                "layer": "shift"
+              },
+              {
+                "id": "K_BKSLASH",
+                "text": ">",
+                "layer": "shift"
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": "100",
+                "sp": "1"
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_SHIFT",
+                "text": "",
+                "width": "160",
+                "sp": "2",
+                "nextlayer": "default"
+              },
+              {
+                "id": "K_Z",
+                "text": "،",
+                "layer": "shift"
+              },
+              {
+                "id": "K_X",
+                "text": "ٌ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_C",
+                "text": "\"",
+                "layer": "shift"
+              },
+              {
+                "id": "K_V",
+                "text": "!",
+                "layer": "shift"
+              },
+              {
+                "id": "K_B",
+                "text": "؛",
+                "layer": "shift"
+              },
+              {
+                "id": "K_N",
+                "text": ":",
+                "layer": "shift"
+              },
+              {
+                "id": "K_M",
+                "text": "،",
+                "layer": "shift"
+              },
+              {
+                "id": "K_COMMA",
+                "text": ".",
+                "layer": "shift"
+              },
+              {
+                "id": "K_PERIOD",
+                "text": "ژ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_SLASH",
+                "text": "؟",
+                "layer": "shift"
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": "145",
+                "sp": "1"
+              }
+            ]
+          },
+          {
+            "id": 5,
+            "key": [
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": "180",
+                "sp": "1"
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": "1140",
+                "sp": "0"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "phone": {
+    "font": "Tahoma",
+    "layer": [
+      {
+        "id": "default",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "K_W",
+                "text": "ص",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ض",
+                    "id": "K_Q"
+                  }
+                ]
+              },
+              {
+                "id": "K_R",
+                "text": "ق",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "(",
+                    "id": "K_9",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": ")",
+                    "id": "K_0",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_T",
+                "text": "ف",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ڤ",
+                    "id": "K_T",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_U",
+                "text": "ع",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "غ",
+                    "id": "K_Y"
+                  }
+                ]
+              },
+              {
+                "id": "K_I",
+                "text": "ه",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ة",
+                    "id": "K_M"
+                  }
+                ]
+              },
+              {
+                "id": "K_P",
+                "text": "ح",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "خ",
+                    "id": "K_O"
+                  }
+                ]
+              },
+              {
+                "id": "K_LBRKT",
+                "text": "ج",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "چ",
+                    "id": "K_LBRKT",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_COLON",
+                "text": "ك",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "گ",
+                    "id": "K_COLON",
+                    "layer": "shift"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "K_S",
+                "text": "س",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ش",
+                    "id": "K_A"
+                  }
+                ]
+              },
+              {
+                "id": "K_D",
+                "text": "ي",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "=",
+                    "id": "K_Y",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_F",
+                "text": "ب",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "پ",
+                    "id": "K_F",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_G",
+                "text": "ا",
+                "width": "146"
+              },
+              {
+                "id": "K_H",
+                "text": "ل",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ـ",
+                    "id": "K_J",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_J",
+                "text": "ت",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ث",
+                    "id": "K_E"
+                  }
+                ]
+              },
+              {
+                "id": "K_K",
+                "text": "ن",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": ".",
+                    "id": "K_COMMA",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_L",
+                "text": "م",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "×",
+                    "id": "K_O",
+                    "layer": "shift"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_Z",
+                "text": "،",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ـ",
+                    "id": "K_J",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_C",
+                "text": "ر",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ز",
+                    "id": "K_PERIOD"
+                  },
+                  {
+                    "text": "ژ",
+                    "id": "K_PERIOD",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_V",
+                "text": "ء",
+                "width": "146"
+              },
+              {
+                "id": "K_B",
+                "text": "ال",
+                "width": "146"
+              },
+              {
+                "id": "K_N",
+                "text": "ى",
+                "width": "146"
+              },
+              {
+                "id": "K_COMMA",
+                "text": "و",
+                "width": "146"
+              },
+              {
+                "id": "K_QUOTE",
+                "text": "ط",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ظ",
+                    "id": "K_SLASH"
+                  }
+                ]
+              },
+              {
+                "id": "K_RBRKT",
+                "text": "د",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "ذ",
+                    "id": "K_BKSLASH"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_NUMLOCK",
+                "text": "*123*",
+                "width": "140",
+                "sp": "1",
+                "nextlayer": "numeric"
+              },
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": "120",
+                "sp": "1"
+              },
+              {
+                "id": "K_COMMA",
+                "text": ".",
+                "width": "146",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "؟",
+                    "id": "K_SLASH",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "!",
+                    "id": "K_V",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": ":",
+                    "id": "K_N",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "؛",
+                    "id": "K_B",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": "340",
+                "sp": "0"
+              },
+              {
+                "id": "K_EQUAL",
+                "text": "ّ",
+                "width": "146",
+                "sk": [
+                  {
+                    "text": "َ",
+                    "id": "K_HYPHEN"
+                  },
+                  {
+                    "text": "ِ",
+                    "id": "K_BKQUOTE"
+                  },
+                  {
+                    "text": "ُ",
+                    "id": "K_X"
+                  }
+                ]
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": "140",
+                "sp": "1"
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": "140",
+                "sp": "1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "numeric",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "K_1",
+                "text": "1",
+                "width": "104"
+              },
+              {
+                "id": "K_2",
+                "text": "2",
+                "width": "104"
+              },
+              {
+                "id": "K_3",
+                "text": "3",
+                "width": "104"
+              },
+              {
+                "id": "K_4",
+                "text": "4",
+                "width": "104"
+              },
+              {
+                "id": "K_5",
+                "text": "5",
+                "width": "104"
+              },
+              {
+                "id": "K_6",
+                "text": "6",
+                "width": "104"
+              },
+              {
+                "id": "K_7",
+                "text": "7",
+                "width": "104"
+              },
+              {
+                "id": "K_8",
+                "text": "8",
+                "width": "104"
+              },
+              {
+                "id": "K_9",
+                "text": "9",
+                "width": "104"
+              },
+              {
+                "id": "K_0",
+                "text": "0",
+                "width": "104"
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "K_2",
+                "text": "@",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_3",
+                "text": "#",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_5",
+                "text": "%",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_6",
+                "text": "*",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_Y",
+                "text": "=",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_U",
+                "text": "\\",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_I",
+                "text": "÷",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_O",
+                "text": "×",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_P",
+                "text": "-",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_RBRKT",
+                "text": "+",
+                "width": "104",
+                "layer": "shift"
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_4",
+                "text": "~",
+                "pad": "",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_C",
+                "text": "\"",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_D",
+                "text": "|",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_G",
+                "text": "{",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_H",
+                "text": "}",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_K",
+                "text": "[",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_L",
+                "text": "]",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_QUOTE",
+                "text": "<",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_BKSLASH",
+                "text": ">",
+                "width": "104",
+                "layer": "shift"
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": "104",
+                "sp": "1"
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": "120",
+                "sp": "1"
+              },
+              {
+                "id": "K_S",
+                "text": "ْ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_BKQUOTE",
+                "text": "ٍ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": "390",
+                "sp": "0"
+              },
+              {
+                "id": "K_HYPHEN",
+                "text": "ً",
+                "layer": "shift"
+              },
+              {
+                "id": "K_X",
+                "text": "ٌ",
+                "layer": "shift"
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": "150",
+                "sp": "1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Corrected the five Keys ("، |، {، } ، [) on numeric layer that weren't working because of small letters used instead of capital ones to identify them.
Swapped some keys on third line of default layer to match those on physical keyboard.
Put letter ة with ه, and the comma in place of ة, and full stop in place of comma in the fourth line.
Couldn't replace, the first key starting left on the fourth line of the numeric layer, with a key that would enable shifting back to default layer.