### PR TITLE
[rac_hindko] Revert rac_hindko.keyboard_info file

### DIFF
--- a/release/rac/rac_hindko/rac_hindko.keyboard_info
+++ b/release/rac/rac_hindko/rac_hindko.keyboard_info
@@ -4,7 +4,7 @@
   "languages": {
     "hnd-Arab": {
       "example" : {
-        "keys" : "hndkw ",
+        "keys" : "ondkw ",
         "text" : "ہندکو",
         "note" : "Name of language"
       }

--- a/release/rac/rac_hindko/rac_hindko.keyboard_info
+++ b/release/rac/rac_hindko/rac_hindko.keyboard_info
@@ -1,0 +1,17 @@
+﻿{
+  "id": "rac_hindko",
+  "name": "Rachitrali-Hindko",
+  "languages": {
+    "hnd-Arab": {
+      "example" : {
+        "keys" : "hndkw ",
+        "text" : "ہندکو",
+        "note" : "Name of language"
+      }
+    }
+  },
+  "description": "This keyboard was developed by Rehmat Aziz Chitrali Linguist and Researcher at Khowar Academy Chitral  Pakistan for keyboarding the Dhatki language in the Arabic Script. You can use this keyboard with any extended Arabic script Unicode font.\r\n\r\nIf you have problems using the RAChitrali-Dhatki Keyman keyboard, please contact:\r\n\r\nRehmat Aziz Chitrali\r\nE-mail: rachitrali@yahoo.com",
+  "authorName": "Rehmat Aziz Chitrali",
+  "license": "mit"
+}
+

--- a/release/rac/rac_hindko/rac_hindko.keyboard_info
+++ b/release/rac/rac_hindko/rac_hindko.keyboard_info
@@ -10,7 +10,7 @@
       }
     }
   },
-  "description": "This keyboard was developed by Rehmat Aziz Chitrali Linguist and Researcher at Khowar Academy Chitral  Pakistan for keyboarding the Dhatki language in the Arabic Script. You can use this keyboard with any extended Arabic script Unicode font.\r\n\r\nIf you have problems using the RAChitrali-Dhatki Keyman keyboard, please contact:\r\n\r\nRehmat Aziz Chitrali\r\nE-mail: rachitrali@yahoo.com",
+  "description": "This keyboard was developed by Rehmat Aziz Chitrali Linguist and Researcher at Khowar Academy Chitral  Pakistan for keyboarding the Hindko language in the Arabic Script. You can use this keyboard with any extended Arabic script Unicode font.\r\n\r\nIf you have problems using the RAChitrali-Hindko Keyman keyboard, please contact:\r\n\r\nRehmat Aziz Chitrali\r\nE-mail: rachitrali@yahoo.com",
   "authorName": "Rehmat Aziz Chitrali",
   "license": "mit"
 }


### PR DESCRIPTION
After #563 , the CI build is failing because `rac_hindko.keyboard_info` is missing.
This PR reverts the file from #356 

