### PR TITLE
[lazuri] Update lazuri.kps

### DIFF
--- a/release/l/lazuri/source/lazuri.kps
+++ b/release/l/lazuri/source/lazuri.kps
@@ -84,7 +84,7 @@
       <ID>lazuri</ID>
       <Version>2.3</Version>
       <Languages>
-        <Language ID="lzz-Latn-TR">Lazuri</Language>
+        <Language ID="lzz-Latn">Lazuri</Language>
       </Languages>
     </Keyboard>
   </Keyboards>

--- a/release/l/lazuri/source/lazuri.kps
+++ b/release/l/lazuri/source/lazuri.kps
@@ -84,7 +84,7 @@
       <ID>lazuri</ID>
       <Version>2.3</Version>
       <Languages>
-        <Language ID="lzz-Latn-TR">Laz (Latin, Turkey)</Language>
+        <Language ID="lzz-Latn-TR">Lazuri</Language>
       </Languages>
     </Keyboard>
   </Keyboards>


### PR DESCRIPTION
For language, Laz (Latin, Turkey) seems to much. Lazuri would be the best since it is the language name.  All Laz speakers in Turkey use Latin script