### PR TITLE
[sil_philippines] Remove statement about US keyboard

### DIFF
--- a/release/sil/sil_philippines/HISTORY.md
+++ b/release/sil/sil_philippines/HISTORY.md
@@ -1,6 +1,11 @@
 Philippines (SIL) Keyboard Change History
 =======================
 
+1.0.1 (22 Aug 2018)
+------------------
+* Removed inaccurate statement about US keyboard.
+* Removed reference to Andika New Basic
+
 1.0 (12 Aug 2018)
 ------------------
 * Renamed keyboard

--- a/release/sil/sil_philippines/README.md
+++ b/release/sil/sil_philippines/README.md
@@ -3,13 +3,11 @@ Philippines (SIL) Keyboard
 
 Copyright (C) 2006-2018 SIL Philippines
 
-Version 1.0
+Version 1.0.1
 
 __DESCRIPTION__
 This keyboard enables the typing of all Philippine languages. It gives the ability to
 type all the special characters and diacritics in the languages of the Philippines.
-
-This keyboard is designed to work with a US English keyboard.
 
 Links
 -----

--- a/release/sil/sil_philippines/sil_philippines.keyboard_info
+++ b/release/sil/sil_philippines/sil_philippines.keyboard_info
@@ -129,5 +129,5 @@
         "yka-Latn",
         "yog-Latn"
         ],
-    "description": "This keyboard enables the typing of all Philippine languages. It gives the ability to type all the special characters and diacritics in the languages of the Philippines. This keyboard is designed to work with a US English keyboard."
+    "description": "This keyboard enables the typing of all Philippine languages. It gives the ability to type all the special characters and diacritics in the languages of the Philippines."
 }

--- a/release/sil/sil_philippines/source/help/sil_philippines.php
+++ b/release/sil/sil_philippines/source/help/sil_philippines.php
@@ -34,7 +34,7 @@ in which column:</p>
 
 <p>All of these characters may be displayed correctly with the <a target='_blank' href='https://software.sil.org/doulos/'>Doulos SIL</a>, 
 	<a target='_blank' href='https://software.sil.org/charis/'>Charis SIL</a>, 
-	<a target='_blank' href='https://software.sil.org/andika/'>Andika New Basic</a>, and 
+	<a target='_blank' href='https://software.sil.org/andika/'>Andika</a>, and 
 	<a target='_blank' href='https://software.sil.org/gentium/'>Gentium Plus</a> fonts, as well as with more
 common Windows fonts like Times New Roman, Arial, Calibri, and Cambria.</p>
 

--- a/release/sil/sil_philippines/source/readme.htm
+++ b/release/sil/sil_philippines/source/readme.htm
@@ -11,7 +11,6 @@
     <p>©&nbsp;2006-2018 SIL Philippines</p>
     <p>This keyboard enables the typing of all Philippine languages. It gives the ability to
 type all the special characters and diacritics in the languages of the Philippines.</p>
-<p>This keyboard is designed to work with a US English keyboard.</p>
   </div>
 </body>
 </html>

--- a/release/sil/sil_philippines/source/sil_philippines.kmn
+++ b/release/sil/sil_philippines/source/sil_philippines.kmn
@@ -7,7 +7,7 @@ store(&VERSION) '10.0'
 store(&NAME) 'Philippines (SIL)'
 store(&BITMAP) 'sil_philippines.ico'
 store(&MnemonicLayout) "1"
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&TARGETS) 'windows macosx linux web'
 store(&COPYRIGHT) '2006-2018 SIL Philippines'
 store(&VISUALKEYBOARD) 'sil_philippines.kvks'

--- a/release/sil/sil_philippines/source/welcome/welcome.htm
+++ b/release/sil/sil_philippines/source/welcome/welcome.htm
@@ -77,7 +77,7 @@ in which column:</p>
 
 <p>All of these characters may be displayed correctly with the <a target='_blank' href='https://software.sil.org/doulos/'>Doulos SIL</a>, 
 	<a target='_blank' href='https://software.sil.org/charis/'>Charis SIL</a>, 
-	<a target='_blank' href='https://software.sil.org/andika/'>Andika New Basic</a>, and 
+	<a target='_blank' href='https://software.sil.org/andika/'>Andika</a>, and 
 	<a target='_blank' href='https://software.sil.org/gentium/'>Gentium Plus</a> fonts, as well as with more
 common Windows fonts like Times New Roman, Arial, Calibri, and Cambria.</p>
 


### PR DESCRIPTION
Also changed "Andika New Basic" to "Andika" since ANB does not have barred yY in the font.