### PR TITLE
[Infrastructure] Improve support for regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 legacy/*/*/build/
 release/*/*/build/
+release/*/*/tests/
 experimental/*/*/build/
 packages/*/build/
 .cache

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,14 @@
 #
 
 function display_usage {
-  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-t project_target] [target]"
+  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [target]"
   exit 1
 }
+
+#
+# Prevents 'clear' on exit of mingw64 bash shell
+#
+SHLVL=0
 
 # TODO: Test on macOS as well.
 # TODO: Copy the final keyboard_info.json to resources/
@@ -93,7 +98,7 @@ if [[ $KEYBOARDS_STARTER == 1 ]]; then
   fi
 else
   if [[ "$TARGET" ]]; then
-    if [[ "$TARGET" == */* ]] && [[ (-d "$TARGET") ]]; then
+    if [[ "$TARGET" == */*/* ]] && [[ (-d "$TARGET") ]]; then
       group=$(cut -d / -f 1 <<< "$TARGET")
       echo "--- Only building $group $TARGET ---"
       build_keyboard $group "$TARGET"

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -76,12 +76,14 @@ function build_keyboards {
     # depends on files created by the keyboards
     #
     
-    if [ -d "$KEYBOARDROOT/$group/packages" ]; then
-      echo "- $ACTION_VERB $group/packages"
-      local package
-      for package in "$KEYBOARDROOT/$group/packages/"*/ ; do
-        build_keyboard "$group" "$package"
-      done
+    if [[ -z "$PROJECT_TARGET_TYPE" ]]; then
+      if [ -d "$KEYBOARDROOT/$group/packages" ]; then
+        echo "- $ACTION_VERB $group/packages"
+        local package
+        for package in "$KEYBOARDROOT/$group/packages/"*/ ; do
+          build_keyboard "$group" "$package"
+        done
+      fi
     fi
   fi
   
@@ -185,6 +187,11 @@ function build_keyboard {
     return 0
   fi
   
+  if [[ ! -z "$PROJECT_TARGET_TYPE" ]]; then
+    popd
+    return 0
+  fi
+
   #
   # Copy the documentation file manually
   #
@@ -275,14 +282,22 @@ function build_release_keyboard {
   if [[ -d build ]]; then
     rm -rf build/ || die
   fi
-  
+
   if [[ ! -z "$FLAG_CLEAN" ]]; then
+    # We only remove the tests folder when cleaning the repo
+    if [[ -d tests ]]; then
+      rm -rf tests/ || die
+    fi
     return 0
   fi
   
   # Recreate build folder
   
   mkdir build || die "Failed to create build folder for $keyboard"
+
+  if [[ ! -z "$PROJECT_TARGET_TYPE" ]]; then
+    PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
+  fi
   
   $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
   

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -61,6 +61,7 @@ function parse_args {
   DO_EXE=true
   WARNINGS_AS_ERRORS=false
   TARGET=
+  PROJECT_TARGET_TYPE=
   PROJECT_TARGET=
   FLAG_SILENT=
   FLAG_DEBUG=
@@ -68,6 +69,7 @@ function parse_args {
   FLAG_TARGET=
   START=
   
+  local lastkey
   local key
   
   # Parse args
@@ -104,11 +106,14 @@ function parse_args {
         -w)
           WARNINGS_AS_ERRORS=true
           ;;          
-        -h|-?)
+        -h|-\?)
           display_usage
           ;;
+        -T)
+          lastkey="$key"
+          ;;
         -t)
-          lastkey=$key
+          lastkey="$key"
           ;;
         *)
           TARGET="$key"
@@ -121,6 +126,10 @@ function parse_args {
         -t)
           FLAG_TARGET=-t
           PROJECT_TARGET="$key"
+          ;;
+        -T)
+          FLAG_TARGET=-t
+          PROJECT_TARGET_TYPE="$key"
           ;;
       esac
       lastkey=


### PR DESCRIPTION
Fixes:
* Bash output being cleared on finish of script on Windows
* Single character parameters not being applied
* Build of single keyboard targets

Supports:
* Build of just keyboard or just package with -T
* Ignoring tests/ folders in release/k/keyboard/
* Cleaning tests/ folders when using -c