### PR TITLE
fix wrong version numbers

### DIFF
--- a/release/basic/basic_kbdfar/source/welcome/welcome.htm
+++ b/release/basic/basic_kbdfar/source/welcome/welcome.htm
@@ -14,7 +14,7 @@
 <h1>Start Using Persian (Standard) Basic</h1>
 
 <p>
-    Persian (Standard) Basic 1.1.
+    Persian (Standard) Basic 1.0.
 </p>
 
 <h1>Keyboard Layout</h1>

--- a/release/basic/basic_kbdogham/source/welcome/welcome.htm
+++ b/release/basic/basic_kbdogham/source/welcome/welcome.htm
@@ -14,7 +14,7 @@
 <h1>Start Using Ogham Basic</h1>
 
 <p>
-    Ogham Basic 1.1.
+    Ogham Basic 1.0.
 </p>
 
 <h1>Keyboard Layout</h1>

--- a/release/basic/basic_kbdoldit/source/welcome/welcome.htm
+++ b/release/basic/basic_kbdoldit/source/welcome/welcome.htm
@@ -14,7 +14,7 @@
 <h1>Start Using Old Italic Basic</h1>
 
 <p>
-    Old Italic Basic 1.1.
+    Old Italic Basic 1.0.
 </p>
 
 <h1>Keyboard Layout</h1>

--- a/release/basic/basic_kbdosm/source/welcome/welcome.htm
+++ b/release/basic/basic_kbdosm/source/welcome/welcome.htm
@@ -14,7 +14,7 @@
 <h1>Start Using Osmanya Basic</h1>
 
 <p>
-    Osmanya Basic 1.1.
+    Osmanya Basic 1.0.
 </p>
 
 <h1>Keyboard Layout</h1>


### PR DESCRIPTION
I copied the welcome folder over from another keyboard which `1.1` as the version number and I did not check it twice before creating the PRs. This PR fixes all those affected by this.