### PR TITLE
Ensure s.keyman.com clone is up to date before pushing changes (reduces risk of CI failing)

### DIFF
--- a/resources/s-keyman-com.sh
+++ b/resources/s-keyman-com.sh
@@ -125,6 +125,12 @@ function commit_and_push {
 # Main
 #
 
+# Ensure s.keyman.com is up to date
+
+pushd $S_KEYMAN_COM
+git pull origin master || return 1
+popd
+
 upload_keyboards || exit 1
 if [ $keyboards_to_push == 1 ]; then
   commit_and_push || exit 1


### PR DESCRIPTION
This should reduce the frequency of CI builds failing because s.keyman.com is updated between the build starting and the build pushing changes upstream to origin, by updating the local clone of s.keyman.com immediately before adding changes.