### PR TITLE
[fv_gwichin] use canonical ordering below mark then above mark (ogonek and grave)

### DIFF
--- a/release/fv/fv_gwichin/HISTORY.md
+++ b/release/fv/fv_gwichin/HISTORY.md
@@ -5,6 +5,7 @@ Gwich'in Change History
 ----------------
 * Canonical ordering normalized (U+0323 and U+0328)
 * Added grave and circumflex keys (` ^) to mobile layout
+* Small bug fixes in mobile layout
 
 9.1.1 (23 Apr 2019)
 -------------------

--- a/release/fv/fv_gwichin/HISTORY.md
+++ b/release/fv/fv_gwichin/HISTORY.md
@@ -1,6 +1,11 @@
 Gwich'in Change History
 ============================
 
+9.2 (27 Jun 2019)
+----------------
+* Canonical ordering normalized (U+0323 and U+0328)
+* Added grave and circumflex keys (` ^) to mobile layout
+
 9.1.1 (23 Apr 2019)
 -------------------
 * Rebuild to resolve compatibility issue with Chrome

--- a/release/fv/fv_gwichin/README.md
+++ b/release/fv/fv_gwichin/README.md
@@ -3,7 +3,7 @@ Gwich'in keyboard
 
 Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1.1
+Version 9.2
 
 Gwich'in keyboard layout for Unicode
 
@@ -23,8 +23,4 @@ Supported Platforms
  * Web
  * Mobile
 
-Todo
-----
-
- * This keyboard needs canonical ordering to be changed and normalized (U+0323 and U+0328)
  

--- a/release/fv/fv_gwichin/source/fv_gwichin.keyman-touch-layout
+++ b/release/fv/fv_gwichin/source/fv_gwichin.keyman-touch-layout
@@ -175,6 +175,14 @@
                   {
                     "text": ";",
                     "id": "K_COLON"
+                  },
+                  {
+                    "text": "`",
+                    "id": "U_0060"
+                  },
+                  {
+                    "text": "^",
+                    "id": "U_005E"
                   }
                 ]
               },
@@ -307,8 +315,10 @@
                 "text": "L"
               },
               {
-                "sp": "10",
-                "width": "10"
+                "id": "T_new_54",
+                "text": "",
+                "width": "10",
+                "sp": "10"
               }
             ]
           },
@@ -393,6 +403,14 @@
                     "text": ";",
                     "id": "K_COLON",
                     "layer": "default"
+                  },
+                  {
+                    "text": "`",
+                    "id": "U_0060"
+                  },
+                  {
+                    "text": "^",
+                    "id": "U_005E"
                   }
                 ]
               },
@@ -490,8 +508,8 @@
               {
                 "id": "K_4",
                 "text": "$",
-                "layer": "shift",
-                "pad": 70
+                "pad": 70,
+                "layer": "shift"
               },
               {
                 "id": "K_2",
@@ -534,6 +552,7 @@
                 "layer": "default"
               },
               {
+                "id": "T_new_88",
                 "text": "",
                 "width": "10",
                 "sp": "10"
@@ -659,7 +678,8 @@
           }
         ]
       }
-    ]
+    ],
+    "displayUnderlying": false
   },
   "phone": {
     "font": "Tahoma",
@@ -753,6 +773,7 @@
                 "text": "l"
               },
               {
+                "id": "T_new_122",
                 "text": "",
                 "width": "10",
                 "sp": "10"
@@ -835,6 +856,14 @@
                   {
                     "text": ";",
                     "id": "K_COLON"
+                  },
+                  {
+                    "text": "`",
+                    "id": "U_0060"
+                  },
+                  {
+                    "text": "^",
+                    "id": "U_005E"
                   }
                 ]
               },
@@ -967,6 +996,7 @@
                 "text": "L"
               },
               {
+                "id": "T_new_122",
                 "text": "",
                 "width": "10",
                 "sp": "10"
@@ -1053,6 +1083,14 @@
                     "text": ";",
                     "id": "K_COLON",
                     "layer": "default"
+                  },
+                  {
+                    "text": "`",
+                    "id": "U_0060"
+                  },
+                  {
+                    "text": "^",
+                    "id": "U_005E"
                   }
                 ]
               },
@@ -1148,34 +1186,34 @@
             "key": [
               {
                 "id": "K_4",
-                "layer": "shift",
                 "text": "$",
-                "pad": "50"
+                "pad": "50",
+                "layer": "shift"
               },
               {
                 "id": "K_2",
-                "layer": "shift",
-                "text": "@"
+                "text": "@",
+                "layer": "shift"
               },
               {
                 "id": "K_3",
-                "layer": "shift",
-                "text": "#"
+                "text": "#",
+                "layer": "shift"
               },
               {
                 "id": "K_5",
-                "layer": "shift",
-                "text": "%"
+                "text": "%",
+                "layer": "shift"
               },
               {
                 "id": "K_6",
-                "layer": "shift",
-                "text": "&"
+                "text": "&",
+                "layer": "shift"
               },
               {
                 "id": "K_HYPHEN",
-                "layer": "shift",
-                "text": "_"
+                "text": "_",
+                "layer": "shift"
               },
               {
                 "id": "K_EQUAL",
@@ -1184,8 +1222,8 @@
               },
               {
                 "id": "K_BKSLASH",
-                "layer": "shift",
-                "text": "|"
+                "text": "|",
+                "layer": "shift"
               },
               {
                 "id": "K_BKSLASH",
@@ -1193,6 +1231,7 @@
                 "layer": "default"
               },
               {
+                "id": "T_new_165",
                 "text": "",
                 "width": "10",
                 "sp": "10"
@@ -1225,13 +1264,13 @@
               },
               {
                 "id": "K_9",
-                "layer": "shift",
-                "text": "("
+                "text": "(",
+                "layer": "shift"
               },
               {
                 "id": "K_0",
-                "layer": "shift",
-                "text": ")"
+                "text": ")",
+                "layer": "shift"
               },
               {
                 "id": "K_RBRKT",
@@ -1255,8 +1294,8 @@
               },
               {
                 "id": "K_EQUAL",
-                "layer": "shift",
-                "text": "+"
+                "text": "+",
+                "layer": "shift"
               },
               {
                 "id": "K_HYPHEN",
@@ -1264,8 +1303,8 @@
               },
               {
                 "id": "K_8",
-                "layer": "shift",
-                "text": "*"
+                "text": "*",
+                "layer": "shift"
               },
               {
                 "id": "K_SLASH",
@@ -1311,6 +1350,7 @@
           }
         ]
       }
-    ]
+    ],
+    "displayUnderlying": false
   }
 }

--- a/release/fv/fv_gwichin/source/fv_gwichin.keyman-touch-layout
+++ b/release/fv/fv_gwichin/source/fv_gwichin.keyman-touch-layout
@@ -155,7 +155,7 @@
                     "layer": "shift"
                   },
                   {
-                    "text": "'",
+                    "text": "’",
                     "id": "K_QUOTE"
                   },
                   {
@@ -361,7 +361,7 @@
                 "text": "M"
               },
               {
-                "id": "K_PERIOD",
+                "id": "U_002E",
                 "text": ".",
                 "sk": [
                   {
@@ -380,7 +380,7 @@
                     "layer": "shift"
                   },
                   {
-                    "text": "'",
+                    "text": "’",
                     "id": "K_QUOTE",
                     "layer": "default"
                   },

--- a/release/fv/fv_gwichin/source/fv_gwichin.kmn
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1.1"
+store(&KEYBOARDVERSION) '9.2'
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "gwi"
 store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
@@ -25,70 +25,70 @@ c Touch layout rules originally imported from KeyMap.plist on Tue Nov 17 2015
 
 store(&LAYOUTFILE) 'fv_gwichin.keyman-touch-layout'
 
-'į' + [SHIFT T_Q] > 'į̀'
-'Ǫ' + [SHIFT T_Q] > 'Ǫ̀'
-'U' + [SHIFT T_Q] > 'Ù'
-'Ų' + [SHIFT T_Q] > 'Ų̀'
-'ų' + [SHIFT T_Q] > 'ų̀'
+'į' + [SHIFT T_Q] > U+0069 U+0328 U+0300 c 'į̀'
+'Ǫ' + [SHIFT T_Q] > U+004F U+0328 U+0300 c 'Ǫ̀'
+'U' + [SHIFT T_Q] > U+0055 U+0328 U+0300 c 'Ù'
+'Ų' + [SHIFT T_Q] > U+0055 U+0328 U+0300 c 'Ų̀'
+'ų' + [SHIFT T_Q] > U+0075 U+0328 U+0300 c 'ų̀'
 'I' + [SHIFT T_Q] > 'Ì'
-'ą' + [SHIFT T_Q] > 'ą̀'
+'ą' + [SHIFT T_Q] > U+0061 U+0328 U+0300 c 'ą̀'
 'e' + [SHIFT T_Q] > 'è'
-'Ą' + [SHIFT T_Q] > 'Ą̀'
+'Ą' + [SHIFT T_Q] > U+0041 U+0328 U+0300 c 'Ą̀'
 'u' + [SHIFT T_Q] > 'ù'
 'i' + [SHIFT T_Q] > 'ì'
-'ę' + [SHIFT T_Q] > 'ę̀'
+'ę' + [SHIFT T_Q] > U+0065 U+0328 U+0300 c 'ę̀'
 'A' + [SHIFT T_Q] > 'À'
 'O' + [SHIFT T_Q] > 'Ò'
-'Ę' + [SHIFT T_Q] > 'Ę̀'
+'Ę' + [SHIFT T_Q] > U+0045 U+0328 U+0300 c 'Ę̀'
 'E' + [SHIFT T_Q] > 'È'
 'a' + [SHIFT T_Q] > 'à'
 'o' + [SHIFT T_Q] > 'ò'
-'ǫ' + [SHIFT T_Q] > 'ǫ̀'
-'Į' + [SHIFT T_Q] > 'Į̀'
+'ǫ' + [SHIFT T_Q] > U+006F U+0328 U+0300 c 'ǫ̀'
+'Į' + [SHIFT T_Q] > U+0049 U+0328 U+0300 c 'Į̀'
 + [SHIFT T_W] > 'W' layer('default')
 + [SHIFT T_E_0] > 'È' layer('default')
 + [SHIFT T_E_1] > 'Ę' layer('default')
-+ [SHIFT T_E_2] > 'Ę̀' layer('default')
++ [SHIFT T_E_2] > U+0045 U+0328 U+0300 c 'Ę̀' layer('default')
 + [SHIFT T_E] > 'E' layer('default')
 + [SHIFT T_R] > 'R' layer('default')
 + [SHIFT T_T] > 'T' layer('default')
 + [SHIFT T_Y] > 'Y' layer('default')
 + [SHIFT T_U_0] > 'Ù' layer('default')
 + [SHIFT T_U_1] > 'Ų' layer('default')
-+ [SHIFT T_U_2] > 'Ų̀' layer('default')
++ [SHIFT T_U_2] > U+0055 U+0328 U+0300 c 'Ų̀' layer('default')
 + [SHIFT T_U] > 'U' layer('default')
 + [SHIFT T_I_0] > 'Ì' layer('default')
 + [SHIFT T_I_1] > 'Į' layer('default')
-+ [SHIFT T_I_2] > 'Į̀' layer('default')
++ [SHIFT T_I_2] > U+0049 U+0328 U+0300 c 'Į̀' layer('default')
 + [SHIFT T_I] > 'I' layer('default')
 + [SHIFT T_O_0] > 'Ò' layer('default')
 + [SHIFT T_O_1] > 'Ǫ' layer('default')
-+ [SHIFT T_O_2] > 'Ǫ̀' layer('default')
++ [SHIFT T_O_2] > U+004F U+0328 U+0300 c 'Ǫ̀' layer('default')
 + [SHIFT T_O] > 'O' layer('default')
 + [SHIFT T_P] > 'Ł' layer('default')
 + [SHIFT T_A_0] > 'À' layer('default')
 + [SHIFT T_A_1] > 'Ą' layer('default')
-+ [SHIFT T_A_2] > 'Ą̀' layer('default')
++ [SHIFT T_A_2] > U+0041 U+0328 U+0300 c 'Ą̀' layer('default')
 + [SHIFT T_A] > 'A' layer('default')
 + [SHIFT T_S] > 'S' layer('default')
 + [SHIFT T_D] > 'D' layer('default')
-'ì' + [SHIFT T_F] > 'į̀'
+'ì' + [SHIFT T_F] > U+0069 U+0328 U+0300 c 'į̀'
 'U' + [SHIFT T_F] > 'Ų'
-'ò' + [SHIFT T_F] > 'ǫ̀'
-'Ì' + [SHIFT T_F] > 'Į̀'
-'ù' + [SHIFT T_F] > 'ų̀'
+'ò' + [SHIFT T_F] > U+006F U+0328 U+0300 c 'ǫ̀'
+'Ì' + [SHIFT T_F] > U+0049 U+0328 U+0300 c 'Į̀'
+'ù' + [SHIFT T_F] > U+0075 U+0328 U+0300 c 'ų̀'
 'I' + [SHIFT T_F] > 'Į'
-'Ò' + [SHIFT T_F] > 'Ǫ̀'
+'Ò' + [SHIFT T_F] > U+004F U+0328 U+0300 c 'Ǫ̀'
 'e' + [SHIFT T_F] > 'ę'
-'Ù' + [SHIFT T_F] > 'Ų̀'
-'à' + [SHIFT T_F] > 'ą̀'
-'À' + [SHIFT T_F] > 'Ą̀'
+'Ù' + [SHIFT T_F] > U+0055 U+0328 U+0300 c 'Ų̀'
+'à' + [SHIFT T_F] > U+0061 U+0328 U+0300 c 'ą̀'
+'À' + [SHIFT T_F] > U+0041 U+0328 U+0300 c 'Ą̀'
 'u' + [SHIFT T_F] > 'ų'
 'i' + [SHIFT T_F] > 'į'
 'A' + [SHIFT T_F] > 'Ą'
 'O' + [SHIFT T_F] > 'Ǫ'
-'è' + [SHIFT T_F] > 'ę̀'
-'È' + [SHIFT T_F] > 'Ę̀'
+'è' + [SHIFT T_F] > U+0065 U+0328 U+0300 c 'ę̀'
+'È' + [SHIFT T_F] > U+0045 U+0328 U+0300 c 'Ę̀'
 'E' + [SHIFT T_F] > 'Ę'
 'a' + [SHIFT T_F] > 'ą'
 'o' + [SHIFT T_F] > 'ǫ'
@@ -100,85 +100,85 @@ store(&LAYOUTFILE) 'fv_gwichin.keyman-touch-layout'
 + [SHIFT T_COLON_0] > '"' layer('default')
 + [SHIFT T_COLON] > "'" layer('default')
 + [SHIFT T_Z] > 'Z' layer('default')
-'o' + [SHIFT T_X] > 'ǫ̀'
-'I' + [SHIFT T_X] > 'Į̀'
-'E' + [SHIFT T_X] > 'Ę̀'
-'A' + [SHIFT T_X] > 'Ą̀'
-'u' + [SHIFT T_X] > 'ų̀'
-'O' + [SHIFT T_X] > 'Ǫ̀'
-'e' + [SHIFT T_X] > 'ę̀'
-'a' + [SHIFT T_X] > 'ą̀'
-'i' + [SHIFT T_X] > 'į̀'
-'U' + [SHIFT T_X] > 'Ų̀'
+'o' + [SHIFT T_X] > U+006F U+0328 U+0300 c 'ǫ̀'
+'I' + [SHIFT T_X] > U+0049 U+0328 U+0300 c 'Į̀'
+'E' + [SHIFT T_X] > U+0045 U+0328 U+0300 c 'Ę̀'
+'A' + [SHIFT T_X] > U+0041 U+0328 U+0300 c 'Ą̀'
+'u' + [SHIFT T_X] > U+0075 U+0328 U+0300 c 'ų̀'
+'O' + [SHIFT T_X] > U+004F U+0328 U+0300 c 'Ǫ̀'
+'e' + [SHIFT T_X] > U+0065 U+0328 U+0300 c 'ę̀'
+'a' + [SHIFT T_X] > U+0061 U+0328 U+0300 c 'ą̀'
+'i' + [SHIFT T_X] > U+0069 U+0328 U+0300 c 'į̀'
+'U' + [SHIFT T_X] > U+0055 U+0328 U+0300 c 'Ų̀'
 + [SHIFT T_C] > 'C' layer('default')
 + [SHIFT T_V] > 'V' layer('default')
 + [SHIFT T_B] > 'B' layer('default')
 + [SHIFT T_N] > 'N' layer('default')
 + [SHIFT T_M] > 'M' layer('default')
-'į' + [T_Q] > 'į̀'
-'Ǫ' + [T_Q] > 'Ǫ̀'
+'į' + [T_Q] > U+0069 U+0328 U+0300 c 'į̀'
+'Ǫ' + [T_Q] > U+004F U+0328 U+0300 c 'Ǫ̀'
 'U' + [T_Q] > 'Ù'
-'Ų' + [T_Q] > 'Ų̀'
-'ų' + [T_Q] > 'ų̀'
+'Ų' + [T_Q] > U+0055 U+0328 U+0300 c 'Ų̀'
+'ų' + [T_Q] > U+0075 U+0328 U+0300 c 'ų̀'
 'I' + [T_Q] > 'Ì'
-'ą' + [T_Q] > 'ą̀'
+'ą' + [T_Q] > U+0061 U+0328 U+0300 c 'ą̀'
 'e' + [T_Q] > 'è'
-'Ą' + [T_Q] > 'Ą̀'
+'Ą' + [T_Q] > U+0041 U+0328 U+0300 c 'Ą̀'
 'u' + [T_Q] > 'ù'
 'i' + [T_Q] > 'ì'
-'ę' + [T_Q] > 'ę̀'
+'ę' + [T_Q] > U+0065 U+0328 U+0300 c 'ę̀'
 'A' + [T_Q] > 'À'
 'O' + [T_Q] > 'Ò'
-'Ę' + [T_Q] > 'Ę̀'
+'Ę' + [T_Q] > U+0045 U+0328 U+0300 c 'Ę̀'
 'E' + [T_Q] > 'È'
 'a' + [T_Q] > 'à'
 'o' + [T_Q] > 'ò'
-'ǫ' + [T_Q] > 'ǫ̀'
-'Į' + [T_Q] > 'Į̀'
+'ǫ' + [T_Q] > U+006F U+0328 U+0300 c 'ǫ̀'
+'Į' + [T_Q] > U+0049 U+0328 U+0300 c 'Į̀'
 + [T_W] > 'w'
 + [T_E_0] > 'è'
 + [T_E_1] > 'ę'
-+ [T_E_2] > 'ę̀'
++ [T_E_2] > U+0065 U+0328 U+0300 c 'ę̀'
 + [T_E] > 'e'
 + [T_R] > 'r'
 + [T_T] > 't'
 + [T_Y] > 'y'
 + [T_U_0] > 'ù'
 + [T_U_1] > 'ų'
-+ [T_U_2] > 'ų̀'
++ [T_U_2] > U+0075 U+0328 U+0300 c 'ų̀'
 + [T_U] > 'u'
 + [T_I_0] > 'ì'
 + [T_I_1] > 'į'
-+ [T_I_2] > 'į̀'
++ [T_I_2] > U+0069 U+0328 U+0300 c 'į̀'
 + [T_I] > 'i'
 + [T_O_0] > 'ò'
 + [T_O_1] > 'ǫ'
-+ [T_O_2] > 'ǫ̀'
++ [T_O_2] > U+006F U+0328 U+0300 c 'ǫ̀'
 + [T_O] > 'o'
 + [T_P] > 'ł'
 + [T_A_0] > 'à'
 + [T_A_1] > 'ą'
-+ [T_A_2] > 'ą̀'
++ [T_A_2] > U+0061 U+0328 U+0300 c 'ą̀'
 + [T_A] > 'a'
 + [T_S] > 's'
 + [T_D] > 'd'
-'ì' + [T_F] > 'į̀'
+'ì' + [T_F] > U+0069 U+0328 U+0300 c 'į̀'
 'U' + [T_F] > 'Ų'
-'ò' + [T_F] > 'ǫ̀'
-'Ì' + [T_F] > 'Į̀'
-'ù' + [T_F] > 'ų̀'
+'ò' + [T_F] > U+006F U+0328 U+0300 c 'ǫ̀'
+'Ì' + [T_F] > U+0049 U+0328 U+0300 c 'Į̀'
+'ù' + [T_F] > U+0075 U+0328 U+0300 c 'ų̀'
 'I' + [T_F] > 'Į'
-'Ò' + [T_F] > 'Ǫ̀'
+'Ò' + [T_F] > U+004F U+0328 U+0300 c 'Ǫ̀'
 'e' + [T_F] > 'ę'
-'Ù' + [T_F] > 'Ų̀'
-'à' + [T_F] > 'ą̀'
-'À' + [T_F] > 'Ą̀'
+'Ù' + [T_F] > U+0055 U+0328 U+0300 c 'Ų̀'
+'à' + [T_F] > U+0061 U+0328 U+0300 c 'ą̀'
+'À' + [T_F] > U+0041 U+0328 U+0300 c 'Ą̀'
 'u' + [T_F] > 'ų'
 'i' + [T_F] > 'į'
 'A' + [T_F] > 'Ą'
 'O' + [T_F] > 'Ǫ'
-'è' + [T_F] > 'ę̀'
-'È' + [T_F] > 'Ę̀'
+'è' + [T_F] > U+0065 U+0328 U+0300 c 'ę̀'
+'È' + [T_F] > U+0045 U+0328 U+0300 c 'Ę̀'
 'E' + [T_F] > 'Ę'
 'a' + [T_F] > 'ą'
 'o' + [T_F] > 'ǫ'
@@ -190,16 +190,16 @@ store(&LAYOUTFILE) 'fv_gwichin.keyman-touch-layout'
 + [T_COLON_0] > '"'
 + [T_COLON] > "'"
 + [T_Z] > 'z'
-'o' + [T_X] > 'ǫ̀'
-'I' + [T_X] > 'Į̀'
-'E' + [T_X] > 'Ę̀'
-'A' + [T_X] > 'Ą̀'
-'u' + [T_X] > 'ų̀'
-'O' + [T_X] > 'Ǫ̀'
-'e' + [T_X] > 'ę̀'
-'a' + [T_X] > 'ą̀'
-'i' + [T_X] > 'į̀'
-'U' + [T_X] > 'Ų̀'
+'o' + [T_X] > U+006F U+0328 U+0300 c 'ǫ̀'
+'I' + [T_X] > U+0049 U+0328 U+0300 c 'Į̀'
+'E' + [T_X] > U+0045 U+0328 U+0300 c 'Ę̀'
+'A' + [T_X] > U+0041 U+0328 U+0300 c 'Ą̀'
+'u' + [T_X] > U+0075 U+0328 U+0300 c 'ų̀'
+'O' + [T_X] > U+004F U+0328 U+0300 c 'Ǫ̀'
+'e' + [T_X] > U+0065 U+0328 U+0300 c 'ę̀'
+'a' + [T_X] > U+0061 U+0328 U+0300 c 'ą̀'
+'i' + [T_X] > U+0069 U+0328 U+0300 c 'į̀'
+'U' + [T_X] > U+0055 U+0328 U+0300 c 'Ų̀'
 + [T_C] > 'c'
 + [T_V] > 'v'
 + [T_B] > 'b'
@@ -308,12 +308,12 @@ c *********
 ',;%' + any(let) > index(let,4) U+0328  U+0308 U+030c 
 ',%;' + any(let) > index(let,4) U+0328  U+0308 U+030c
 
-';^,' + any(let) > index(let,4) U+0328  U+0308 U+0302 c dia cir ogo
-'^;,' + any(let) > index(let,4)  U+0328 U+0308 U+0302
-';,^' + any(let) > index(let,4) U+0328  U+0308 U+0302 
-'^,;' + any(let) > index(let,4)  U+0328 U+0308 U+0302
-',;^' + any(let) > index(let,4) U+0328  U+0308 U+0302 
-',^;' + any(let) > index(let,4)  U+0328 U+0308 U+0302
+';^,' + any(let) > index(let,4) U+0328 U+0308 U+0302 c dia cir ogo
+'^;,' + any(let) > index(let,4) U+0328 U+0308 U+0302
+';,^' + any(let) > index(let,4) U+0328 U+0308 U+0302 
+'^,;' + any(let) > index(let,4) U+0328 U+0308 U+0302
+',;^' + any(let) > index(let,4) U+0328 U+0308 U+0302 
+',^;' + any(let) > index(let,4) U+0328 U+0308 U+0302
 
 ';&,' + any(let) > index(let,4) U+0328  U+0308 U+030B c dia dac ogo
 '&;,' + any(let) > index(let,4) U+0328  U+0308 U+030B
@@ -351,18 +351,18 @@ c *********
 ',=' + any(let) > index(let,3) U+0304  U+0328
 
 '=`,' + any(let) > index(let,4)  U+0328  U+0304 U+0300  c mac gra ogo
-'`=,' + any(let) > index(let,4)  U+0328  U+0304   U+0300        
-'`,=' + any(let) > index(let,4)  U+0328  U+0304   U+0300   
-'=,`' + any(let) > index(let,4)  U+0328  U+0304   U+0300   
-',`=' + any(let) > index(let,4)  U+0328  U+0304   U+0300   
-',=`' + any(let) > index(let,4)  U+0328  U+0304   U+0300          
+'`=,' + any(let) > index(let,4)  U+0328  U+0304 U+0300        
+'`,=' + any(let) > index(let,4)  U+0328  U+0304 U+0300   
+'=,`' + any(let) > index(let,4)  U+0328  U+0304 U+0300   
+',`=' + any(let) > index(let,4)  U+0328  U+0304 U+0300   
+',=`' + any(let) > index(let,4)  U+0328  U+0304 U+0300          
 
 '=/,' + any(let) > index(let,4)  U+0328  U+0304 U+0301  c mac acu ogo
-'/=,' + any(let) > index(let,4)  U+0328  U+0304  U+0301             
+'/=,' + any(let) > index(let,4)  U+0328  U+0304 U+0301             
 '=,/' + any(let) > index(let,4)  U+0328  U+0304 U+0301  
-'/,=' + any(let) > index(let,4)  U+0328  U+0304  U+0301 
-',=/' + any(let) > index(let,4)  U+0328  U+0304  U+0301  
-',/=' + any(let) > index(let,4)  U+0328  U+0304  U+0301 
+'/,=' + any(let) > index(let,4)  U+0328  U+0304 U+0301 
+',=/' + any(let) > index(let,4)  U+0328  U+0304 U+0301  
+',/=' + any(let) > index(let,4)  U+0328  U+0304 U+0301 
 
 '=%,' + any(let) > index(let,4)  U+0328  U+0304 U+030c  c mac car ogo
 '%=,' + any(let) > index(let,4)  U+0328  U+0304  U+030c
@@ -372,11 +372,11 @@ c *********
 ',%=' + any(let) > index(let,4)  U+0328  U+0304  U+030c
 
 '=^,' + any(let) > index(let,4)  U+0328  U+0304  U+0302 c mac cir ogo
-'^=,' + any(let) > index(let,4)   U+0328  U+0304  U+0302
+'^=,' + any(let) > index(let,4)  U+0328  U+0304  U+0302
 '=,^' + any(let) > index(let,4)  U+0328  U+0304  U+0302 
-'^,=' + any(let) > index(let,4)   U+0328  U+0304  U+0302
+'^,=' + any(let) > index(let,4)  U+0328  U+0304  U+0302
 ',=^' + any(let) > index(let,4)  U+0328  U+0304  U+0302 
-',^=' + any(let) > index(let,4)   U+0328  U+0304  U+0302
+',^=' + any(let) > index(let,4)  U+0328  U+0304  U+0302
 
 '=&,' + any(let) > index(let,4)  U+0328  U+0304  U+030B c mac dac ogo
 '&=,' + any(let) > index(let,4)  U+0328  U+0304  U+030B
@@ -393,19 +393,19 @@ c ***********
 '=;' + any (let) > index(let,3) U+0308 U+0304
 
 ';=,' + any (let) > index(let,4) U+0328 U+0308 U+0304
-'=;,' + any (let) > index(let,4) U+0328  U+0308 U+0304
-';,=' + any (let) > index(let,4) U+0328  U+0308 U+0304
-'=,;' + any (let) > index(let,4) U+0328  U+0308 U+0304
-',;=' + any (let) > index(let,4) U+0328  U+0308 U+0304
-',=;' + any (let) > index(let,4) U+0328  U+0308 U+0304    
+'=;,' + any (let) > index(let,4) U+0328 U+0308 U+0304
+';,=' + any (let) > index(let,4) U+0328 U+0308 U+0304
+'=,;' + any (let) > index(let,4) U+0328 U+0308 U+0304
+',;=' + any (let) > index(let,4) U+0328 U+0308 U+0304
+',=;' + any (let) > index(let,4) U+0328 U+0308 U+0304    
 
 c ***********
 c *** misc ***
 c ***********
 
-'.' + any(let) > index(let,2) U+0323  c dot under
-"~" + any(let) > index(let,2) U+0303 c tilde
-"+(" + any(let) > index(let,3) U+0306  c breve      
+'.' + any(let)  > index(let,2) U+0323 c dot under
+"~" + any(let)  > index(let,2) U+0303 c tilde
+"+(" + any(let) > index(let,3) U+0306 c breve      
 "+)" + any(let) > index(let,3) U+0325 c ring under
 '+' + "O" > "Œ"
 "+" + "o" > "œ"

--- a/release/fv/fv_gwichin/source/fv_gwichin.kvks
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kvks
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <visualkeyboard>
   <header>
     <version>10.0</version>

--- a/release/fv/fv_gwichin/source/help/fv_gwichin.php
+++ b/release/fv/fv_gwichin/source/help/fv_gwichin.php
@@ -26,7 +26,7 @@ This keyboard is designed for the <b>Gwich'in</b> language of the Western Subarc
 <tr ><td  align='center'>a à ą ą̀</td><td  align='center'>s</td><td  align='center'>d</td><th  align='center'>˛</th><td  align='center'>g</td><td  align='center'>h</td><td  align='center'>j</td><td  align='center'>k</td><td  align='center'>l</td><td  align='center'>' "</td></tr>
 <tr ><td >&nbsp;</td><td  align='center'>z</td><td  align='center'>. ,</td><td  align='center'>c</td><td  align='center'>v</td><td  align='center'>b</td><td  align='center'>n</td><td  align='center'>m</td><td  colspan='2'>&nbsp;</td></tr>
 </table>
-<div class='vspace'></div><ul><li>keys with a red background are combining accents.
+<div class='vspace'></div><ul><li>` (grave) , (ogonek) / (acute) % (caron) ^ (circumflex) & (diaeresis) are combining accents and should be typed before the vowel.
 </li><li>the first character in a cell is the "one-tap" key, any further characters are "hold-select" keys.
 </li></ul>
 </div>

--- a/release/fv/fv_gwichin/source/help/fv_gwichin.php
+++ b/release/fv/fv_gwichin/source/help/fv_gwichin.php
@@ -38,5 +38,5 @@ This keyboard is designed for the <b>Gwich'in</b> language of the Western Subarc
 </div>
 
 <h2>Tablet Keyboard Layout</h2>
-<div id='osk-tablet'>
+<div id='osk-tablet' data-states='default shift numeric'></div>
 </div>

--- a/release/fv/fv_gwichin/source/welcome/welcome.htm
+++ b/release/fv/fv_gwichin/source/welcome/welcome.htm
@@ -35,7 +35,7 @@ This keyboard is designed for the <b>Gwich'in</b> language of the Western Subarc
 <tr ><td  align='center'>a à ą ą̀</td><td  align='center'>s</td><td  align='center'>d</td><th  align='center'>˛</th><td  align='center'>g</td><td  align='center'>h</td><td  align='center'>j</td><td  align='center'>k</td><td  align='center'>l</td><td  align='center'>' "</td></tr>
 <tr ><td >&nbsp;</td><td  align='center'>z</td><td  align='center'>. ,</td><td  align='center'>c</td><td  align='center'>v</td><td  align='center'>b</td><td  align='center'>n</td><td  align='center'>m</td><td  colspan='2'>&nbsp;</td></tr>
 </table>
-<div class='vspace'></div><ul><li>keys with a red background are combining accents.
+<div class='vspace'></div><ul><li>` (grave) , (ogonek) / (acute) % (caron) ^ (circumflex) & (diaeresis) are combining accents and should be typed before the vowel.
 </li><li>the first character in a cell is the "one-tap" key, any further characters are "hold-select" keys.
 </li></ul>
 </div>


### PR DESCRIPTION
I also added ` and ^ to the mobile layout so they could type grave and circumflex on mobile since they can type them on desktop.