### PR TITLE
[basic-help] adjust name of rightalt-shift to shift-alt and shift-ralt

### DIFF
--- a/release/basic/basic_kbdarmph/source/help/basic_kbdarmph.php
+++ b/release/basic/basic_kbdarmph/source/help/basic_kbdarmph.php
@@ -19,7 +19,7 @@ A font must be installed to support this keyboard. Windows includes a number of 
 </div>
 
 <h2>Mobile/Tablet Keyboard Layout</h2>
-<div id='osk-tablet' data-states='default shift rightalt rightalt-shift'>
+<div id='osk-tablet' data-states='default shift rightalt shift-ralt'>
 </div>
 
 

--- a/release/basic/basic_kbddzo/source/help/basic_kbddzo.php
+++ b/release/basic/basic_kbddzo/source/help/basic_kbddzo.php
@@ -22,7 +22,7 @@ Dzongkha Basic keyboard 1.0 is generated from template.
 </div>
 
 <h2>Mobile/Tablet Keyboard Layout</h2>
-<div id='osk-tablet' data-states='default shift rightalt rightalt-shift'>
+<div id='osk-tablet' data-states='default shift alt shift-alt'>
 </div>
 
 


### PR DESCRIPTION
Mobile layout was not displaying rightalt-shift layer. I think these are now correct.