### PR TITLE
[sil_tawallammat] case in welcome.htm for ralt image

### DIFF
--- a/release/sil/sil_tawallammat/source/welcome/welcome.htm
+++ b/release/sil/sil_tawallammat/source/welcome/welcome.htm
@@ -34,7 +34,7 @@ sequence: <img src="2d54.png">, <img src="2d7f.png">, and <img src="2d5c.png"> t
     <h3>Shift</h3>
     <p><img src="sil_tawallammatU_S.png" alt="Tawallammat Tifinagh (SIL) Keyboard: shift"></p>
     <h3>Right ALT</h3>
-    <p><img src="sil_tawallammAtU_RA.png" alt="Tawallammat Tifinagh (SIL) Keyboard: ralt"></p>
+    <p><img src="sil_tawallammatU_RA.png" alt="Tawallammat Tifinagh (SIL) Keyboard: ralt"></p>
 
   
 


### PR DESCRIPTION
The ralt image in welcome.htm isn't visible on case-sensitive systems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyboards/571)
<!-- Reviewable:end -->
