### PR TITLE
[lao_2008_basic] Associate saysettha_ot.ttf font

### DIFF
--- a/release/l/lao_2008_basic/lao_2008_basic.keyboard_info
+++ b/release/l/lao_2008_basic/lao_2008_basic.keyboard_info
@@ -2,6 +2,13 @@
     "license": "mit",
     "languages": {
       "lo": {
+        "font": {
+          "family": "Saysettha_OT",
+          "source": [
+            "saysettha_ot.ttf",
+            "saysettha_OT.mobileconfig"
+          ]
+        },
         "example": {
           "keys": "rklk]k;d=wfh",
           "text": "\u0E9E\u0EB2\u0EAA\u0EB2\u0EA5\u0EB2\u0EA7\u0E81\u0ECD\u0EC4\u0E94\u0EC9",


### PR DESCRIPTION
The keyboard uses saysettha_ot.ttf so update keyboard_info file.

c.f. https://github.com/sillsdev/keyman-s.keyman.com/pull/46