### PR TITLE
[aksarabali_panlex] implement alt + dependent vowel combos; update docs

### DIFF
--- a/release/a/aksarabali_panlex/HISTORY.md
+++ b/release/a/aksarabali_panlex/HISTORY.md
@@ -1,6 +1,11 @@
 Aksara Bali Unicode Keyboard Change History
 ===========================================
 
+1.0.3 (1 August 2019)
+---------------------
+
+* Add support for inserting dependent vowel marks anywhere by adding ALT to regular keystroke
+
 1.0.2 (29 July 2019)
 --------------------
 

--- a/release/a/aksarabali_panlex/README.md
+++ b/release/a/aksarabali_panlex/README.md
@@ -3,7 +3,7 @@ Aksara Bali Unicode Keyboard
 
 Copyright (C) 2019 The PanLex Project of The Long Now Foundation
 
-Version 1.0.2
+Version 1.0.3
 
 __DESCRIPTION__
 This keyboard lets you type Aksara Bali (Balinese script) in Unicode. It is a Unicode reimplementation of the Bali Simbar keyboard (the de-facto standard keyboard in Bali for typing in Balinese script).

--- a/release/a/aksarabali_panlex/source/aksarabali_panlex.kmn
+++ b/release/a/aksarabali_panlex/source/aksarabali_panlex.kmn
@@ -1,7 +1,7 @@
 ﻿store(&NAME) 'Aksara Bali Unicode'
 store(&TARGETS) 'windows macosx linux desktop web'
 store(&COPYRIGHT) '© 2019 The PanLex Project of The Long Now Foundation'
-store(&KEYBOARDVERSION) '1.0.2'
+store(&KEYBOARDVERSION) '1.0.3'
 store(&MESSAGE) 'Aksara Bali Unicode, based on Bali Simbar'
 store(&BITMAP) 'aksarabali_panlex.ico'
 store(&VISUALKEYBOARD) 'aksarabali_panlex.kvks'
@@ -41,6 +41,7 @@ store(dvowel_short_key) [K_E] [SHIFT K_E] [K_I] [K_O] [K_U]
 store(dvowel_short)     'ᭂᬾᬶᭀᬸ'
 store(dvowel_key)       outs(dvowel_short_key) [SHIFT K_A] [CTRL SHIFT K_E] [SHIFT K_I] [SHIFT K_U]
 store(dvowel)           outs(dvowel_short)     'ᬵᬿᬷᬹ'
+store(dvowel_key_alt)   [ALT K_E] [ALT SHIFT K_E] [ALT K_I] [ALT K_O] [ALT K_U] [ALT SHIFT K_A] [ALT CTRL SHIFT K_E] [ALT SHIFT K_I] [ALT SHIFT K_U]
 store(dvowel_front)     'ᬶᬾ'
 store(dvowel_back)      'ᬸᭀ'
 
@@ -216,6 +217,7 @@ group(main) using keys
   + any(cons_key) > index(cons_main, 1) '?'
   '?' + any(indep_key) > index(indep, 2)
   + any(indep_key) > index(indep, 1)
+  + any(dvowel_key_alt) > index(dvowel, 1)
 
   c ha insertion
   $adeg + [K_A] > context $zwnj 'ᬳ' 

--- a/release/a/aksarabali_panlex/source/welcome/welcome.htm
+++ b/release/a/aksarabali_panlex/source/welcome/welcome.htm
@@ -30,13 +30,14 @@
 <p>This keyboard contains several additions to the original Bali Simbar keyboard:</p>
 
 <ul>
-    <li>[/] types <em>adeg-adeg</em></li>
-    <li>[Ctrl-Shift-/] types ⟨/⟩</li>
-    <li>[Shift-number] types Arabic numerals, for example [Shift-1] types ⟨1⟩
-    <li>[Ctrl-r] types <em>rerekan</em>, for example [p] [Ctrl-r] types ⟨ᬧ᬴⟩</li>
-    <li>[Ctrl-Alt-o] types <em>windu</em> ⟨᭜⟩</li>
-    <li>[Ctrl-Shift-,] types ⟨᭚᭜᭚⟩, repeat for ⟨᭟᭜᭟⟩</li>
-    <li>[Ctrl-Shift-.] types ⟨᭛᭜᭛⟩, repeat for ⟨᭟᭜᭟⟩</li>
+    <li>[/] types <em>adeg-adeg</em>.</li>
+    <li>[Ctrl-Shift-/] types ⟨/⟩.</li>
+    <li>[Shift-number] types Arabic numerals. For example, [Shift-1] types ⟨1⟩.
+    <li>[Ctrl-R] types <em>rerekan</em>. For example, [P] [Ctrl-R] types ⟨ᬧ᬴⟩.</li>
+    <li>[Ctrl-Alt-O] types <em>windu</em> ⟨᭜⟩.</li>
+    <li>[Ctrl-Shift-,] types ⟨᭚᭜᭚⟩. Repeat for ⟨᭟᭜᭟⟩.</li>
+    <li>[Ctrl-Shift-.] types ⟨᭛᭜᭛⟩. Repeat for ⟨᭟᭜᭟⟩.</li>
+    <li>[Alt-vowel] types a dependent vowel even in places where it normally isn’t allowed. For example, [P] [I] [Alt-U] lets you type ⟨ᬧᬶᬸ⟩, with <em>suku</em> after <em>ulu</em>. This is attested as a way to indicate a scribal error.</li>
 </ul>
 
 <p>For much more detailed information, read the original <a href="bali_simbar_panduan.pdf">Bali Simbar keyboard guide</a> (in Indonesian), included with the permission of author I Made Suatjana. Keyboard instructions begin on page 8.</p>


### PR DESCRIPTION
Adds support for typing ulu plus suku after a consonant. This is an illicit combination of vowel marks, but it is actually attested in palm leaf manuscripts as a way to indicate that an aksara was a mistake and should be ignored. So the keyboard needs to support it!