### PR TITLE
[Infrastructure] Support building just a shortname-group of keyboards

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@
 
 function display_usage {
   echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [target]"
+  echo "  target should be a folder, for example: release, or release/k, or release/k/keyboard"
+  echo "  (on keyboards_starter repo, target is not necessary)"
   exit 1
 }
 
@@ -102,6 +104,9 @@ else
       group=$(cut -d / -f 1 <<< "$TARGET")
       echo "--- Only building $group $TARGET ---"
       build_keyboard $group "$TARGET"
+    elif [[ "$TARGET" == */* ]] && [[ (-d "$TARGET") ]]; then
+      echo "--- Only building $TARGET ---"
+      build_keyboard_group "$TARGET"
     elif [[ "$TARGET" == "release" ]] || [[ "$TARGET" == "legacy" ]] || [[ "$TARGET" == "experimental" ]]; then
       # Assuming release|legacy|experimental
       echo "--- Only building $TARGET ---"

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -90,6 +90,19 @@ function build_keyboards {
   return 0
 }
 
+function build_keyboard_group {
+  # Build a single group of keyboards, e.g. release/a
+  # This function is only valid for the keyboards repo; it is
+  # unnecessary for the keyboards_starter repo.
+  local shortname=$(basename "$1")
+  local group=$(dirname "$1")
+
+  local keyboard
+  for keyboard in "$group/$shortname/"*/ ; do
+    build_keyboard "$group" "$keyboard"
+  done
+}
+
 #----------------------------------------------------------------------------------------
 # Build a keyboard
 #----------------------------------------------------------------------------------------


### PR DESCRIPTION
This is a dependency for the FirstVoices apps builds.