### PR TITLE
[ntl_onekey] Add language tag khb-Talu to keyboard package

### DIFF
--- a/experimental/n/ntl_onekey/HISTORY.md
+++ b/experimental/n/ntl_onekey/HISTORY.md
@@ -1,6 +1,7 @@
 NTL OneKey Changelog
 ====================
 
+DDW   1.003   21-JAN-2019     Add language tag to keyboard package
 EJD   1.002   18-FEB-2018     Fix up numeric layer issues
 EJD   1.001   18-DEC-2017     Added touch layout
 AYWC  1.000   22-MAY-2015     Original

--- a/experimental/n/ntl_onekey/README.md
+++ b/experimental/n/ntl_onekey/README.md
@@ -1,11 +1,11 @@
 NTL OneKey keyboard
 ===================
 
-Copyright (C) 2015-2018 SIL International
+Copyright (C) 2015-2019 SIL International
 
-Version 1.002
+Version 1.003
 
-A Unicode keyboard for the New Tai Lue script (khb).
+A Unicode keyboard for the New Tai Lue script (khb-Talu).
 
 Supported Platforms
 -------------------

--- a/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/experimental/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -3,6 +3,6 @@
     "name": "\u65B0\u50A3\u6587\u4E00\u952E",
     "license": "mit",
     "languages": [
-        "khb"
+        "khb-Talu"
     ]
 }

--- a/experimental/n/ntl_onekey/ntl_onekey.kpj
+++ b/experimental/n/ntl_onekey/ntl_onekey.kpj
@@ -10,11 +10,11 @@
       <ID>id_59d1bdff9611be66e1f2ce122cbcdac9</ID>
       <Filename>ntl_onekey.kmn</Filename>
       <Filepath>source\ntl_onekey.kmn</Filepath>
-      <FileVersion>1.002</FileVersion>
+      <FileVersion>1.003</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>新傣文一键</Name>
-        <Copyright>Copyright © 2015-2018 SIL International</Copyright>
+        <Copyright>Copyright © 2015-2019 SIL International</Copyright>
         <Message>This NTL OneKey (新傣文一键) keyboard is distributed under the MIT License.</Message>
       </Details>
     </File>
@@ -22,12 +22,11 @@
       <ID>id_bf8a8c18aead9f9ea9bf587a10c174cf</ID>
       <Filename>ntl_onekey.kps</Filename>
       <Filepath>source\ntl_onekey.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion></FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>ntl_onekey</Name>
-        <Copyright>© 2015-2018 SIL International</Copyright>
-        <Version>1.0</Version>
+        <Copyright>© 2015-2019 SIL International</Copyright>
       </Details>
     </File>
     <File>

--- a/experimental/n/ntl_onekey/source/ntl_onekey.kmn
+++ b/experimental/n/ntl_onekey/source/ntl_onekey.kmn
@@ -10,10 +10,10 @@ store(&VERSION) '9.0'
 store(&NAME) '新傣文一键'
 store(&TARGETS) 'windows macosx iphone androidphone mobile'
 store(&ETHNOLOGUECODE) 'khb'
-store(&COPYRIGHT) 'Copyright © 2015-2018 SIL International'
+store(&COPYRIGHT) 'Copyright © 2015-2019 SIL International'
 store(&MESSAGE) 'This NTL OneKey (新傣文一键) keyboard is distributed under the MIT License.'
 store(&LAYOUTFILE) 'ntl_onekey-layout.js'
-store(&KEYBOARDVERSION) '1.002'
+store(&KEYBOARDVERSION) '1.003'
 store(&BITMAP) 'ntl_onekey.ico'
 
 begin Unicode > use(main)

--- a/experimental/n/ntl_onekey/source/ntl_onekey.kps
+++ b/experimental/n/ntl_onekey/source/ntl_onekey.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>10.0.1000.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>11.0.1306.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -17,8 +17,8 @@
   </StartMenu>
   <Info>
     <Name URL="">ntl_onekey</Name>
-    <Version URL="">1.0</Version>
-    <Copyright URL="">© 2015-2018 SIL International</Copyright>
+    <Version URL=""></Version>
+    <Copyright URL="">© 2015-2019 SIL International</Copyright>
     <Author URL="mailto:eric_ding@sil.org">A. Cheuk and E. Ding</Author>
   </Info>
   <Files>
@@ -52,7 +52,9 @@
       <Name>新傣文一键</Name>
       <ID>ntl_onekey</ID>
       <Version>1.002</Version>
-      <Languages/>
+      <Languages>
+        <Language ID="khb-Talu">Lü (New Tai Lue)</Language>
+      </Languages>
     </Keyboard>
   </Keyboards>
   <Strings/>


### PR DESCRIPTION
The .kmp keyboard package fails to install on Keyman for Android because there's no language associated with the keyboard.

This PR updates the associated language to `khb-Talu`