### PR TITLE
[infrastructure] Always use wine when not on Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,11 @@ function display_usage {
 KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 KMCOMP="$KEYBOARDROOT/tools/kmcomp.exe"
 
-if [[ "${OSTYPE}" != "darwin"* ]]; then
-  KMCOMP_LAUNCHER=
-else
-  KMCOMP_LAUNCHER=wine
-fi
+case "${OSTYPE}" in
+  "cygwin") KMCOMP_LAUNCHER= ;;
+  "msys") KMCOMP_LAUNCHER= ;;
+  *) KMCOMP_LAUNCHER=wine ;;
+esac
 
 # Master json schema is from https://api.keyman.com/schemas/keyboard_info.json
 KEYBOARDINFO_SCHEMA_JSON="$KEYBOARDROOT/tools/keyboard_info.source.json"


### PR DESCRIPTION
The `build.sh` script as it is now failed to build the layouts on Linux for me. This small patch changes how `KMCOMP_LAUNCHER` is defined: instead of only setting the value to `wine` on darwin, it will only be left empty on Windows and set to `wine` on all other platforms.