### PR TITLE
[sil_yi] correct output for rryx

### DIFF
--- a/release/sil/sil_yi/HISTORY.md
+++ b/release/sil/sil_yi/HISTORY.md
@@ -1,5 +1,8 @@
 SIL Yi Keyboard Change History
 =======================
+1.2.3 (19 Nov 2018)
+--------------------
+* Fix output for 'rryx'
 
 1.2.2 (14 Sept 2018)
 --------------------

--- a/release/sil/sil_yi/README.md
+++ b/release/sil/sil_yi/README.md
@@ -3,7 +3,7 @@ SIL Yi Keyboard
 
 Copyright (C) 2000-2018 SIL International
 
-Version 1.2.1
+Version 1.2.3
 
 __DESCRIPTION__
 Yi keyboard layout using pinyin input.

--- a/release/sil/sil_yi/sil_yi.kpj
+++ b/release/sil/sil_yi/sil_yi.kpj
@@ -10,7 +10,7 @@
       <ID>id_caa17db2739ae8db77ef908aaf9e2108</ID>
       <Filename>sil_yi.kmn</Filename>
       <Filepath>source\sil_yi.kmn</Filepath>
-      <FileVersion>1.2.2</FileVersion>
+      <FileVersion>1.2.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>SIL Yi</Name>

--- a/release/sil/sil_yi/source/readme.htm
+++ b/release/sil/sil_yi/source/readme.htm
@@ -8,7 +8,7 @@
 
 <h1>SIL Yi keyboard layout</h1>
 
-<p>Version 1.2.2<br>Copyright (C) 2000-2018 SIL International</p>
+<p>Version 1.2.3<br>Copyright (C) 2000-2018 SIL International</p>
 
 <p>Yi keyboard layout using pinyin input.</p>
 

--- a/release/sil/sil_yi/source/sil_yi.kmn
+++ b/release/sil/sil_yi/source/sil_yi.kmn
@@ -1094,7 +1094,7 @@ c ------------------------------------
 'rrurx' + ' '       > U+a38c         c rrurx
 'rrur' + ' '      > U+a38d         c rrur
 'rryt' + ' '       > U+a38e         c rryt
-'rryx' + ' '       > U+a39f         c rryx
+'rryx' + ' '       > U+a38f         c rryx
 'rry' + ' '      > U+a390         c rry
 'rryp' + ' '       > U+a391         c rryp
 'rryrx' + ' '       > U+a392         c rryrx

--- a/release/sil/sil_yi/source/sil_yi.kps
+++ b/release/sil/sil_yi/source/sil_yi.kps
@@ -44,7 +44,7 @@
     <Keyboard>
       <Name>SIL Yi</Name>
       <ID>sil_yi</ID>
-      <Version>1.2.2</Version>
+      <Version>1.2.3</Version>
       <Languages>
         <Language ID="ii-Yiii">Sichuan Yi, Nuosu</Language>
         <Language ID="nos">Eastern Nisu</Language>


### PR DESCRIPTION
This fix is based on comment from @mhosken: I've found a bug in the SIL Yi keyboard. `'rryx' + " "` should map to `U+A38F` but there is a typo mapping it to `U+A39F`.