### PR TITLE
[itrans_roman] Version 1.1.1 add IPA vowels - map to lowercase characters

### DIFF
--- a/release/itrans/itrans_roman/HISTORY.md
+++ b/release/itrans/itrans_roman/HISTORY.md
@@ -1,7 +1,7 @@
 Indic Romanization from ITRANS - Version History
 ===========================
 
-1.1.1 (2019-06-15)
+1.1.1 (2019-06-17)
 ----------------
 * Add alternative maps for some IPA vowels using lowercase punctuation
 

--- a/release/itrans/itrans_roman/HISTORY.md
+++ b/release/itrans/itrans_roman/HISTORY.md
@@ -1,6 +1,14 @@
 Indic Romanization from ITRANS - Version History
 ===========================
 
+1.1.1 (2019-06-15)
+----------------
+* Add alternative maps for some IPA vowels using lowercase punctuation
+
+1.1.0 (2019-06-12)
+----------------
+* Add support for IPA (vowels only) output, useful for words pronunciation key
+
 1.0.0 (2019-06-01)
 ----------------
 * Indic Romanization in various schemes such as 
@@ -11,6 +19,4 @@ Indic Romanization from ITRANS - Version History
 * from ITRANS and 7 bit ISO transliteration 
 * for easy typing of accents.
 
-1.1.0 (2019-06-12)
-----------------
-* Add support for IPA (vowels only) output, useful for words pronunciation key
+

--- a/release/itrans/itrans_roman/itrans_roman.kpj
+++ b/release/itrans/itrans_roman/itrans_roman.kpj
@@ -11,19 +11,19 @@
       <ID>id_9cdaa369f8fe94a9fdbbf9b331371bfe</ID>
       <Filename>itrans_roman.kps</Filename>
       <Filepath>source\itrans_roman.kps</Filepath>
-      <FileVersion>1.1.0</FileVersion>
+      <FileVersion>1.1.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Indic Romanization from ITRANS</Name>
         <Copyright>©2019 sanskritdocuments.org</Copyright>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
       </Details>
     </File>
     <File>
       <ID>id_5d66759dfae9addda099c4426e6546d8</ID>
       <Filename>itrans_roman.kmn</Filename>
       <Filepath>source\itrans_roman.kmn</Filepath>
-      <FileVersion>1.1.0</FileVersion>
+      <FileVersion>1.1.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Indic Romanization from ITRANS</Name>

--- a/release/itrans/itrans_roman/source/extras/test_ipa_vowels.xml
+++ b/release/itrans/itrans_roman/source/extras/test_ipa_vowels.xml
@@ -74,102 +74,102 @@
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_COLON</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u;</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_U</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; u</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː u</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_QUOTE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_U</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ u</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ u</text></postcontext>
     </event>
     <event>
        <key><shiftstate><shift/></shiftstate><vkey>K_COLON</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_E</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː e</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː e</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_QUOTE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_A</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ a</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ a</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_I</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ ai</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ ai</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_QUOTE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_O</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ o</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ o</text></postcontext>
     </event>
     <event>
        <key><shiftstate><shift/></shiftstate><vkey>K_COLON</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_A</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː a</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː a</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_U</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː au</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː au</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_QUOTE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː əʊ</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː əʊ</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː əʊ </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː əʊ </text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_A</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː əʊ a</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː əʊ a</text></postcontext>
     </event>
     <event>
        <key><shiftstate><shift/></shiftstate><vkey>K_QUOTE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː əʊ ɒ</text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː əʊ ɒ</text></postcontext>
     </event>
     <event>
        <key><shiftstate></shiftstate><vkey>K_SPACE</vkey></key>
-       <postcontext><text>ʌ ə ɑː ɪ iː u; ʊ uː ɛ əɪ ɔː əʊ ɒ </text></postcontext>
+       <postcontext><text>ʌ ə ɑː ɪ iː uː ʊ uː ɛ əɪ ɔː əʊ ɒ </text></postcontext>
     </event>
   </events></regressiontest>

--- a/release/itrans/itrans_roman/source/help/itrans_roman.php
+++ b/release/itrans/itrans_roman/source/help/itrans_roman.php
@@ -14,7 +14,7 @@ END;
   require_once('header.php');
 ?>
 
-<h2><span style="color: chocolate;">Indic Romanization from ITRANS</span> Keyboard Version 1.1.0</h2>
+<h2><span style="color: chocolate;">Indic Romanization from ITRANS</span> Keyboard Version 1.1.1</h2>
 
 <p>This is a phonetic keyboard for Indic Romanization which is based on  
 <strong><a href="https://www.aczoom.com/itrans/">ITRANS</a></strong> 
@@ -23,12 +23,18 @@ has also been referred to for modifying the input scheme.
 Accented letters used by various Indic Romanization schemes such as 
 <strong><a href="https://en.wikipedia.org/wiki/ISO_15919">ISO 15919</a></strong>, 
 <strong><a href="https://en.wikipedia.org/wiki/International_Alphabet_of_Sanskrit_Transliteration">IAST</a></strong>,
-<strong><a href="https://en.wikipedia.org/wiki/National_Library_at_Kolkata_romanisation#Scheme_table">NLK</a></strong>  are supported for output.</p>
+<strong><a href="https://en.wikipedia.org/wiki/National_Library_at_Kolkata_romanisation#Scheme_table">NLK</a></strong>  
+are supported for output.</p>
 
 <p>The modified input scheme 
 uses only lowercase letters. This allows the same letters to be typed
 with CAPS LOCK/SHIFT to get Unicode Romanized output in UPPERCASE letters, 
-which is useful for typing Proper names, Headings, etc. </p>
+which is useful for typing Proper names, Headings, etc. 
+It also supports typing of IPA vowels for pronunciation keys.</p>
+
+<p>Some punctuation keys are used as part of mapping to get Romanized accented 
+output, use these keys twice (thrice for period) if punctuation is required. 
+e.g. <kbd>,,</kbd> for <samp>,</samp> and  <kbd>;;</kbd> for <samp>;</samp>
 
 <h3>Vowels</h3>
 <p>The following table shows the letters to type to get the vowels.</p>
@@ -206,15 +212,15 @@ for words pronunciation key.</p>
 <tr><td>a'</td> <td><samp>ə</samp></td></tr>
 <tr><td>ai'</td> <td><samp>əɪ</samp></td></tr>
 <tr><td>au'</td> <td><samp>əʊ</samp></td></tr>
-<tr><td>a:</td> <td><samp>ɑː</samp></td></tr>
+<tr><td>a:/a;</td> <td><samp>ɑː</samp></td></tr>
 <tr><td>a`</td> <td><samp>ʌ</samp></td></tr>
-<tr><td>a"</td> <td><samp>ɒ</samp></td></tr>
+<tr><td>a"/a,</td> <td><samp>ɒ</samp></td></tr>
 <tr><td>e'</td> <td><samp>ɛ</samp></td></tr>
 <tr><td>i'</td> <td><samp>ɪ</samp></td></tr>
-<tr><td>i:</td> <td><samp>iː</samp></td></tr>
-<tr><td>o:</td> <td><samp>ɔː</samp></td></tr>
+<tr><td>i:/i;</td> <td><samp>iː</samp></td></tr>
+<tr><td>o:/o;</td> <td><samp>ɔː</samp></td></tr>
 <tr><td>u'</td> <td><samp>ʊ</samp></td></tr>
-<tr><td>u:</td> <td><samp>uː</samp></td></tr>
+<tr><td>u:/u;</td> <td><samp>uː</samp></td></tr>
 </tbody>
 </table>
 

--- a/release/itrans/itrans_roman/source/help/itrans_roman.php
+++ b/release/itrans/itrans_roman/source/help/itrans_roman.php
@@ -66,14 +66,14 @@ e.g. <kbd>,,</kbd> for <samp>,</samp> and  <kbd>;;</kbd> for <samp>;</samp>
 <tr><td>ऍ</td><td>~ae</td> <td><samp>ĕ</samp></td><td></td></tr>
 <tr><td>ऑ</td><td>aw</td> <td><samp>ŏ</samp></td><td>ŏ/ɔ/</td></tr>
 <tr><td></td><td></td> <td><samp></samp></td><td></tr>
-<tr><td>ऎ</td><td>e</td> <td><samp>e</samp></td><td>ISO</td></tr>
 <tr><td>ऎ</td><td>~e</td> <td><samp>ẽ</samp></td><td>resembles matra</td></tr>
+<tr><td>ऎ</td><td>e</td> <td><samp>e</samp></td><td>ISO</td></tr>
 <tr><td>ए</td><td>-e</td> <td><samp>ē</samp></td><td>ISO</td></tr>
 <tr><td>ए</td><td>e</td> <td><samp>e</samp></td><td>IAST</td></tr>
 <tr><td>ऐ</td><td>ai</td> <td><samp>ai</samp></td><td>IAST/ISO</td></tr>
 <tr><td></td><td></td> <td><samp></samp></td><td></tr>
-<tr><td>ऒ</td><td>o</td> <td><samp>o</samp></td><td>ISO</td></tr>
 <tr><td>ऒ</td><td>~o</td> <td><samp>õ</samp></td><td>resembles matra</td></tr>
+<tr><td>ऒ</td><td>o</td> <td><samp>o</samp></td><td>ISO</td></tr>
 <tr><td>ओ</td><td>-o</td> <td><samp>ō</samp></td><td>ISO</td></tr>
 <tr><td>ओ</td><td>o</td> <td><samp>o</samp></td><td>IAST</td></tr>
 <tr><td>औ</td><td>au</td> <td><samp>au</samp></td><td>IAST/ISO</td></tr>
@@ -208,7 +208,7 @@ for words pronunciation key.</p>
 <tr><th>Input</th><th>IPA</th></tr>
 </thead>
 <tbody>
-<tr><td>@</td> <td><samp>æ</samp></td></tr>
+<tr><td>@/a-</td> <td><samp>æ</samp></td></tr>
 <tr><td>a'</td> <td><samp>ə</samp></td></tr>
 <tr><td>ai'</td> <td><samp>əɪ</samp></td></tr>
 <tr><td>au'</td> <td><samp>əʊ</samp></td></tr>

--- a/release/itrans/itrans_roman/source/itrans_roman.kmn
+++ b/release/itrans/itrans_roman/source/itrans_roman.kmn
@@ -58,15 +58,15 @@ c Double for original character
 c IPA Vowels only as pronunciation key
 
 +"@">"æ"
-"a"+"'"	>"ə"
+"a"+"'"		>"ə"
 "a"+"i"	>"ai"
 "a"+"u"	>"au"
 "ai"+"'"	>"əɪ"
 "au"+"'"	>"əʊ"
-"a"+":"	>"ɑː"
+"a"+":"		>"ɑː"
 "a"+"`"	>"ʌ"
 "a"+'"'	>"ɒ"
-"e"+"'"	>"ɛ"
+"e"+"'"		>"ɛ"
 "i"+"'"	>"ɪ"
 "i"+":"	>"iː"
 "o"+":"	>"ɔː"
@@ -74,11 +74,12 @@ c IPA Vowels only as pronunciation key
 "u"+":"	>"uː"
 
 c IPA Vowels - alternatively use lowercase punctuation for ease of typing
-"a"+";"	>"ɑː"
+"a"+";"		>"ɑː"
 "i"+";"	>"iː"
 "o"+";"	>"ɔː"
 "u"+";"	>"uː"
-"a"+","	>"ɒ"
+"a"+","		>"ɒ"
+"a"+"-"	>"æ"
 
 c vocalics - ISO
 "," + "r" > "r̥"

--- a/release/itrans/itrans_roman/source/itrans_roman.kmn
+++ b/release/itrans/itrans_roman/source/itrans_roman.kmn
@@ -1,37 +1,24 @@
-﻿c Reference Schemes
+﻿store(&VERSION) "10.0" 
+store(&KEYBOARDVERSION) '1.1.1'
+store(&NAME) 'Indic Romanization from ITRANS'
+store(&TARGETS) 'any windows macosx linux web'
+store(&COPYRIGHT) '©2019 sanskritdocuments.org'
+store(&MESSAGE) 'Indic Roman Transliteration (IAST, ISO, NLK, etc.) from ITRANS'
+store(&KMW_HELPTEXT) 'Provides Unicode output in ISO_15919, IAST, NLK transliteration schemes for Indic languages. Also has support for IPA vowels output.'
+store(&BITMAP) 'itrans_roman.ico'
+store(&VISUALKEYBOARD) 'itrans_roman.kvks'
+c
+c See HISTORY.md for details of changes
+c Reference Schemes
 c https://en.wikipedia.org/wiki/International_Alphabet_of_Sanskrit_Transliteration
 c https://en.wikipedia.org/wiki/ISO_15919
 c https://en.wikipedia.org/wiki/National_Library_at_Kolkata_romanisation#Scheme_table
 c http://aksharamukha.appspot.com/#/script-matrix
 c http://transliteration.eki.ee/pdf/Hindi-Marathi-Nepali.pdf
 c https://web.archive.org/web/20160414223033/http://homepage.ntlworld.com/stone-catend/trind.htm
-c IAST extensions, Pangrams and sample texts provided by Ken P
+c https://www.internationalphoneticassociation.org/content/ipa-vowels
+c IAST extensions, IPA vowels mapping, Pangrams and sample texts provided by Ken P
 c
-c Version 1.0.0 
-c 20190601
-c Indic Romanization in various schemes such as 
-c International Alphabet of Sanskrit Transliteration (IAST),
-c ISO_15919, NLK, IAST extensions, etc
-c from ITRANS / 7 bit ISO transliteration input 
-c for easy typing of accents.
-c 20190606
-c Fixes as per PR feedback
-c Mapping changes as per user feedback
-c 20190609
-c Add nukta consonants
-c Version 1.1.0 
-c 20190612
-c Add IPA (vowels only) for words pronunciation key
-c
-store(&VERSION) "10.0" 
-store(&NAME) 'Indic Romanization from ITRANS'
-store(&TARGETS) 'any windows macosx linux web'
-store(&COPYRIGHT) '©2019 sanskritdocuments.org'
-store(&MESSAGE) 'Indic Roman Transliteration (IAST, ISO, NLK, etc.) from ITRANS'
-store(&KMW_HELPTEXT) 'Provides Unicode output in ISO_15919, IAST, NLK transliteration schemes for Indic languages. Also has support for IPA vowels output.'
-store(&KEYBOARDVERSION) '1.1.0'
-store(&BITMAP) 'itrans_roman.ico'
-store(&VISUALKEYBOARD) 'itrans_roman.kvks'
 
 begin Unicode > use(main)
 group(main) using keys
@@ -85,6 +72,13 @@ c IPA Vowels only as pronunciation key
 "o"+":"	>"ɔː"
 "u"+"'"	>"ʊ"
 "u"+":"	>"uː"
+
+c IPA Vowels - alternatively use lowercase punctuation for ease of typing
+"a"+";"	>"ɑː"
+"i"+";"	>"iː"
+"o"+";"	>"ɔː"
+"u"+";"	>"uː"
+"a"+","	>"ɒ"
 
 c vocalics - ISO
 "," + "r" > "r̥"

--- a/release/itrans/itrans_roman/source/itrans_roman.kps
+++ b/release/itrans/itrans_roman/source/itrans_roman.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Indic Romanization from ITRANS</Name>
-    <Version URL="">1.1.0</Version>
+    <Version URL="">1.1.1</Version>
     <Copyright URL="">©2019 sanskritdocuments.org</Copyright>
     <Author URL="">Shree Devi Kumar</Author>
     <WebSite URL="https:// sanskritdocuments.org">https:// sanskritdocuments.org</WebSite>
@@ -52,7 +52,7 @@
     <Keyboard>
       <Name>itrans_roman</Name>
       <ID>itrans_roman</ID>
-      <Version>1.1.0</Version>
+      <Version>1.1.1</Version>
       <Languages>
         <Language ID="sa-Latn">Sanskrit (Latin)</Language>
         <Language ID="hi-Latn">Hindi (Latin)</Language>

--- a/release/itrans/itrans_roman/source/welcome/welcome.htm
+++ b/release/itrans/itrans_roman/source/welcome/welcome.htm
@@ -73,7 +73,7 @@ text-align: right;
 </style>
   </head>
   <body>
-    <h2>Welcome!!!</h2>
+    <h2>Welcome!</h2>
 <h2><span style="color: chocolate;">Indic Romanization from ITRANS</span> Keyboard Version 1.1.1</h2>
 
 <p>This is a phonetic keyboard for Indic Romanization which is based on  
@@ -126,14 +126,14 @@ e.g. <kbd>,,</kbd> for <samp>,</samp> and  <kbd>;;</kbd> for <samp>;</samp>
 <tr><td>ऍ</td><td>~ae</td> <td><samp>ĕ</samp></td><td></td></tr>
 <tr><td>ऑ</td><td>aw</td> <td><samp>ŏ</samp></td><td>ŏ/ɔ/</td></tr>
 <tr><td></td><td></td> <td><samp></samp></td><td></tr>
-<tr><td>ऎ</td><td>e</td> <td><samp>e</samp></td><td>ISO</td></tr>
 <tr><td>ऎ</td><td>~e</td> <td><samp>ẽ</samp></td><td>resembles matra</td></tr>
+<tr><td>ऎ</td><td>e</td> <td><samp>e</samp></td><td>ISO</td></tr>
 <tr><td>ए</td><td>-e</td> <td><samp>ē</samp></td><td>ISO</td></tr>
 <tr><td>ए</td><td>e</td> <td><samp>e</samp></td><td>IAST</td></tr>
 <tr><td>ऐ</td><td>ai</td> <td><samp>ai</samp></td><td>IAST/ISO</td></tr>
 <tr><td></td><td></td> <td><samp></samp></td><td></tr>
-<tr><td>ऒ</td><td>o</td> <td><samp>o</samp></td><td>ISO</td></tr>
 <tr><td>ऒ</td><td>~o</td> <td><samp>õ</samp></td><td>resembles matra</td></tr>
+<tr><td>ऒ</td><td>o</td> <td><samp>o</samp></td><td>ISO</td></tr>
 <tr><td>ओ</td><td>-o</td> <td><samp>ō</samp></td><td>ISO</td></tr>
 <tr><td>ओ</td><td>o</td> <td><samp>o</samp></td><td>IAST</td></tr>
 <tr><td>औ</td><td>au</td> <td><samp>au</samp></td><td>IAST/ISO</td></tr>
@@ -268,7 +268,7 @@ for words pronunciation key.</p>
 <tr><th>Input</th><th>IPA</th></tr>
 </thead>
 <tbody>
-<tr><td>@</td> <td><samp>æ</samp></td></tr>
+<tr><td>@/a-</td> <td><samp>æ</samp></td></tr>
 <tr><td>a'</td> <td><samp>ə</samp></td></tr>
 <tr><td>ai'</td> <td><samp>əɪ</samp></td></tr>
 <tr><td>au'</td> <td><samp>əʊ</samp></td></tr>

--- a/release/itrans/itrans_roman/source/welcome/welcome.htm
+++ b/release/itrans/itrans_roman/source/welcome/welcome.htm
@@ -8,15 +8,8 @@ html, body {
 font-family: serif; 
 font-size: 110%;
 }
-@font-face {
-font-family: 'Siddhanta';
-src:  url('https://sanskritdocuments.org/css/fonts/Siddhanta.ttf') format('truetype'); 
-font-weight: normal;
-font-style: normal;
-}
 a {text-decoration: none;}
 samp {
-font-family: "Siddhanta", "Arial Unicode MS", Helvetica, sans-serif;
 font-size: 120%;
 }
 kbd {
@@ -81,7 +74,7 @@ text-align: right;
   </head>
   <body>
     <h2>Welcome!!!</h2>
-<h2><span style="color: chocolate;">Indic Romanization from ITRANS</span> Keyboard Version 1.1.0</h2>
+<h2><span style="color: chocolate;">Indic Romanization from ITRANS</span> Keyboard Version 1.1.1</h2>
 
 <p>This is a phonetic keyboard for Indic Romanization which is based on  
 <strong><a href="https://www.aczoom.com/itrans/">ITRANS</a></strong> 
@@ -90,12 +83,18 @@ has also been referred to for modifying the input scheme.
 Accented letters used by various Indic Romanization schemes such as 
 <strong><a href="https://en.wikipedia.org/wiki/ISO_15919">ISO 15919</a></strong>, 
 <strong><a href="https://en.wikipedia.org/wiki/International_Alphabet_of_Sanskrit_Transliteration">IAST</a></strong>,
-<strong><a href="https://en.wikipedia.org/wiki/National_Library_at_Kolkata_romanisation#Scheme_table">NLK</a></strong>  are supported for output.</p>
+<strong><a href="https://en.wikipedia.org/wiki/National_Library_at_Kolkata_romanisation#Scheme_table">NLK</a></strong>  
+are supported for output.</p>
 
 <p>The modified input scheme 
 uses only lowercase letters. This allows the same letters to be typed
 with CAPS LOCK/SHIFT to get Unicode Romanized output in UPPERCASE letters, 
-which is useful for typing Proper names, Headings, etc. </p>
+which is useful for typing Proper names, Headings, etc. 
+It also supports typing of IPA vowels for pronunciation keys.</p>
+
+<p>Some punctuation keys are used as part of mapping to get Romanized accented 
+output, use these keys twice (thrice for period) if punctuation is required. 
+e.g. <kbd>,,</kbd> for <samp>,</samp> and  <kbd>;;</kbd> for <samp>;</samp>
 
 <h3>Vowels</h3>
 <p>The following table shows the letters to type to get the vowels.</p>
@@ -273,15 +272,15 @@ for words pronunciation key.</p>
 <tr><td>a'</td> <td><samp>ə</samp></td></tr>
 <tr><td>ai'</td> <td><samp>əɪ</samp></td></tr>
 <tr><td>au'</td> <td><samp>əʊ</samp></td></tr>
-<tr><td>a:</td> <td><samp>ɑː</samp></td></tr>
+<tr><td>a:/a;</td> <td><samp>ɑː</samp></td></tr>
 <tr><td>a`</td> <td><samp>ʌ</samp></td></tr>
-<tr><td>a"</td> <td><samp>ɒ</samp></td></tr>
+<tr><td>a"/a,</td> <td><samp>ɒ</samp></td></tr>
 <tr><td>e'</td> <td><samp>ɛ</samp></td></tr>
 <tr><td>i'</td> <td><samp>ɪ</samp></td></tr>
-<tr><td>i:</td> <td><samp>iː</samp></td></tr>
-<tr><td>o:</td> <td><samp>ɔː</samp></td></tr>
+<tr><td>i:/i;</td> <td><samp>iː</samp></td></tr>
+<tr><td>o:/o;</td> <td><samp>ɔː</samp></td></tr>
 <tr><td>u'</td> <td><samp>ʊ</samp></td></tr>
-<tr><td>u:</td> <td><samp>uː</samp></td></tr>
+<tr><td>u:/u;</td> <td><samp>uː</samp></td></tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
also removes the font-family in help files, page was not displaying OK on Mac OS.