### PR TITLE
[Krung] Fixup missing symbols from krung.kvks

### DIFF
--- a/release/k/krung/HISTORY.md
+++ b/release/k/krung/HISTORY.md
@@ -1,6 +1,10 @@
 Krung Change History
 ====================
 
+1.0.1 (2019-09-06)
+------------------
+* Fixup missing symbols in on screen keyboard
+
 1.0 (2019-03-01)
 ----------------
 * Created by SIL International

--- a/release/k/krung/README.md
+++ b/release/k/krung/README.md
@@ -3,7 +3,7 @@ Krung keyboard
 
 © 2019 SIL International
 
-Version 1.0
+Version 1.0.1
 
 Description
 -----------

--- a/release/k/krung/source/krung.kmn
+++ b/release/k/krung/source/krung.kmn
@@ -3,7 +3,7 @@ c krung generated from template at 2019-03-01 13:05:36
 c with name "Krung"
 store(&NAME) 'Krung'
 store(&COPYRIGHT) '© 2019 SIL International'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'krung.kvks'
 store(&LAYOUTFILE) 'krung.keyman-touch-layout'
@@ -16,7 +16,7 @@ group(main) using keys
 c SHIFT KEYS
 store(not_in_use)   [SHIFT K_Q] [SHIFT K_W] [SHIFT K_E] [SHIFT K_R] [SHIFT K_T] [SHIFT K_Y] [SHIFT K_U] [SHIFT K_I] [SHIFT K_O] [SHIFT K_P] \
                     [SHIFT K_A] [SHIFT K_S] [SHIFT K_D] [SHIFT K_F] [SHIFT K_G] [SHIFT K_H] [SHIFT K_J] [SHIFT K_K] [SHIFT K_L] \
-                    [SHIFT K_Z] [SHIFT K_X] [SHIFT K_C] [SHIFT K_V] [SHIFT K_B] [SHIFT K_N] [SHIFT K_M] [K_F] 
+                    [SHIFT K_Z] [SHIFT K_X] [SHIFT K_C] [SHIFT K_V] [SHIFT K_B] [SHIFT K_N] [SHIFT K_M] [K_F]
 
 + any(not_in_use)    > nul
 c punctuations
@@ -31,18 +31,18 @@ U+003E + [SHIFT K_PERIOD]   > U+00BB    c >> > »
 
 
 c numerals
-store(number_key)   [K_0] [K_1] [K_2] [K_3] [K_4] [K_5] [K_6] [K_7] [K_8] [K_9] 
+store(number_key)   [K_0] [K_1] [K_2] [K_3] [K_4] [K_5] [K_6] [K_7] [K_8] [K_9]
 store(number_out)   U+17E0 U+17E1 U+17E2 U+17E3 U+17E4 U+17E5 U+17E6 U+17E7 U+17E8 U+17E9
 + any(number_key)   > index(number_out,1)
 
 
 c single orthographic consonant mappings
-store(sin_con1_key)     [K_B] [K_C] [K_D] [K_H] [K_J] [K_K] [K_Q] [K_S] [K_T]           c bcdhjkqst      
+store(sin_con1_key)     [K_B] [K_C] [K_D] [K_H] [K_J] [K_K] [K_Q] [K_S] [K_T]           c bcdhjkqst
 store(sin_con1_out)     U+1794 U+1785 U+178A U+17A0 U+1786 U+1780 U+17A2 U+179F U+178F  c បចដហឆកអសត
 + any(sin_con1_key)     > index(sin_con1_out,1)
 
 store(sin_con2_key)     [K_G] [K_M] [K_P] [K_R] [K_W] [K_Y] [K_L] [K_N]         c gmprwyln
-store(sin_con2_out)     U+179D U+1798 U+1796 U+179A U+179C U+1799 U+179B U+1793 c ឝមពរវយលន 
+store(sin_con2_out)     U+179D U+1798 U+1796 U+179A U+179C U+1799 U+179B U+1793 c ឝមពរវយលន
 + any(sin_con2_key)     > index(sin_con2_out,1)
 
 
@@ -62,7 +62,7 @@ U+17A2 + [K_M]                  > context U+17D2 U+1798     c for qm    អ្�
 U+17A0 + [K_N]                  > context U+17D2 U+1793     c for hn    ហ្ន
 U+17A2 + [K_N]                  > context U+17D2 U+1793     c for qn    អ្ន
 
-U+17A0 U+17D2 U+1793 + [K_G]    > context(1) U+17D2 U+1784  c for hng   ហ្ង  
+U+17A0 U+17D2 U+1793 + [K_G]    > context(1) U+17D2 U+1784  c for hng   ហ្ង
 U+17A2 U+17D2 U+1793 + [K_G]    > context(1) U+17D2 U+1784  c for qng   អ្ង
 
 U+17A2 + [K_Y]                  > context(1) U+17D2 U+1799  c for qy    អ្យ
@@ -70,7 +70,7 @@ U+17D2 U+1799 + [K_R]           > context(1) context(2) U+17D2 U+179A     c for 
 U+179E + [K_R]                  > context U+17D2 U+179A     c for qbr   ឞ្រ
 U+178B + [K_R]                  > context U+17D2 U+179A     c for qdr   ឋ្រ
 U+1795 + [K_L]                  > context U+17D2 U+179B     c for phl   ផ្ល
- 
+
 
 c consonants with two key combination
 U+1793 + [K_G]    > U+1784    c ng > ង
@@ -105,7 +105,7 @@ store(sin_fin_con)      U+1785 U+1780 U+179B U+1798 U+1793 U+1784 U+1789 U+1794 
 c consonants to be modified by Triisap
 store(con_triisap)      U+17A0 U+17A2 U+179E U+179F c ហអឞស
 store(con_bo)           U+1794                      c ប
-store(some_sin_con1)    U+1785 U+178A U+1786 U+1780 U+1781 U+17A1 U+178E U+1795 U+178B U+178F U+1790    
+store(some_sin_con1)    U+1785 U+178A U+1786 U+1780 U+1781 U+17A1 U+178E U+1795 U+178B U+178F U+1790
 store(all_sin_con1_but_bo)  outs(con_triisap) outs(some_sin_con1)
 store(all_sin_con1)     outs(con_triisap) outs(some_sin_con1) outs(con_bo)
 
@@ -119,7 +119,7 @@ store(any_con)          outs(all_sin_con1_but_bo) outs(all_sin_con2) outs(con_bo
 store(any_con_but_bo)   outs(all_sin_con1_but_bo) outs(all_sin_con2)
 
 
-c +++++++++++++++++ VE and EE Vowel Combination Disambiguation +++++++++++++++++ 
+c +++++++++++++++++ VE and EE Vowel Combination Disambiguation +++++++++++++++++
 U+1794 + [K_V]                                      > context(1) U+17CA U+17B9 dk(deadkey_v)
 any(all_sin_con2) + [K_V]                           > context(1) U+17B9 dk(deadkey_v)   c ឹ in series 2
 any(con_triisap) + [K_V]                            > context(1) U+17CA U+17B9 dk(deadkey_v)
@@ -144,7 +144,7 @@ U+17B9 dk(deadkey_v) + [K_E]        > U+17BF    c ve > ឿ (non-series)
 U+17B9 dk(deadkey_e) + [K_E]        > U+17BE    c ee > ើ (series 1)
 
 c vy
-any(con_muusikatoan) U+17B9 dk(deadkey_v) + [K_Y]   > context(1) U+17C9 U+17B8 
+any(con_muusikatoan) U+17B9 dk(deadkey_v) + [K_Y]   > context(1) U+17C9 U+17B8
 any(nl_con2) U+17B9 dk(deadkey_v) + [K_Y]   > index(nl_con1,1) U+17B8         c [n/l]vy
 U+1796 U+17B9 dk(deadkey_v) + [K_Y]         > U+1794 U+17C9 U+17B8  c pvy
 
@@ -204,7 +204,7 @@ U+17A1 U+17B6 U+1782 U+17CB + [K_A]                         > context(1) context
 U+178E U+17B6 U+1782 U+17CB + [K_A]                         > context(1) context(2)             c naa
 any(con_muusikatoan) + [K_A]                                > context U+17C9 U+17B6 U+1782 U+17CB
 any(all_sin_con1) + [K_A]                                   > context(1) U+17B6 U+1782 U+17CB   c any C1 a > any C1 ាគ់
-any(all_sin_con1) U+17B6 U+1782 U+17CB + [K_A]              > context(1) U+17B6                 c any C1 aa > any C1 ា 
+any(all_sin_con1) U+17B6 U+1782 U+17CB + [K_A]              > context(1) U+17B6                 c any C1 aa > any C1 ា
 U+17C9 U+17B6 U+1782 U+17CB + [K_A]                         > context(1) context(2)             c ា​គ់់ > ា
 
 
@@ -225,7 +225,7 @@ U+1782 U+17CB + [K_Z]               > dk(deadkey_z)
 dk(deadkey_z) + [K_P]               > U+1794
 
 any(con_bo) + [K_Z]                                 > context(1) U+1782 U+17CB  c bz > បគ់
-any(con_bo) U+1782 U+17CB + [K_Z]                   > context(1) dk(deadkey_z)  c bzz > ប 
+any(con_bo) U+1782 U+17CB + [K_Z]                   > context(1) dk(deadkey_z)  c bzz > ប
 any(con_muusikatoan) + [K_Z]                        > context U+17C9 U+1782 U+17CB
 any(con_muusikatoan) U+17C9 U+1782 U+17CB + [K_Z]   > context(1) U+17C9 dk(deadkey_z)
 
@@ -279,7 +279,7 @@ any(counterpart_con1) U+17D2 any(sub_con) + [K_V]                         > inde
 any(counterpart_con1) U+17D2 any(sub_con) U+17B7 + [K_X]                  > index(counterpart_con2,1) context(2) context(3) U+17C2                c C1[sub_con]xx
 
 any(counterpart_con2) U+17D2 any(sub_con) U+17B9 dk(deadkey_v) + [K_E]    > index(counterpart_con1,1) context(2) context(3) U+17BF                c C2[sub_con]ve, non series
-any(counterpart_con2) U+17D2 any(sub_con) U+17B9 dk(deadkey_v) + [K_Y]    > index(counterpart_con1,1) context(2) context(3) U+17B8                c C2[sub_con]vy, series 1 
+any(counterpart_con2) U+17D2 any(sub_con) U+17B9 dk(deadkey_v) + [K_Y]    > index(counterpart_con1,1) context(2) context(3) U+17B8                c C2[sub_con]vy, series 1
 any(counterpart_con2) U+17D2 any(sub_con) U+17BB + [K_E]                  > index(counterpart_con1,1) context(2) context(3) U+17BD                c C2[sub_con]ue, series 2
 any(counterpart_con2) U+17D2 any(sub_con) U+17B7 + [K_E]                  > index(counterpart_con1,1) context(2) context(3) U+17C0                c C2[sub_con]ie, series 1
 
@@ -289,8 +289,8 @@ U+1796 U+17D2 any(sub_con) + [K_E]                                > U+1794 conte
 U+1796 U+17D2 any(sub_con) + [K_A]                                > U+1794 context(2) context(3) U+17C9 U+17B6 U+1782 U+17CB  c p[r/l/m/n/ng]a
 U+1796 U+17D2 any(sub_con) + [K_Z]                                > U+1794 context(2) context(3) U+17C9 U+1782 U+17CB         c p[r/l/m/n/ng]z
 
-U+1796 U+17D2 any(sub_con) + any(sin_vow2_key)                    > context(1) context(2) context(3) index(sin_vow2_out,4) 
-U+1796 U+17D2 any(sub_con) + [K_V]                                > context(1) context(2) context(3) U+17B9 dk(deadkey_v) 
+U+1796 U+17D2 any(sub_con) + any(sin_vow2_key)                    > context(1) context(2) context(3) index(sin_vow2_out,4)
+U+1796 U+17D2 any(sub_con) + [K_V]                                > context(1) context(2) context(3) U+17B9 dk(deadkey_v)
 
 U+1796 U+17D2 any(sub_con) U+17B9 dk(deadkey_v) + [K_Y]           > U+1794 context(2) context(3) U+17C9 U+17B8                c p[r/l/m/n/ng]vy
 U+1796 U+17D2 any(sub_con) U+17B7 + [K_E]                         > context(1) context(2) context(3) U+17C0                   c p[r/l/m/n/ng]ie
@@ -343,11 +343,11 @@ U+17C9 U+17B6 any(con_bo) U+17CB + any(sin_vow2_key)    > context(3) U+17CA inde
 U+17C9 U+17B6 any(con_bo) U+17CB + [K_V]                > context(3) U+17CA U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]aCzz C៝៝៝៝៝៝ប 
+c [n/l/p]aCzz C៝៝៝៝៝៝ប
 any(nl_con1) any(any_con) U+1782 U+17CB + [K_Z]     > index(nl_con2,1) U+17DD context(2)
 U+1794 U+17C9 any(any_con) U+1782 U+17CB + [K_Z]    > U+1796 U+17DD context(3)
 
-c CaCzz C៝៝៝៝៝៝ប 
+c CaCzz C៝៝៝៝៝៝ប
 any(any_con) any(any_con) U+1782 U+17CB + [K_Z]         > context(1) U+17DD context(2)
 any(any_con) U+17C9 any(any_con) U+1782 U+17CB + [K_Z]  > context(1) U+17DD context(3)
 U+17DD any(any_con) + any(sin_con1_key)                 > context(2) index(sin_con1_out,3)  c fix hngkzzk > ហ្ងកក, not ហ្ង៝កក
@@ -358,12 +358,12 @@ U+17C9 any(any_con) U+17C9 any(con_bo) U+1782 U+17CB + [K_Z]    > context(2) U+1
 
 
 c [n/l/p]abrV-
-any(nl_con1) U+17B6 U+1794 U+17CB + [K_R]   > index(nl_con2,1) context(3) U+17D2 U+179A 
-U+1794 U+17C9 U+17B6 U+1794 U+17CB + [K_R]  > U+1796 context(4) U+17D2 U+179A  
+any(nl_con1) U+17B6 U+1794 U+17CB + [K_R]   > index(nl_con2,1) context(3) U+17D2 U+179A
+U+1794 U+17C9 U+17B6 U+1794 U+17CB + [K_R]  > U+1796 context(4) U+17D2 U+179A
 
 c -abrV-
 U+17B6 U+1794 U+17CB + [K_R]            > context(2) U+17D2 U+179A  c kabra
-U+17C9 U+17B6 U+1794 U+17CB + [K_R]     > context(3) U+17D2 U+179A  c gabra 
+U+17C9 U+17B6 U+1794 U+17CB + [K_R]     > context(3) U+17D2 U+179A  c gabra
 
 
 c [n/l/p]apV1-
@@ -445,7 +445,7 @@ any(nl_con1) U+17B6 U+17C6 + any(sin_vow1_key)    > index(nl_con2,1) U+1798 U+17
 any(nl_con1) U+17B6 U+17C6 + [K_A]                > index(nl_con2,1) U+1798 U+17C9 U+17B6 U+1782 U+17CB   c [n/l]ama
 any(nl_con1) U+17B6 U+17C6 + [K_Z]                > index(nl_con2,1) U+1798 U+17C9 U+1782 U+17CB          c [n/l]amz
 any(nl_con1) U+17B6 U+17C6 + [K_E]                > index(nl_con2,1) U+1798 U+17C9 U+17B9 dk(deadkey_e)   c [n/l]ame
-any(nl_con1) U+17B6 U+17C6 U+17B7 + [K_X]         > index(nl_con2,1) U+1798 U+17C2                        c [n/l]amxx 
+any(nl_con1) U+17B6 U+17C6 U+17B7 + [K_X]         > index(nl_con2,1) U+1798 U+17C2                        c [n/l]amxx
 
 any(nl_con1) U+17B6 U+17C6 + any(sin_vow2_key)    > index(nl_con2,1) U+1798 index(sin_vow2_out,4)         c [n/l]amV2
 any(nl_con1) U+17B6 U+17C6 + [K_V]                > index(nl_con2,1) U+1798 U+17B9 dk(deadkey_v)          c [n/l]amv
@@ -464,7 +464,7 @@ U+17B6 U+17C6 + any(sin_vow1_key)    > U+1798 U+17C9 index(sin_vow1_out,3)  c am
 U+17B6 U+17C6 + [K_A]                > U+1798 U+17C9 U+17B6 U+1782 U+17CB   c ama
 U+17B6 U+17C6 + [K_Z]                > U+1798 U+17C9 U+1782 U+17CB          c amz
 U+17B6 U+17C6 + [K_E]                > U+1798 U+17C9 U+17B9 dk(deadkey_e)   c ame
-U+17B6 U+17C6 U+17B7 + [K_X]         > U+1798 U+17C2                        c amxx 
+U+17B6 U+17C6 U+17B7 + [K_X]         > U+1798 U+17C2                        c amxx
 
 U+17B6 U+17C6 + any(sin_vow2_key)    > U+1798 index(sin_vow2_out,3)         c amV2
 U+17B6 U+17C6 + [K_V]                > U+1798 U+17B9 dk(deadkey_v)          c amv
@@ -502,7 +502,7 @@ any(nl_con1) U+17B6 U+179B U+17CB + [K_A]               > index(nl_con2,1) U+17A
 any(nl_con1) U+17B6 U+179B U+17CB + [K_Z]               > index(nl_con2,1) U+17A1 U+1782 U+17CB               c [n/l]alz
 any(nl_con1) U+17B6 U+179B U+17CB + [K_E]               > index(nl_con2,1) U+17A1 U+17B9 dk(deadkey_e)        c [n/l]ale
 any(nl_con1) U+17B6 U+179B U+17CB + [K_X]               > index(nl_con2,1) U+17A1 U+17B7                      c [n/l]alx
-any(nl_con1) U+17A1 U+17B7 + [K_X]                      > index(nl_con2,1) U+179B U+17C2                      c [n/l]alxx 
+any(nl_con1) U+17A1 U+17B7 + [K_X]                      > index(nl_con2,1) U+179B U+17C2                      c [n/l]alxx
 
 U+1794 U+17C9 U+17B6 U+179B U+17CB + any(sin_vow1_key)   > U+1796 U+17A1 index(sin_vow1_out,6)       c palV1
 U+1794 U+17C9 U+17B6 U+179B U+17CB + any(sin_vow2_key)   > U+1796 context(4) index(sin_vow2_out,6)   c palV2
@@ -511,7 +511,7 @@ U+1794 U+17C9 U+17B6 U+179B U+17CB + [K_A]               > U+1796 U+17A1 U+17B6 
 U+1794 U+17C9 U+17B6 U+179B U+17CB + [K_Z]               > U+1796 U+17A1 U+1782 U+17CB               c palz
 U+1794 U+17C9 U+17B6 U+179B U+17CB + [K_E]               > U+1796 U+17A1 U+17B9 dk(deadkey_e) c pale
 U+1794 U+17C9 U+17B6 U+179B U+17CB + [K_X]               > U+1796 U+17A1 U+17B7                      c palx
-U+1794 U+17C9 U+17A1 U+17B7 + [K_X]                      > U+1796 U+179B U+17C2                      c palxx 
+U+1794 U+17C9 U+17A1 U+17B7 + [K_X]                      > U+1796 U+179B U+17C2                      c palxx
 
 c presyllable with "-alV-"
 U+17B6 U+179B U+17CB + any(sin_vow1_key)   > U+17A1 index(sin_vow1_out,4)       c alV1
@@ -521,7 +521,7 @@ U+17B6 U+179B U+17CB + [K_A]               > U+17A1 U+17B6 U+1782 U+17CB        
 U+17B6 U+179B U+17CB + [K_Z]               > U+17A1 U+1782 U+17CB               c alz
 U+17B6 U+179B U+17CB + [K_E]               > U+17A1 U+17B9 dk(deadkey_e) c ale
 U+17B6 U+179B U+17CB + [K_X]               > U+17A1 U+17B7                      c alx
-U+17A1 U+17B7 + [K_X]                      > U+179B U+17C2                      c alxx 
+U+17A1 U+17B7 + [K_X]                      > U+179B U+17C2                      c alxx
 
 U+17C9 U+17B6 U+179B U+17CB + any(sin_vow1_key)   > U+17A1 index(sin_vow1_out,5)       c alV1
 U+17C9 U+17B6 U+179B U+17CB + any(sin_vow2_key)   > context(3) index(sin_vow2_out,5)   c alV2
@@ -530,7 +530,7 @@ U+17C9 U+17B6 U+179B U+17CB + [K_A]               > U+17A1 U+17B6 U+1782 U+17CB 
 U+17C9 U+17B6 U+179B U+17CB + [K_Z]               > U+17A1 U+1782 U+17CB               c alz
 U+17C9 U+17B6 U+179B U+17CB + [K_E]               > U+17A1 U+17B9 dk(deadkey_e) c ale
 U+17C9 U+17B6 U+179B U+17CB + [K_X]               > U+17A1 U+17B7                      c alx
-U+17C9 U+17A1 U+17B7 + [K_X]                      > U+179B U+17C2                      c alxx 
+U+17C9 U+17A1 U+17B7 + [K_X]                      > U+179B U+17C2                      c alxx
 
 
 c -[n/l/p]nV1-
@@ -570,7 +570,7 @@ U+17C9 U+17B6 U+1793 U+17CB + any(sin_vow2_key)    > context(3) index(sin_vow2_o
 U+17C9 U+17B6 U+1793 U+17CB + [K_V]                > context(3) U+17B9 dk(deadkey_v)
 
 
-c -[n/l/p]acV1- 
+c -[n/l/p]acV1-
 any(nl_con1) U+17B6 U+1785 U+17CB + any(sin_vow1_key)   > index(nl_con2,1) context(3) index(sin_vow1_out,5)
 any(nl_con1) U+17B6 U+1785 U+17CB + [K_A]               > index(nl_con2,1) context(3) U+17B6 U+1782 U+17CB
 any(nl_con1) U+17B6 U+1785 U+17CB + [K_Z]               > index(nl_con2,1) context(3) U+1782 U+17CB
@@ -581,7 +581,7 @@ U+1794 U+17C9 U+17B6 U+1785 U+17CB + [K_A]              > U+1796 context(4) U+17
 U+1794 U+17C9 U+17B6 U+1785 U+17CB + [K_Z]              > U+1796 context(4) U+1782 U+17CB
 U+1794 U+17C9 U+17B6 U+1785 U+17CB + [K_E]              > U+1796 context(4) U+17B9 dk(deadkey_e)
 
-c -acV1- 
+c -acV1-
 U+17B6 U+1785 U+17CB + any(sin_vow1_key)           > context(2) index(sin_vow1_out,4)
 U+17B6 U+1785 U+17CB + [K_A]                       > context(2) U+17B6 U+1782 U+17CB
 U+17B6 U+1785 U+17CB + [K_Z]                       > context(2) U+1782 U+17CB
@@ -607,7 +607,7 @@ U+17C9 U+17B6 U+1785 U+17CB + any(sin_vow2_key)    > U+1787 index(sin_vow2_out,5
 U+17C9 U+17B6 U+1785 U+17CB + [K_V]                > U+1787 U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]adV1- 
+c [n/l/p]adV1-
 any(nl_con1) U+17B6 U+178A U+17CB + any(sin_vow1_key)   > index(nl_con2,1) context(3) index(sin_vow1_out,5)
 any(nl_con1) U+17B6 U+178A U+17CB + [K_A]               > index(nl_con2,1) context(3) U+17B6 U+1782 U+17CB
 any(nl_con1) U+17B6 U+178A U+17CB + [K_Z]               > index(nl_con2,1) context(3) U+1782 U+17CB
@@ -618,7 +618,7 @@ U+1794 U+17C9 U+17B6 U+178A U+17CB + [K_A]                > U+1796 context(4) U+
 U+1794 U+17C9 U+17B6 U+178A U+17CB + [K_Z]                > U+1796 context(4) U+1782 U+17CB
 U+1794 U+17C9 U+17B6 U+178A U+17CB + [K_E]                > U+1796 context(4) U+17B9 dk(deadkey_e)
 
-c -adV1- 
+c -adV1-
 U+17B6 U+178A U+17CB + any(sin_vow1_key)           > context(2) index(sin_vow1_out,4)
 U+17B6 U+178A U+17CB + [K_A]                       > context(2) U+17B6 U+1782 U+17CB
 U+17B6 U+178A U+17CB + [K_Z]                       > context(2) U+1782 U+17CB
@@ -644,7 +644,7 @@ U+17C9 U+17B6 U+178A U+17CB + any(sin_vow2_key)    > U+178C index(sin_vow2_out,5
 U+17C9 U+17B6 U+178A U+17CB + [K_V]                > U+178C U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]ajV1-  
+c [n/l/p]ajV1-
 any(nl_con1) U+17B6 U+1786 U+17CB + any(sin_vow1_key)   > index(nl_con2,1) context(3) index(sin_vow1_out,5)
 any(nl_con1) U+17B6 U+1786 U+17CB + [K_A]               > index(nl_con2,1) context(3) U+17B6 U+1782 U+17CB
 any(nl_con1) U+17B6 U+1786 U+17CB + [K_Z]               > index(nl_con2,1) context(3) U+1782 U+17CB
@@ -655,7 +655,7 @@ U+1794 U+17C9 U+17B6 U+1786 U+17CB + [K_A]                > U+1796 context(4) U+
 U+1794 U+17C9 U+17B6 U+1786 U+17CB + [K_Z]                > U+1796 context(4) U+1782 U+17CB
 U+1794 U+17C9 U+17B6 U+1786 U+17CB + [K_E]                > U+1796 context(4) U+17B9 dk(deadkey_e)
 
-c -ajV1-  
+c -ajV1-
 U+17B6 U+1786 U+17CB + any(sin_vow1_key)            > context(2) index(sin_vow1_out,4)
 U+17B6 U+1786 U+17CB + [K_A]                        > context(2) U+17B6 U+1782 U+17CB
 U+17B6 U+1786 U+17CB + [K_Z]                        > context(2) U+1782 U+17CB
@@ -681,7 +681,7 @@ U+17C9 U+17B6 U+1786 U+17CB + any(sin_vow2_key)    > U+1788 index(sin_vow2_out,5
 U+17C9 U+17B6 U+1786 U+17CB + [K_V]                > U+1788 U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]akV1-   
+c [n/l/p]akV1-
 any(nl_con1) U+17B6 U+1780 U+17CB + any(sin_vow1_key)   > index(nl_con2,1) context(3) index(sin_vow1_out,5)
 any(nl_con1) U+17B6 U+1780 U+17CB + [K_A]               > index(nl_con2,1) context(3) U+17B6 U+1782 U+17CB
 any(nl_con1) U+17B6 U+1780 U+17CB + [K_Z]               > index(nl_con2,1) context(3) U+1782 U+17CB
@@ -692,7 +692,7 @@ U+1794 U+17C9 U+17B6 U+1780 U+17CB + [K_A]              > U+1796 context(4) U+17
 U+1794 U+17C9 U+17B6 U+1780 U+17CB + [K_Z]              > U+1796 context(4) U+1782 U+17CB
 U+1794 U+17C9 U+17B6 U+1780 U+17CB + [K_E]              > U+1796 context(4) U+17B9 dk(deadkey_e)
 
-c -akV1-   
+c -akV1-
 U+17B6 U+1780 U+17CB + any(sin_vow1_key)           > context(2) index(sin_vow1_out,4)
 U+17B6 U+1780 U+17CB + [K_A]                       > context(2) U+17B6 U+1782 U+17CB
 U+17B6 U+1780 U+17CB + [K_Z]                       > context(2) U+1782 U+17CB
@@ -718,7 +718,7 @@ U+17C9 U+17B6 U+1780 U+17CB + any(sin_vow2_key)    > U+1782 index(sin_vow2_out,5
 U+17C9 U+17B6 U+1780 U+17CB + [K_V]                > U+1782 U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]atV1-  
+c [n/l/p]atV1-
 any(nl_con1) U+17B6 U+178F U+17CB + any(sin_vow1_key)   > index(nl_con2,1) context(3) index(sin_vow1_out,5)
 any(nl_con1) U+17B6 U+178F U+17CB + [K_A]               > index(nl_con2,1) context(3) U+17B6 U+1782 U+17CB
 any(nl_con1) U+17B6 U+178F U+17CB + [K_Z]               > index(nl_con2,1) context(3) U+1782 U+17CB
@@ -729,7 +729,7 @@ U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_A]                > U+1796 context(4) U+
 U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_Z]                > U+1796 context(4) U+1782 U+17CB
 U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_E]                > U+1796 context(4) U+17B9 dk(deadkey_e)
 
-c -atV1-  
+c -atV1-
 U+17B6 U+178F U+17CB + any(sin_vow1_key)           > context(2) index(sin_vow1_out,4)
 U+17B6 U+178F U+17CB + [K_A]                       > context(2) U+17B6 U+1782 U+17CB
 U+17B6 U+178F U+17CB + [K_Z]                       > context(2) U+1782 U+17CB
@@ -757,12 +757,12 @@ U+17C9 U+17B6 U+178F U+17CB + [K_V]                > U+1791 U+17B9 dk(deadkey_v)
 c [n/l/p]atrV-
 c any(nl_con1) U+17B6 U+178F U+17CB + [K_R]   > index(nl_con2,1) context(3) U+17D2 U+179A
 
-c U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_R]  > U+1796 context(4) U+17D2 U+179A 
+c U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_R]  > U+1796 context(4) U+17D2 U+179A
 
 c -atrV-
 c U+17B6 U+178F U+17CB + [K_R]            > context(2) U+17D2 U+179A  c katra
 
-c U+17C9 U+17B6 U+178F U+17CB + [K_R]     > context(3) U+17D2 U+179A  c gatra 
+c U+17C9 U+17B6 U+178F U+17CB + [K_R]     > context(3) U+17D2 U+179A  c gatra
 
 
 c [p/n/l]asV1
@@ -789,24 +789,24 @@ U+17C9 U+17B6 U+179F U+17CB + [K_E]                > context(3) U+17B9 dk(deadke
 
 c [p/n/l]asV2
 U+1794 U+17C9 U+17B6 U+179F U+17CB + any(sin_vow2_key)    > U+1796 context(4) U+17CA index(sin_vow2_out,6)  c pasum > ពស៊ុំ, not បស៊ុំ
-U+1794 U+17C9 U+17B6 U+179F U+17CB + [K_V]                > U+1796 context(4) U+17CA U+17B9 dk(deadkey_v)   
+U+1794 U+17C9 U+17B6 U+179F U+17CB + [K_V]                > U+1796 context(4) U+17CA U+17B9 dk(deadkey_v)
 
-any(nl_con1) U+17B6 U+179F U+17CB + any(sin_vow2_key)    > index(nl_con2,1) context(3) U+17CA index(sin_vow2_out,5)  
-any(nl_con1) U+17B6 U+179F U+17CB + [K_V]                > index(nl_con2,1) context(3) U+17CA U+17B9 dk(deadkey_v)   
+any(nl_con1) U+17B6 U+179F U+17CB + any(sin_vow2_key)    > index(nl_con2,1) context(3) U+17CA index(sin_vow2_out,5)
+any(nl_con1) U+17B6 U+179F U+17CB + [K_V]                > index(nl_con2,1) context(3) U+17CA U+17B9 dk(deadkey_v)
 
 c -asV2-
 U+17B6 U+179F U+17CB + any(sin_vow2_key)           > context(2) U+17CA index(sin_vow2_out,4)
 U+17B6 U+179F U+17CB + [K_V]                       > context(2) U+17CA U+17B9 dk(deadkey_v)
 
 U+17C9 U+17B6 U+179F U+17CB + any(sin_vow2_key)    > context(3) U+17CA index(sin_vow2_out,5)
-U+17C9 U+17B6 U+179F U+17CB + [K_V]                > context(3) U+17CA U+17B9 dk(deadkey_v)  
+U+17C9 U+17B6 U+179F U+17CB + [K_V]                > context(3) U+17CA U+17B9 dk(deadkey_v)
 
 
-c [n/l/p]aqdV- 
+c [n/l/p]aqdV-
 any(nl_con1) U+17B6 U+1782 U+17CB dk(middle_q) + [K_D]  > index(nl_con2,1) U+178B
 U+1794 U+17C9 U+17B6 U+1782 U+17CB dk(middle_q) + [K_D] > U+1796 U+178B
 
-c -aqdV- 
+c -aqdV-
 U+17B6 U+1782 U+17CB dk(middle_q) + [K_D]           > U+178B
 U+17C9 U+17B6 U+1782 U+17CB dk(middle_q) + [K_D]    > U+178B
 
@@ -820,29 +820,29 @@ U+17B6 U+1782 U+17CB dk(middle_q) + [K_B]           > U+179E
 U+17C9 U+17B6 U+1782 U+17CB dk(middle_q) + [K_B]    > U+179E
 
 
-c [n/l/p]akhV- 
+c [n/l/p]akhV-
 any(nl_con1) U+17B6 U+1780 U+17CB + [K_H]   > index(nl_con2,1) U+1781
 U+1794 U+17C9 U+17B6 U+1780 U+17CB + [K_H]  > U+1796 U+1781
 
-c -akhV- 
+c -akhV-
 U+17B6 U+1780 U+17CB + [K_H]           > U+1781
 U+17C9 U+17B6 U+1780 U+17CB + [K_H]    > U+1781
 
 
-c [n/l/p]aphV- 
+c [n/l/p]aphV-
 any(nl_con1) U+17B6 U+1794 U+17CB dk(middle_p) + [K_H]  > index(nl_con2,1) U+1795
 U+1794 U+17C9 U+17B6 U+1794 U+17CB dk(middle_p) + [K_H] > U+1796 U+1795
 
-c -aphV- 
+c -aphV-
 U+17B6 U+1794 U+17CB dk(middle_p) + [K_H]           > U+1795
 U+17C9 U+17B6 U+1794 U+17CB dk(middle_p) + [K_H]    > U+1795
 
 
-c [n/l/p]athV- 
+c [n/l/p]athV-
 any(nl_con1) U+17B6 U+178F U+17CB + [K_H]   > index(nl_con2,1) U+1790
 U+1794 U+17C9 U+17B6 U+178F U+17CB + [K_H]  > U+1796 U+1790
 
-c -athV- 
+c -athV-
 U+17B6 U+178F U+17CB + [K_H]           > U+1790
 U+17C9 U+17B6 U+178F U+17CB + [K_H]    > U+1790
 
@@ -999,9 +999,9 @@ U+17B7 + [K_E]                      > U+17C0                        c ie > ៀ
 U+17C0 + [K_H]                      > context(1) U+17C7             c ieh> ៀះ
 U+17B9 + [K_E]                      > U+17BE                        c ee > ើ
 U+17A2 U+17B6 U+1782 U+17CB + [K_Y] > context(1) U+17C3             c ay > អៃ
-U+17B6 U+1782 U+17CB + [K_Y]        > U+17C3                        c ay > ៃ 
+U+17B6 U+1782 U+17CB + [K_Y]        > U+17C3                        c ay > ៃ
 U+17CA U+17B9 dk(deadkey_v) + [K_Y] > U+17B8                        c vy > ី -- v, series 2, vy series 1
-U+17B9 dk(deadkey_v) + [K_Y]        > U+17B8                        c vy > ី 
+U+17B9 dk(deadkey_v) + [K_Y]        > U+17B8                        c vy > ី
 U+17A2 U+1782 U+17CB + [K_Q]        > U+17A2 U+1782 U+17CB          c zq > អគ់់
 U+17A2 U+17B6 U+1782 U+17CB + [K_Q] > U+17A2 U+17B6 U+1782 U+17CB dk(middle_q)  c aq > អាគ់
 U+17B6 U+1782 U+17CB + [K_Q]        > U+17B6 U+1782 U+17CB dk(middle_q)         c Caq > ាគ់
@@ -1010,7 +1010,7 @@ U+17B7 + [K_H]                      > U+17B7 U+17C7                 c xh > ិ�
 U+17B9 dk(deadkey_e) + [K_H]        > U+17B9 U+17C7                 c eh > ឹះ
 U+17B7 + [K_Q]                      > U+17B7                        c xq > ិ
 U+17B9 dk(deadkey_e) + [K_Q]        > U+17B9                        c eq > ឹ
-U+17BB + [K_O]                      > U+17BC                        c oo > ូ 
+U+17BB + [K_O]                      > U+17BC                        c oo > ូ
 
 any(con_triisap) U+17B7 + [K_X]     > context(1) U+17CA U+17C2
 any(con_bo) U+17B7 + [K_X]          > context(1) U+17CA U+17C2      c bx > ប៊ិ
@@ -1037,13 +1037,13 @@ U+17BB + [K_E]                  > U+17BD            c ue > ួ
 U+17BB + [K_U]                  > U+17BC            c uu > ូ
 
 
-any(sin_con1_out) U+17CA U+17BB + [K_E]     > context(1) U+17BD     c buer > បួរ not ប៊ួរ 
+any(sin_con1_out) U+17CA U+17BB + [K_E]     > context(1) U+17BD     c buer > បួរ not ប៊ួរ
 any(con_muusikatoan) U+17C9 U+17B7 + [K_X]  > context(1) U+17C2
 any(con_bo) U+17C9 U+17B7 + [K_X]           > U+1796 U+17C2         c pxx > ពែ
 
 
 c any vowel
-store(any_vowel)    outs(sin_vow1_out) outs(sin_vow2_out) U+17C0 U+17BE U+17C3 U+17BC U+17C2 U+17B8 U+17BA U+17BD U+17BC U+17B6 
+store(any_vowel)    outs(sin_vow1_out) outs(sin_vow2_out) U+17C0 U+17BE U+17C3 U+17BC U+17C2 U+17B8 U+17BA U+17BD U+17BC U+17B6
 
 
 c change series of single consonants in harmony with the series of the vowel
@@ -1053,7 +1053,7 @@ U+1794 U+17B7 + [K_X]       > U+1796 U+17C2             c pxx > ពែ
 any(nl_con1) U+17B7 + [K_X] > index(nl_con2,1) U+17C2   c lxx > លែ, nxx > នែ
 
 c C1 > C2 after xx as in cxx > ជែ, dxx > ឌែ, jxx > ឈែ, kxx > គែ, txx > ទែ, qdxx > ឍែ, khxx > ឃែ, phxx > ភែ, thxx > ធែ
-any(counterpart_con1) U+17B7 + [K_X]    > index(counterpart_con2,1) U+17C2     
+any(counterpart_con1) U+17B7 + [K_X]    > index(counterpart_con2,1) U+17C2
 
 c VV combo series 2 with final q
 U+17C2 + [K_Q]          > context U+1782    c xxq > ែគ
@@ -1065,20 +1065,20 @@ U+17BC + [K_Q]          > context U+1782    c uuq > ូគ
 
 c second-series consonant + first-series vowel "ue" and "ie" > first-series consonant + the first-series vowel
 c as in cue > ចួ, due > ដួ, jue > ឆួ, kue > កួ, tue > តួ, qdue > ឋួ, khue > ខួ, phue > ផួ, thue > ថួ
-any(counterpart_con2) U+17BB + [K_E]    > index(counterpart_con1,1) U+17BD    
+any(counterpart_con2) U+17BB + [K_E]    > index(counterpart_con1,1) U+17BD
 
 c as in cie > ចៀ, die > ដៀ, jie > ឆៀ, kie > កៀ, tie > តៀ, qdie > ឋៀ, khie > ខៀ, phie > ផៀ, thie > ថៀ
-any(counterpart_con2) U+17B7 + [K_E]    > index(counterpart_con1,1) U+17C0          
+any(counterpart_con2) U+17B7 + [K_E]    > index(counterpart_con1,1) U+17C0
 
 c second-series consonant + first-series vowel "vy" > first-series consonant + the first-series vowel
 c as in cvy > ចី, dvy > ដី, jvy > ឆី, kvy > កី, tvy > តី, qdvy > ឋី, khvy > ខី, phvy > ផី, thvy > ថី
-any(counterpart_con2) U+17B9 dk(deadkey_v) + [K_Y]  > index(counterpart_con1,1) U+17B8            
+any(counterpart_con2) U+17B9 dk(deadkey_v) + [K_Y]  > index(counterpart_con1,1) U+17B8
 
 
 c +++++++++++++++++++++++++++++++++++Other CC CLUSTER CHANGES SERIES IN HARMONY WITH THE SERIES OF THE VOWEL+++++++++++++++++++++++++++++++++++
 
 
-any(all_sin_con1) U+17D2 U+179A + [K_Z]                 > context(1) context(2) context(3) U+1782 U+17CB 
+any(all_sin_con1) U+17D2 U+179A + [K_Z]                 > context(1) context(2) context(3) U+1782 U+17CB
 any(all_sin_con1) U+17D2 U+179A U+1782 U+17CB + [K_Z]   > context(1) context(2) context(3)  dk(deadkey_z)
 
 
@@ -1087,8 +1087,8 @@ U+17A2 U+17D2 U+1799 U+17D2 U+179A + any(sin_vow1_key)    > context(1) context(2
 U+17A2 U+17D2 U+1799 U+17D2 U+179A + [K_E]                > context(1) context(2) context(3) context(4) context(5) U+17B9 dk(deadkey_e)
 U+17A2 U+17D2 U+1799 U+17D2 U+179A + [K_Z]                > context(1) context(2) context(3) context(4) context(5) U+1782 U+17CB   c qyrz
 
-U+17A2 U+17D2 U+1799 U+17D2 U+179A + any(sin_vow2_key)    > context(1) context(2) context(3) context(4) context(5) U+17CA index(sin_vow2_out,6) 
-U+17A2 U+17D2 U+1799 U+17D2 U+179A + [K_V]                > context(1) context(2) context(3) context(4) context(5) U+17CA U+17B9 dk(deadkey_v) 
+U+17A2 U+17D2 U+1799 U+17D2 U+179A + any(sin_vow2_key)    > context(1) context(2) context(3) context(4) context(5) U+17CA index(sin_vow2_out,6)
+U+17A2 U+17D2 U+1799 U+17D2 U+179A + [K_V]                > context(1) context(2) context(3) context(4) context(5) U+17CA U+17B9 dk(deadkey_v)
 
 U+17A2 U+17D2 U+1799 U+17D2 U+179A U+17B7 + [K_X]         > context(1) context(2) context(3) context(4) context(5) U+17CA U+17C2   c qyrxx
 U+17A2 U+17D2 U+1799 U+17D2 U+179A U+1782 U+17CB + [K_Z]  > context(1) context(2) context(3) context(4) context(5) dk(deadkey_z)  c qyrzz
@@ -1096,9 +1096,9 @@ U+17A2 U+17D2 U+1799 U+17D2 U+179A U+1782 U+17CB + [K_Z]  > context(1) context(2
 
 c qy
 U+17A2 U+17D2 U+1799 + any(sin_vow1_key)    > context(1) context(2) context(3) index(sin_vow1_out,4)
-U+17A2 U+17D2 U+1799 + any(sin_vow2_key)    > context(1) context(2) context(3) U+17CA index(sin_vow2_out,4) 
+U+17A2 U+17D2 U+1799 + any(sin_vow2_key)    > context(1) context(2) context(3) U+17CA index(sin_vow2_out,4)
 U+17A2 U+17D2 U+1799 + [K_E]                > context(1) context(2) context(3) U+17B9 dk(deadkey_e)
-U+17A2 U+17D2 U+1799 + [K_V]                > context(1) context(2) context(3) U+17CA U+17B9 dk(deadkey_v) 
+U+17A2 U+17D2 U+1799 + [K_V]                > context(1) context(2) context(3) U+17CA U+17B9 dk(deadkey_v)
 U+17A2 U+17D2 U+1799 U+17B7 + [K_X]         > context(1) context(2) context(3) U+17CA U+17C2   c qyxx
 U+17A2 U+17D2 U+1799 + [K_Z]                > context(1) context(2) context(3) U+1782 U+17CB   c qyz
 U+17A2 U+17D2 U+1799 U+1782 U+17CB + [K_Z]  > context(1) context(2) context(3) dk(deadkey_z)  c qyzz
@@ -1125,7 +1125,7 @@ dk(deadkey_e) + [K_P]                   > U+1794
 c ហ after គ in the final position
 any(any_con) + [K_H]            > context U+17A0
 U+17B6 U+1782 U+17CB + [K_H]    > U+17C7                        c ាហ់ > ះ in the final position
-U+1782 U+17CB + [K_H]           > U+17C4 U+17C7                 c fix ហ់ 
+U+1782 U+17CB + [K_H]           > U+17C4 U+17C7                 c fix ហ់
 U+1793 U+17CB + [K_H]           > U+1789 context(2)             c nh > ញ
 U+17B6 U+1793 U+17CB + [K_H]    > context(1) U+1789 context(3)  c anh > ាញ់
 
@@ -1135,7 +1135,7 @@ U+17B6 U+1793 U+17CB + [K_G]    > U+17B6 U+17C6 U+1784  c ang
 U+1793 U+17CB + [K_G]           > U+1784 context(2)     c zng
 
 c ន replaced គ in the final position after Bantoc
-U+17B6 U+1782 U+17CB + [K_N]    > context(1) U+1793 context(3)  
+U+17B6 U+1782 U+17CB + [K_N]    > context(1) U+1793 context(3)
 
 
 c អ in the final position becomes គ
@@ -1145,7 +1145,7 @@ U+17CA + [K_Q]                  > context U+1782
 U+17C9 + [K_Q]                  > context U+1782
 U+17CA dk(deadkey_z) + [K_Q]    > context(1) U+1782
 U+17C9 dk(deadkey_z) + [K_Q]    > context(1) U+1782
-dk(deadkey_v) + [K_Q]           > nul 
+dk(deadkey_v) + [K_Q]           > nul
 
 c wq > វ្គ
 U+179C + [K_Q]                  > context U+17D2 U+1782
@@ -1187,8 +1187,8 @@ any(any_vowel) + [K_H]                      > context U+17C7
 
 
 c inherent vowel and ា treatments (2) with consonant key fired.
-U+17B6 U+1782 U+17CB + any(sin_con1_key)    > context(1) index(sin_con1_out,4) context(3) 
-U+17B6 U+1782 U+17CB + any(sin_con2_key)    > context(1) index(sin_con2_out,4) context(3) 
+U+17B6 U+1782 U+17CB + any(sin_con1_key)    > context(1) index(sin_con1_out,4) context(3)
+U+17B6 U+1782 U+17CB + any(sin_con2_key)    > context(1) index(sin_con2_out,4) context(3)
 
 U+1782 U+17CB + [K_P]                       > U+1794 context(2)
 U+1782 U+17CB + any(sin_con1_key)           > index(sin_con1_out,3) context(2)
@@ -1243,7 +1243,7 @@ U+17A2 U+17D2 U+1799 U+17D2 U+179A  > context
 
 
 c presyllable boundary
-any(any_con) U+17D2 any(any_con) U+17D2 any(any_con)    > context(1) context(2) context(3) context(5)   c prevent brn from outputting ប្ន្រ 
+any(any_con) U+17D2 any(any_con) U+17D2 any(any_con)    > context(1) context(2) context(3) context(5)   c prevent brn from outputting ប្ន្រ
 
 
 c remove the ៝ on ក before ឡ

--- a/release/k/krung/source/krung.kvks
+++ b/release/k/krung/source/krung.kvks
@@ -9,8 +9,7 @@
   </header>
   <encoding name="unicode" fontname="Arial" fontsize="12">
     <layer shift="">
-      <key vkey="K_COMMA"></key>
-      <key vkey="K_PERIOD">។</key>
+      <key vkey="K_BKQUOTE">`</key>
       <key vkey="K_0">០</key>
       <key vkey="K_1">១</key>
       <key vkey="K_2">២</key>
@@ -21,6 +20,8 @@
       <key vkey="K_7">៧</key>
       <key vkey="K_8">៨</key>
       <key vkey="K_9">៩</key>
+      <key vkey="K_HYPHEN">-</key>
+      <key vkey="K_EQUAL">=</key>
       <key vkey="K_A">អាគ់</key>
       <key vkey="K_B">ប</key>
       <key vkey="K_C">ច</key>
@@ -46,11 +47,41 @@
       <key vkey="K_X">អិ</key>
       <key vkey="K_Y">យ</key>
       <key vkey="K_Z">អគ់</key>
+      <key vkey="K_LBRKT">[</key>
+      <key vkey="K_RBRKT">]</key>
+      <key vkey="K_BKSLASH">\</key>
+      <key vkey="K_COLON">;</key>
+      <key vkey="K_QUOTE">'</key>
+      <key vkey="K_oE2">\</key>
+      <key vkey="K_COMMA"> </key>
+      <key vkey="K_PERIOD">។</key>
+      <key vkey="K_SLASH">/</key>
+      <key vkey="K_SPACE"> </key>
     </layer>
     <layer shift="S">
+      <key vkey="K_BKQUOTE">~</key>
+      <key vkey="K_1">!</key>
+      <key vkey="K_2">@</key>
+      <key vkey="K_3">#</key>
+      <key vkey="K_4">$</key>
+      <key vkey="K_5">%</key>
+      <key vkey="K_6">^</key>
+      <key vkey="K_7">&amp;</key>
+      <key vkey="K_8">*</key>
+      <key vkey="K_9">(</key>
+      <key vkey="K_0">)</key>
+      <key vkey="K_HYPHEN">_</key>
+      <key vkey="K_EQUAL">+</key>
+      <key vkey="K_LBRKT">{</key>
+      <key vkey="K_RBRKT">}</key>
+      <key vkey="K_BKSLASH">|</key>
       <key vkey="K_COLON">៖</key>
+      <key vkey="K_QUOTE">"</key>
+      <key vkey="K_oE2">|</key>
       <key vkey="K_COMMA">&lt;</key>
       <key vkey="K_PERIOD">&gt;</key>
+      <key vkey="K_SLASH">?</key>
+      <key vkey="K_SPACE"> </key>
     </layer>
   </encoding>
 </visualkeyboard>


### PR DESCRIPTION
This addresses issues in on screen keyboards arising from keymanapp/keyman#1460. The good news is that only Krung was impacted negatively. The only other keyboard in the **release/** folder listed in that issue is **sil_cameroon_qwerty**, but it turns out the OSK is correct as in the source. The remaining keyboards from the issue are all in the **legacy/** folder, which means they are not rebuilt so the compiler update will not impact them.