### PR TITLE
[meta] Testing displayUnderlying flag which was breaking CI for unknown reason

### DIFF
--- a/release/c/coptic_qwerty/source/coptic_qwerty.keyman-touch-layout
+++ b/release/c/coptic_qwerty/source/coptic_qwerty.keyman-touch-layout
@@ -1187,6 +1187,7 @@
         ]
       }
     ],
-    "fontsize": ""
+    "fontsize": "",
+    "displayUnderlying": false
   }
 }


### PR DESCRIPTION
This pull request is just to test the issue reported in https://github.com/keymanapp/keyboards/pull/617#issuecomment-483876195 regarding `displayUnderlying` breaking CI build.
Do not merge; I will be investigating further.