### PR TITLE
[syriac_aramaic-help] Added minimal help file with links to layouts

### DIFF
--- a/release/packages/syriac_aramaic/source/help/syriac_aramaic.php
+++ b/release/packages/syriac_aramaic/source/help/syriac_aramaic.php
@@ -10,8 +10,8 @@
 href='http://www.BethMardutho.org/'>Beth Mardutho: The Syriac Institute</a>.</p>
   <section id='related'>
 	<h2>Keyboard Layouts</h2>
-<ul><a href="http://help.keyman.com/keyboard/aramaic_hebrew">Aramaic (Hebrew layout)</a> </ul>
-<ul><a href="http://help.keyman.com/keyboard/syriac_arabic">Syriac (Arabic layout)</a> </ul>
-<ul><a href="http://help.keyman.com/keyboard/syriac_phonetic">Syriac (Phonetic layout)</a> </ul>
+<ul><a href="https://help.keyman.com/keyboard/aramaic_hebrew">Aramaic (Hebrew layout)</a> </ul>
+<ul><a href="https://help.keyman.com/keyboard/syriac_arabic">Syriac (Arabic layout)</a> </ul>
+<ul><a href="https://help.keyman.com/keyboard/syriac_phonetic">Syriac (Phonetic layout)</a> </ul>
   </section>
 

--- a/release/packages/syriac_aramaic/source/help/syriac_aramaic.php
+++ b/release/packages/syriac_aramaic/source/help/syriac_aramaic.php
@@ -1,0 +1,17 @@
+﻿<?php
+  $pagename = 'Syriac/Aramaic Keyboard Package Help';
+  $pagetitle = 'Syriac/Aramaic Keyboard Package Help';
+  require_once('header.php');
+?>
+<body>
+<p>This package includes 3 Syriac/Aramaic keyboards called: <b>Aramaic (Hebrew layout)</b>, <b>Syriac (Phonetic layout)</b>, and <b>Syriac (Arabic layout)</b> designed for use with <b>Aramaic</b> and <b>Syriac</b> and related languages.</p>
+<p>Syriac (Arabic layout) and Syriac (Phonetic layout) keyboards are based on the standard Syriac keyboards.  The Aramaic (Hebrew layout) keyboard was originally created by Illan Gonen, and is based on the Hebrew standard keyboard layout.</p>
+<p>The fonts included with these keyboards have been provided by <a target='_blank' 
+href='http://www.BethMardutho.org/'>Beth Mardutho: The Syriac Institute</a>.</p>
+  <section id='related'>
+	<h2>Keyboard Layouts</h2>
+<ul><a href="http://help.keyman.com/keyboard/aramaic_hebrew">Aramaic (Hebrew layout)</a> </ul>
+<ul><a href="http://help.keyman.com/keyboard/syriac_arabic">Syriac (Arabic layout)</a> </ul>
+<ul><a href="http://help.keyman.com/keyboard/syriac_phonetic">Syriac (Phonetic layout)</a> </ul>
+  </section>
+


### PR DESCRIPTION
I realized there is a link to a non-existent help file. So, this is a minimal file that points to the 3 keyboard layouts.