### PR TITLE
[basic_kbduzb-dep] Deprecate uzbek keyboard also

### DIFF
--- a/legacy/u/uzbek/DEPRECATED.md
+++ b/legacy/u/uzbek/DEPRECATED.md
@@ -1,0 +1,2 @@
+This keyboard has been deprecated and replaced by release/basic/basic_kbduzb.
+

--- a/release/basic/basic_kbduzb/basic_kbduzb.keyboard_info
+++ b/release/basic/basic_kbduzb/basic_kbduzb.keyboard_info
@@ -8,6 +8,9 @@
     "uzbek_cyrillic": {
       "deprecates": true
     },
+    "uzbek": {
+      "deprecates": true
+    },
     "kbduzb": {
       "deprecates": true
     }


### PR DESCRIPTION
I neglected to associate the legacy "uzbek" keyboard as deprecated.
No need for version bump.