### PR TITLE
[inscript-farsi] Deprecate Farsi KAB Inscript keyboard

### DIFF
--- a/legacy/f/farsi_kab/DEPRECATED.md
+++ b/legacy/f/farsi_kab/DEPRECATED.md
@@ -1,0 +1,2 @@
+This keyboard has been deprecated and replaced by release/basic/basic_kbdfa
+

--- a/release/basic/basic_kbdfa/basic_kbdfa.keyboard_info
+++ b/release/basic/basic_kbdfa/basic_kbdfa.keyboard_info
@@ -3,8 +3,11 @@
     "languages": [
         "fa"
     ],
-	  "description": "Persian Basic generated from template",
+	  "description": "Persian Basic generated from template. This keyboard follows the Inscript Farsi layout.",
   "related": {
+    "farsi_kab": {
+      "deprecates": true
+    },
     "farsi": {
       "deprecates": true
     },


### PR DESCRIPTION
Deprecate one keyboard. No version bump needed.

Relates to Issue #337