### PR TITLE
[easy_chakma_new_deprecate] keyboard is deprecated

### DIFF
--- a/legacy/e/easy chakma new/DEPRECATED.md
+++ b/legacy/e/easy chakma new/DEPRECATED.md
@@ -1,0 +1,1 @@
+This keyboard has been deprecated and replaced by release/e/easy_chakma


### PR DESCRIPTION
Added DEPRECATED.md file. The keyboard_info file in easy_chakma already deprecates this keyboard so this is just completing it to make it clearer that this is deprecated.