### PR TITLE
[meta] Increment version numbers on keyboards that were impacted by Chrome compatibility issue #183 to force redeployment

### DIFF
--- a/release/fv/fv_gwichin/HISTORY.md
+++ b/release/fv/fv_gwichin/HISTORY.md
@@ -1,6 +1,10 @@
 Gwich'in Change History
 ============================
 
+9.1.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 9.1 (8 Oct 2018)
 -----------------
 * Merged Desktop, Web and mobile keyboards

--- a/release/fv/fv_gwichin/LICENSE.md
+++ b/release/fv/fv_gwichin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_gwichin/README.md
+++ b/release/fv/fv_gwichin/README.md
@@ -1,9 +1,9 @@
 Gwich'in keyboard
 ======================
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1
+Version 9.1.1
 
 Gwich'in keyboard layout for Unicode
 

--- a/release/fv/fv_gwichin/source/fv_gwichin.kmn
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kmn
@@ -2,7 +2,7 @@
 store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "gwi"
-store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) "Gwich'in"
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_gwichin.ico'

--- a/release/fv/fv_gwichin/source/fv_gwichin.kmn
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "gwi"
 store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"

--- a/release/fv/fv_gwichin/source/fv_gwichin.kps
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kps
@@ -12,7 +12,7 @@
   </Options>
   <Info>
     <Name URL="">Gwich'in</Name>
-    <Copyright URL="">(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/fv/fv_han/HISTORY.md
+++ b/release/fv/fv_han/HISTORY.md
@@ -1,6 +1,10 @@
 Hän Change History
 ============================
 
+9.1.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 9.1 (8 Oct 2018)
 -----------------
 * Merged Desktop, Web and mobile keyboards

--- a/release/fv/fv_han/LICENSE.md
+++ b/release/fv/fv_han/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_han/README.md
+++ b/release/fv/fv_han/README.md
@@ -1,9 +1,9 @@
 Hän keyboard
 ======================
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1
+Version 9.1.1
 
 Hän keyboard layout for Unicode
 

--- a/release/fv/fv_han/source/fv_han.kmn
+++ b/release/fv/fv_han/source/fv_han.kmn
@@ -2,7 +2,7 @@
 store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "haa"
-store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) 'Hän'
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_han.ico'

--- a/release/fv/fv_han/source/fv_han.kmn
+++ b/release/fv/fv_han/source/fv_han.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "haa"
 store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"

--- a/release/fv/fv_han/source/fv_han.kps
+++ b/release/fv/fv_han/source/fv_han.kps
@@ -16,7 +16,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Hän</Name>
-    <Copyright URL="">(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/fv/fv_northern_tutchone/HISTORY.md
+++ b/release/fv/fv_northern_tutchone/HISTORY.md
@@ -1,6 +1,10 @@
 Northern Tutchone Change History
 ============================
 
+9.1.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 9.1 (8 Oct 2018)
 -----------------
 * Merged Desktop, Web and mobile keyboards

--- a/release/fv/fv_northern_tutchone/LICENSE.md
+++ b/release/fv/fv_northern_tutchone/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_northern_tutchone/README.md
+++ b/release/fv/fv_northern_tutchone/README.md
@@ -1,9 +1,9 @@
 Northern Tutchone keyboard
 ======================
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1
+Version 9.1.1
 
 Northern Tutchone keyboard layout for Unicode
 

--- a/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kmn
+++ b/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "ttm"
 store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"

--- a/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kmn
+++ b/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kmn
@@ -2,7 +2,7 @@
 store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "ttm"
-store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) 'Northern Tutchone'
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_northern_tutchone.ico'

--- a/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kps
+++ b/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kps
@@ -18,7 +18,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Northern Tutchone</Name>
-    <Copyright URL="">(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/fv/fv_southern_tutchone/HISTORY.md
+++ b/release/fv/fv_southern_tutchone/HISTORY.md
@@ -1,6 +1,10 @@
 Southern Tutchone Change History
 ============================
 
+9.1.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 9.1 (8 Oct 2018)
 -----------------
 * Merged Desktop, Web and mobile keyboards

--- a/release/fv/fv_southern_tutchone/LICENSE.md
+++ b/release/fv/fv_southern_tutchone/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_southern_tutchone/README.md
+++ b/release/fv/fv_southern_tutchone/README.md
@@ -1,9 +1,9 @@
 Southern Tutchone keyboard
 ======================
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1
+Version 9.1.1
 
 Southern Tutchone keyboard layout for Unicode
 

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "tce"
 store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
@@ -2,7 +2,7 @@
 store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "tce"
-store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) 'Southern Tutchone'
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_southern_tutchone.ico'

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Southern Tutchone</Name>
-    <Copyright URL="">(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/fv/fv_tagizi_dene/HISTORY.md
+++ b/release/fv/fv_tagizi_dene/HISTORY.md
@@ -1,6 +1,10 @@
 Tāgizi Dene Change History
 ============================
 
+9.1.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 9.1 (8 Oct 2018)
 -----------------
 * Merged Desktop, Web and mobile keyboards

--- a/release/fv/fv_tagizi_dene/LICENSE.md
+++ b/release/fv/fv_tagizi_dene/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_tagizi_dene/README.md
+++ b/release/fv/fv_tagizi_dene/README.md
@@ -1,9 +1,9 @@
 Tāgizi Dene keyboard
 ======================
 
-Copyright (c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1
+Version 9.1.1
 
 Tāgizi Dene keyboard layout for Unicode
 

--- a/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kmn
+++ b/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "tgx"
 store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"

--- a/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kmn
+++ b/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kmn
@@ -2,7 +2,7 @@
 store(&KEYBOARDVERSION) "9.1.1"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "tgx"
-store(&COPYRIGHT) "(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) 'Tāgizi Dene'
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_tagizi_dene.ico'

--- a/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kps
+++ b/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Tagizi Dene</Name>
-    <Copyright URL="">(c) 2008-2018 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/h/hieroglyphic/HISTORY.md
+++ b/release/h/hieroglyphic/HISTORY.md
@@ -1,6 +1,10 @@
 Hieroglyphic Keyboard Change History
 =======================
 
+1.3.1 (23 Apr 2019)
+-------------------
+* Rebuild to resolve compatibility issue with Chrome
+
 1.3 (1 Jun 2018)
 -----------------
 * Migrated to GitHub

--- a/release/h/hieroglyphic/LICENSE.md
+++ b/release/h/hieroglyphic/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2018 Christian Casey
+Copyright (c) 2010-2019 Christian Casey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/h/hieroglyphic/README.md
+++ b/release/h/hieroglyphic/README.md
@@ -1,9 +1,9 @@
 Hieroglyphic Keyboard
 =====================
 
-Copyright (C) 2010-2018 Christian Casey
+Copyright (C) 2010-2019 Christian Casey
 
-Version 1.3
+Version 1.3.1
 
 __DESCRIPTION__
 This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text.

--- a/release/h/hieroglyphic/source/hieroglyphic.kmn
+++ b/release/h/hieroglyphic/source/hieroglyphic.kmn
@@ -6,7 +6,7 @@ store(&INCLUDECODES) 'codes.txt'
 store(&COPYRIGHT) '© 2010-2018 Christian Casey'
 store(&ETHNOLOGUECODE) 'egy'
 store(&VISUALKEYBOARD) 'hieroglyphic.kvks'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.3.1'
 store(&TARGETS) 'windows macosx linux web'
 
 begin Unicode > use(main)

--- a/release/h/hieroglyphic/source/hieroglyphic.kmn
+++ b/release/h/hieroglyphic/source/hieroglyphic.kmn
@@ -3,7 +3,7 @@ store(&NAME) 'Hieroglyphic'
 store(&BITMAP) 'hieroglyphic.ico'
 store(&INCLUDECODES) 'codes.txt'
 
-store(&COPYRIGHT) '© 2010-2018 Christian Casey'
+store(&COPYRIGHT) '© 2010-2019 Christian Casey'
 store(&ETHNOLOGUECODE) 'egy'
 store(&VISUALKEYBOARD) 'hieroglyphic.kvks'
 store(&KEYBOARDVERSION) '1.3.1'

--- a/release/h/hieroglyphic/source/hieroglyphic.kps
+++ b/release/h/hieroglyphic/source/hieroglyphic.kps
@@ -18,7 +18,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">Hieroglyphic</Name>
-    <Copyright URL="">© 2010-2018 Christian Casey</Copyright>
+    <Copyright URL="">© 2010-2019 Christian Casey</Copyright>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
The keyboards impacted were:

  * fv_gwichin
  * fv_han
  * fv_northern_tutchone
  * fv_southern_tutchone
  * fv_tagizi_dene
  * hieroglyphic