### PR TITLE
fix(ci): dependencies for release packages

### DIFF
--- a/release/packages/galaxie_greek_hebrew_mnemonic/galaxie_greek_hebrew_mnemonic.kpj
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/galaxie_greek_hebrew_mnemonic.kpj
@@ -4,6 +4,8 @@
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -13,8 +15,31 @@
       <FileVersion>3.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
-        <Name>Galaxie Greek/Hebrew (Mnemonic) Keyboard Package</Name>
+        <Name>Galaxie Hebrew (Mnemonic)</Name>
         <Copyright>© 2004-2018 Galaxie Software and SIL International</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>id_7fcd95f99aecd00e09bc154eab7d9b62</ID>
+      <Filename>galaxie_greek_mnemonic.kmn</Filename>
+      <Filepath>..\..\g\galaxie_greek_mnemonic\source\galaxie_greek_mnemonic.kmn</Filepath>
+      <FileVersion>3.2.1</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Galaxie Greek (Mnemonic)</Name>
+        <Copyright>© 2004-2018 Galaxie Software and SIL International</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>id_d35d8529aead72a58fbeb371a5a6a059</ID>
+      <Filename>galaxie_greek_hebrew_mnemonic.kps</Filename>
+      <Filepath>source\galaxie_greek_hebrew_mnemonic.kps</Filepath>
+      <FileVersion>3.2.1</FileVersion>
+      <FileType>.kps</FileType>
+      <Details>
+        <Name>Galaxie Greek/Hebrew (Mnemonic) Keyboard Package</Name>
+        <Copyright>2004-2019 Galaxie Software and SIL International</Copyright>
+        <Version>3.2.1</Version>
       </Details>
     </File>
     <File>
@@ -26,35 +51,12 @@
       <ParentFileID>id_24d45c74b8f91ec6adcabf9c32d150b0</ParentFileID>
     </File>
     <File>
-      <ID>id_7fcd95f99aecd00e09bc154eab7d9b62</ID>
-      <Filename>galaxie_greek_mnemonic.kmn</Filename>
-      <Filepath>..\..\g\galaxie_greek_mnemonic\source\galaxie_greek_mnemonic.kmn</Filepath>
-      <FileVersion>3.2</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Galaxie Greek (Mnemonic)</Name>
-        <Copyright>© 2004-2018 Galaxie Software and SIL International</Copyright>
-      </Details>
-    </File>
-    <File>
       <ID>id_85d7d8c61f019415edaa1c4cb5e1435d</ID>
       <Filename>galaxie_greek_mnemonic.ico</Filename>
       <Filepath>..\..\g\galaxie_greek_mnemonic\source\galaxie_greek_mnemonic.ico</Filepath>
       <FileVersion></FileVersion>
       <FileType>.ico</FileType>
       <ParentFileID>id_7fcd95f99aecd00e09bc154eab7d9b62</ParentFileID>
-    </File>
-    <File>
-      <ID>id_d35d8529aead72a58fbeb371a5a6a059</ID>
-      <Filename>galaxie_greek_hebrew_mnemonic.kps</Filename>
-      <Filepath>source\galaxie_greek_hebrew_mnemonic.kps</Filepath>
-      <FileVersion>3.2</FileVersion>
-      <FileType>.kps</FileType>
-      <Details>
-        <Name>Galaxie Greek/Hebrew (Mnemonic)</Name>
-        <Copyright>2004-2018 Galaxie Software and SIL International</Copyright>
-        <Version>3.2</Version>
-      </Details>
     </File>
     <File>
       <ID>id_2953db7f04181940605d4ff324e7423f</ID>
@@ -97,49 +99,49 @@
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_db7a6eba5ccb9966c07b35b84efea8cc</ID>
+      <ID>id_fb10783ec9b926b190110d6cc016458b</ID>
       <Filename>galaxie_hebrew_mnemonic.js</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.js</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_mnemonic.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_7dbeb97419c218cb46c390fff9baeb69</ID>
+      <ID>id_0c7d43e7a191ca369b21623397eff1a7</ID>
       <Filename>galaxie_hebrew_mnemonic.kvk</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.kvk</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_mnemonic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_4f6f85387ffa142b21a485ff65e2a325</ID>
+      <ID>id_1e2bcf0151500370cdb4f2a3f74c2cde</ID>
       <Filename>galaxie_hebrew_mnemonic.kmx</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.kmx</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_mnemonic.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_b36334c81889c439fe2867bf8a3de70a</ID>
+      <ID>id_53e4f7538ec1144bcf225ba2cb281a3c</ID>
       <Filename>galaxie_greek_mnemonic.js</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.js</Filepath>
+      <Filepath>source\..\build\galaxie_greek_mnemonic.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_08f3461fad275352f18eb15ad5251364</ID>
+      <ID>id_eeae5ca3c04aceedc08921ac701845d9</ID>
       <Filename>galaxie_greek_mnemonic.kvk</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.kvk</Filepath>
+      <Filepath>source\..\build\galaxie_greek_mnemonic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
     <File>
-      <ID>id_715385986e6fd33f7e802147eadbc5a3</ID>
+      <ID>id_a302a003ba2d87a70ca4d1f9a3afc399</ID>
       <Filename>galaxie_greek_mnemonic.kmx</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.kmx</Filepath>
+      <Filepath>source\..\build\galaxie_greek_mnemonic.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>

--- a/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1356.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.52.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -51,37 +51,37 @@
       <FileType>.htm</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.js</Name>
+      <Name>..\build\galaxie_hebrew_mnemonic.js</Name>
       <Description>File galaxie_hebrew_mnemonic.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.kvk</Name>
+      <Name>..\build\galaxie_hebrew_mnemonic.kvk</Name>
       <Description>File galaxie_hebrew_mnemonic.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_mnemonic\build\galaxie_hebrew_mnemonic.kmx</Name>
+      <Name>..\build\galaxie_hebrew_mnemonic.kmx</Name>
       <Description>Keyboard Galaxie Hebrew (Mnemonic)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.js</Name>
+      <Name>..\build\galaxie_greek_mnemonic.js</Name>
       <Description>File galaxie_greek_mnemonic.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.kvk</Name>
+      <Name>..\build\galaxie_greek_mnemonic.kvk</Name>
       <Description>File galaxie_greek_mnemonic.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_mnemonic\build\galaxie_greek_mnemonic.kmx</Name>
+      <Name>..\build\galaxie_greek_mnemonic.kmx</Name>
       <Description>Keyboard Galaxie Greek (Mnemonic)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
@@ -92,6 +92,7 @@
       <Name>Galaxie Hebrew (Mnemonic)</Name>
       <ID>galaxie_hebrew_mnemonic</ID>
       <Version>3.2</Version>
+      <RTL>True</RTL>
       <Languages>
         <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
         <Language ID="he">Hebrew (Hebrew)</Language>
@@ -100,7 +101,7 @@
     <Keyboard>
       <Name>Galaxie Greek (Mnemonic)</Name>
       <ID>galaxie_greek_mnemonic</ID>
-      <Version>3.2</Version>
+      <Version>3.2.1</Version>
       <Languages>
         <Language ID="grc-Grek">Ancient Greek (to 1453) (Greek)</Language>
         <Language ID="el">Modern Greek (1453-) (Greek)</Language>

--- a/release/packages/galaxie_greek_hebrew_positional/galaxie_greek_hebrew_positional.kpj
+++ b/release/packages/galaxie_greek_hebrew_positional/galaxie_greek_hebrew_positional.kpj
@@ -4,6 +4,8 @@
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -17,6 +19,45 @@
         <Copyright>2004-2019 Galaxie Software and SIL International</Copyright>
         <Version>2.2.1</Version>
       </Details>
+    </File>
+    <File>
+      <ID>id_d3cc7ea9cf1c488b0662f2c5765fdfab</ID>
+      <Filename>galaxie_hebrew_positional.kmn</Filename>
+      <Filepath>..\..\g\galaxie_hebrew_positional\source\galaxie_hebrew_positional.kmn</Filepath>
+      <FileVersion>2.2</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Galaxie Hebrew (Positional)</Name>
+        <Copyright>2004-2018 Galaxie Software and SIL International</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>id_5e19948b19e2d5b4ca6993f1a97f7872</ID>
+      <Filename>galaxie_greek_positional.kmn</Filename>
+      <Filepath>..\..\g\galaxie_greek_positional\source\galaxie_greek_positional.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Galaxie Greek (Phonetic)</Name>
+        <Copyright>Copyright 2004-2018 Galaxie Software and SIL International</Copyright>
+        <Message>http://www.galaxie.com</Message>
+      </Details>
+    </File>
+    <File>
+      <ID>id_c61a5242d4510646e82a6759ca7015d8</ID>
+      <Filename>galaxie_hebrew_positional.bmp</Filename>
+      <Filepath>..\..\g\galaxie_hebrew_positional\source\galaxie_hebrew_positional.bmp</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.bmp</FileType>
+      <ParentFileID>id_d3cc7ea9cf1c488b0662f2c5765fdfab</ParentFileID>
+    </File>
+    <File>
+      <ID>id_698eb710ee5e6a87d67dddb534781b67</ID>
+      <Filename>galaxie_greek_positional.bmp</Filename>
+      <Filepath>..\..\g\galaxie_greek_positional\source\galaxie_greek_positional.bmp</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.bmp</FileType>
+      <ParentFileID>id_5e19948b19e2d5b4ca6993f1a97f7872</ParentFileID>
     </File>
     <File>
       <ID>id_2953db7f04181940605d4ff324e7423f</ID>
@@ -59,91 +100,52 @@
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_de082d4e3448605dd023e831f1b6b732</ID>
+      <ID>id_b8b4f7f506620adc6129f960461e7470</ID>
       <Filename>galaxie_hebrew_positional.js</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.js</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_positional.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_c08fd81e1e6f148d31f1bc365886e276</ID>
+      <ID>id_23878a69893d4496d818b727008974e3</ID>
       <Filename>galaxie_hebrew_positional.kvk</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.kvk</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_positional.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_9d4a56aa29add674771406c51eae5ade</ID>
+      <ID>id_7f46a4a9bc241645d4c96774f4a7e0aa</ID>
       <Filename>galaxie_hebrew_positional.kmx</Filename>
-      <Filepath>source\..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.kmx</Filepath>
+      <Filepath>source\..\build\galaxie_hebrew_positional.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_984d05111b8ee3f1faa4c41ba5187a15</ID>
+      <ID>id_b91e4114eaeaef4c79fcb17f21c2adc4</ID>
       <Filename>galaxie_greek_positional.js</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.js</Filepath>
+      <Filepath>source\..\build\galaxie_greek_positional.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_1ee854c6aa8b14064fbbaf7e6aa1b228</ID>
+      <ID>id_fa82eec7dcc2a307e0799b324d5f6de4</ID>
       <Filename>galaxie_greek_positional.kvk</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.kvk</Filepath>
+      <Filepath>source\..\build\galaxie_greek_positional.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
     <File>
-      <ID>id_6a0d3cd3b1a2b18ccc710d5277afaf6f</ID>
+      <ID>id_205438a41d8473457fa7d63053a955e3</ID>
       <Filename>galaxie_greek_positional.kmx</Filename>
-      <Filepath>source\..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.kmx</Filepath>
+      <Filepath>source\..\build\galaxie_greek_positional.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
-    </File>
-    <File>
-      <ID>id_d3cc7ea9cf1c488b0662f2c5765fdfab</ID>
-      <Filename>galaxie_hebrew_positional.kmn</Filename>
-      <Filepath>..\..\g\galaxie_hebrew_positional\source\galaxie_hebrew_positional.kmn</Filepath>
-      <FileVersion>2.2</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Galaxie Hebrew (Positional)</Name>
-        <Copyright>2004-2018 Galaxie Software and SIL International</Copyright>
-      </Details>
-    </File>
-    <File>
-      <ID>id_c61a5242d4510646e82a6759ca7015d8</ID>
-      <Filename>galaxie_hebrew_positional.bmp</Filename>
-      <Filepath>..\..\g\galaxie_hebrew_positional\source\galaxie_hebrew_positional.bmp</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.bmp</FileType>
-      <ParentFileID>id_d3cc7ea9cf1c488b0662f2c5765fdfab</ParentFileID>
-    </File>
-    <File>
-      <ID>id_5e19948b19e2d5b4ca6993f1a97f7872</ID>
-      <Filename>galaxie_greek_positional.kmn</Filename>
-      <Filepath>..\..\g\galaxie_greek_positional\source\galaxie_greek_positional.kmn</Filepath>
-      <FileVersion>1.0</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Galaxie Greek (Phonetic)</Name>
-        <Copyright>Copyright 2004-2018 Galaxie Software and SIL International</Copyright>
-        <Message>http://www.galaxie.com</Message>
-      </Details>
-    </File>
-    <File>
-      <ID>id_698eb710ee5e6a87d67dddb534781b67</ID>
-      <Filename>galaxie_greek_positional.bmp</Filename>
-      <Filepath>..\..\g\galaxie_greek_positional\source\galaxie_greek_positional.bmp</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.bmp</FileType>
-      <ParentFileID>id_5e19948b19e2d5b4ca6993f1a97f7872</ParentFileID>
     </File>
   </Files>
 </KeymanDeveloperProject>

--- a/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
+++ b/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>10.0.1200.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.52.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -51,37 +51,37 @@
       <FileType>.htm</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.js</Name>
+      <Name>..\build\galaxie_hebrew_positional.js</Name>
       <Description>File galaxie_hebrew_positional.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.kvk</Name>
+      <Name>..\build\galaxie_hebrew_positional.kvk</Name>
       <Description>File galaxie_hebrew_positional.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_hebrew_positional\build\galaxie_hebrew_positional.kmx</Name>
+      <Name>..\build\galaxie_hebrew_positional.kmx</Name>
       <Description>Keyboard Galaxie Hebrew (Positional)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.js</Name>
+      <Name>..\build\galaxie_greek_positional.js</Name>
       <Description>File galaxie_greek_positional.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.kvk</Name>
+      <Name>..\build\galaxie_greek_positional.kvk</Name>
       <Description>File galaxie_greek_positional.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\g\galaxie_greek_positional\build\galaxie_greek_positional.kmx</Name>
+      <Name>..\build\galaxie_greek_positional.kmx</Name>
       <Description>Keyboard Galaxie Greek (Phonetic)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
@@ -92,6 +92,7 @@
       <Name>Galaxie Hebrew (Positional)</Name>
       <ID>galaxie_hebrew_positional</ID>
       <Version>2.2</Version>
+      <RTL>True</RTL>
       <Languages>
         <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
         <Language ID="he">Hebrew (Hebrew)</Language>

--- a/release/packages/gff_amh_powerpack_7/gff_amh_powerpack_7.kpj
+++ b/release/packages/gff_amh_powerpack_7/gff_amh_powerpack_7.kpj
@@ -2,6 +2,10 @@
 <KeymanDeveloperProject>
   <Options>
     <BuildPath>$PROJECTPATH\build</BuildPath>
+    <CompilerWarningsAsErrors>False</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>True</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -17,7 +21,39 @@
       </Details>
     </File>
     <File>
-      <ID>id_d13d8b82e52c6ec8717e2aa53fa3a6a2</ID>
+      <ID>id_0f9ec59212e081a9b4382ac28d9cfabe</ID>
+      <Filename>gff_amh_7.kmn</Filename>
+      <Filepath>..\..\gff\gff_amh_7\source\gff_amh_7.kmn</Filepath>
+      <FileVersion>1.4</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Amharic</Name>
+        <Copyright>Creative Commons Attribution 3.0</Copyright>
+        <Message>This is an Amharic language mnemonic input method for Ethiopic script that requires Unicode 4.1 support.</Message>
+      </Details>
+    </File>
+    <File>
+      <ID>id_b640ca0ff6a508563277828cf4544980</ID>
+      <Filename>gff_ethiopic_7.kmn</Filename>
+      <Filepath>..\..\gff\gff_ethiopic_7\source\gff_ethiopic_7.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Ethiopic - (Language Neutral)</Name>
+        <Copyright>Creative Commons Attribution 3.0</Copyright>
+        <Message>This is a language neutral mnemonic input method for Ethiopic script that requires Unicode 4.1 support.</Message>
+      </Details>
+    </File>
+    <File>
+      <ID>id_56e21fe855faba2f337c1ef30c78aeb1</ID>
+      <Filename>ethiopic.bmp</Filename>
+      <Filepath>..\..\gff\gff_ethiopic_7\source\ethiopic.bmp</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.bmp</FileType>
+      <ParentFileID>id_b640ca0ff6a508563277828cf4544980</ParentFileID>
+    </File>
+    <File>
+      <ID>id_8da344c4cea6f467013357fe099006f5</ID>
       <Filename>readme.htm</Filename>
       <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
@@ -25,7 +61,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_5ca913904030f88c2e459c9d6c2f6032</ID>
+      <ID>id_b9a62f6081af204f1538454e0862d155</ID>
       <Filename>sideimage.bmp</Filename>
       <Filepath>source\sideimage.bmp</Filepath>
       <FileVersion></FileVersion>
@@ -33,23 +69,23 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_ff3a36a67d7bca7d5e0b7126944e6c75</ID>
+      <ID>id_efc02ecbcb2dd28e4a17ca79fe42b46d</ID>
       <Filename>AmharicTyping-Amharic.pdf</Filename>
-      <Filepath>source\..\..\..\gff_amh_7\source\AmharicTyping-Amharic.pdf</Filepath>
+      <Filepath>source\..\..\..\gff\gff_amh_7\source\AmharicTyping-Amharic.pdf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.pdf</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_4401e91f90703f34d93f602988388609</ID>
+      <ID>id_9784a5356a1f5c75d9292e531510c802</ID>
       <Filename>AmharicTyping-English.pdf</Filename>
-      <Filepath>source\..\..\..\gff_amh_7\source\AmharicTyping-English.pdf</Filepath>
+      <Filepath>source\..\..\..\gff\gff_amh_7\source\AmharicTyping-English.pdf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.pdf</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_d0bc6276594c05bca600c6ae650bf5fc</ID>
+      <ID>id_90434375fde64a2c595f8ba32a6e1662</ID>
       <Filename>OFL.txt</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\OFL.txt</Filepath>
       <FileVersion></FileVersion>
@@ -57,7 +93,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_cfcfc5ba46b6a02bd8e02b6317cc8406</ID>
+      <ID>id_013ca59571c49a6f4a47830a871d79c5</ID>
       <Filename>GNU-GPLv2.txt</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\GNU-GPLv2.txt</Filepath>
       <FileVersion></FileVersion>
@@ -65,15 +101,15 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_a65b0f37e1c523107536fa263b70a332</ID>
+      <ID>id_2e950a37e4a049cc0ca2d07502ebe0f6</ID>
       <Filename>welcome.htm</Filename>
-      <Filepath>source\..\..\..\gff_amh_7\source\welcome.htm</Filepath>
+      <Filepath>source\..\..\..\gff\gff_amh_7\source\welcome.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_5378adb7ed6bb52e4dc4cd272e15ac94</ID>
+      <ID>id_a53b630e68c28978d47da652021682cf</ID>
       <Filename>AbyssinicaSIL-R.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\AbyssinicaSIL-R.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -81,7 +117,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_073189f88aba7e43ffea5623f38c0200</ID>
+      <ID>id_53ec714fda5f206fb077803ef2f9e5da</ID>
       <Filename>fantuwua.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\fantuwua.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -89,7 +125,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_5d15a7a3a968b9fe682be16c8d002361</ID>
+      <ID>id_e18d6435aba33cc65579d0ab10e6c5e6</ID>
       <Filename>FreeSerif.otf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\FreeSerif.otf</Filepath>
       <FileVersion></FileVersion>
@@ -97,7 +133,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_dab0b2e934043d2b32629c674e8808e0</ID>
+      <ID>id_3777b75b09e869ae197b750b1c3ca2ca</ID>
       <Filename>goffer.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\goffer.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -105,7 +141,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_e3e83055d5e73c0694e3b513a0add468</ID>
+      <ID>id_969886c5552a5cae16f251dd9d23bdf9</ID>
       <Filename>hiwua.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\hiwua.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -113,7 +149,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_1056a000d515498ccd80fb2e40c22ff5</ID>
+      <ID>id_3a230e5c6e27e60af162dca60f4b68f6</ID>
       <Filename>jiret.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\jiret.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -121,7 +157,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_ce12112ddc0636801e87e0a17f4b7c00</ID>
+      <ID>id_7a123608b6600324c02fbbe00000f610</ID>
       <Filename>jiretsl.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\jiretsl.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -129,7 +165,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_4f147beb8fba933eca41dad11d60fca3</ID>
+      <ID>id_70b1cd9414cb8ad181bced52ae12fc1b</ID>
       <Filename>tint.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\tint.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -137,7 +173,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_4adf15c59e5972733c25bbdc0cf10cd4</ID>
+      <ID>id_49691a00db6e06b4f1b6795bbf616477</ID>
       <Filename>washrab.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\washrab.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -145,7 +181,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_34c7f03310537c0d35ddc20bc89509f8</ID>
+      <ID>id_9d9a843600e00e5f466eb7f1685b99a1</ID>
       <Filename>washrabsl.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\washrabsl.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -153,7 +189,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_c6ca78a793df09d7d3036b569252903f</ID>
+      <ID>id_7f6409caef57ccc54765f964c6ad4c0a</ID>
       <Filename>washrasb.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\washrasb.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -161,7 +197,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_6a0f8331f31916edec372f3e10d07ca2</ID>
+      <ID>id_a02ee71af8674c29215b2697bc38a6b0</ID>
       <Filename>washrasbsl.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\washrasbsl.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -169,7 +205,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_983b2fdc3d3edf15be5f35b7f39f7d63</ID>
+      <ID>id_342c7ba4dd176ef27de3e3780129b02f</ID>
       <Filename>wookianos.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\wookianos.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -177,7 +213,7 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_96ae9f26356d0433188e9566b6390df0</ID>
+      <ID>id_528fa28f1d08bcdf1b6435a8ad24c7d6</ID>
       <Filename>yebse.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\yebse.ttf</Filepath>
       <FileVersion></FileVersion>
@@ -185,33 +221,33 @@
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_b7f1a62c9e943cc11ea229a8b0a167f7</ID>
-      <Filename>gff-amh-7.kvk</Filename>
-      <Filepath>source\..\..\..\gff_amh_7\build\gff-amh-7.kvk</Filepath>
+      <ID>id_ef29c30d3998418c5019de521b657ac4</ID>
+      <Filename>gff_amh_7.kvk</Filename>
+      <Filepath>source\..\build\gff_amh_7.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_d4aaa15e3c2ef04ed438f1672027c74e</ID>
-      <Filename>gff-amh-7.kmx</Filename>
-      <Filepath>source\..\..\..\gff_amh_7\build\gff-amh-7.kmx</Filepath>
+      <ID>id_aee0f78cb2d70366218bae7a52c0a164</ID>
+      <Filename>gff_amh_7.kmx</Filename>
+      <Filepath>source\..\build\gff_amh_7.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_37d6d562e6fbaa43d53f10720ca270ce</ID>
-      <Filename>gff-ethiopic-7.kvk</Filename>
-      <Filepath>source\..\..\..\gff_ethiopic_7\build\gff-ethiopic-7.kvk</Filepath>
+      <ID>id_ed4def5660797394879fbf071d4b169e</ID>
+      <Filename>gff_ethiopic_7.kvk</Filename>
+      <Filepath>source\..\build\gff_ethiopic_7.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>
     </File>
     <File>
-      <ID>id_92d1598d450585c958eb8738b88dea42</ID>
-      <Filename>gff-ethiopic-7.kmx</Filename>
-      <Filepath>source\..\..\..\gff_ethiopic_7\source\gff-ethiopic-7.kmx</Filepath>
+      <ID>id_8199545704aedd4265f961691edd02e5</ID>
+      <Filename>gff_ethiopic_7.kmx</Filename>
+      <Filepath>source\..\build\gff_ethiopic_7.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_E8A42B31BAC14ECAB2509D21FBF0D9DD</ParentFileID>

--- a/release/packages/gff_amh_powerpack_7/source/gff_amh_powerpack_7.kps
+++ b/release/packages/gff_amh_powerpack_7/source/gff_amh_powerpack_7.kps
@@ -1,2 +1,231 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Package><System><KeymanDeveloperVersion>9.0.500.0</KeymanDeveloperVersion><FileVersion>7.0</FileVersion></System><Options><ExecuteProgram></ExecuteProgram><ReadMeFile>readme.htm</ReadMeFile><GraphicFile>sideimage.bmp</GraphicFile><MSIFileName></MSIFileName><MSIOptions></MSIOptions></Options><Buttons><Button><ButtonType>install</ButtonType><Caption>&amp;Install</Caption><URL></URL><Left>0</Left><Top>0</Top></Button><Button><ButtonType>cancel</ButtonType><Caption>Cancel</Caption><URL></URL><Left>0</Left><Top>0</Top></Button><Button><ButtonType>about</ButtonType><Caption>&amp;About...</Caption><URL></URL><Left>0</Left><Top>0</Top></Button></Buttons><Registry/><StartMenu><Folder>GFF Amharic Keyboard</Folder><AddUninstallEntry/><Items><Item><Name>Welcome</Name><FileName>..\..\..\gff\gff_amh_7\source\welcome.htm</FileName><Arguments></Arguments><Icon></Icon><Location>psmelStartMenu</Location></Item><Item><Name>Amharic Keyboard Manual (Amharic)</Name><FileName>AmharicTyping-Amharic.pdf</FileName><Arguments></Arguments><Icon></Icon><Location>psmelStartMenu</Location></Item><Item><Name>Amharic Keyboard Manual (English)</Name><FileName>AmharicTyping-English.pdf</FileName><Arguments></Arguments><Icon></Icon><Location>psmelStartMenu</Location></Item><Item><Name>OFL (Abyssinica SIL Licence)</Name><FileName>OFL.txt</FileName><Arguments></Arguments><Icon></Icon><Location>psmelStartMenu</Location></Item><Item><Name>GPL (WashRa + Free Serif Licence) </Name><FileName>GNU-GPLv2.txt</FileName><Arguments></Arguments><Icon></Icon><Location>psmelStartMenu</Location></Item></Items></StartMenu><Info><WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite><Version URL="">8.0.0</Version><Name URL="">GFF Amharic Keyboard</Name><Copyright URL="">Creative Commons Attribution 3.0</Copyright><Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author></Info><Files><File><Name>readme.htm</Name><Description>File readme.htm</Description><CopyLocation>0</CopyLocation><FileType>.htm</FileType></File><File><Name>sideimage.bmp</Name><Description>File sideimage.bmp</Description><CopyLocation>0</CopyLocation><FileType>.bmp</FileType></File><File><Name>..\..\..\gff\gff_amh_7\source\AmharicTyping-Amharic.pdf</Name><Description>File AmharicTyping-Amharic.pdf</Description><CopyLocation>0</CopyLocation><FileType>.pdf</FileType></File><File><Name>..\..\..\gff\gff_amh_7\source\AmharicTyping-English.pdf</Name><Description>File AmharicTyping-English.pdf</Description><CopyLocation>0</CopyLocation><FileType>.pdf</FileType></File><File><Name>..\..\..\shared\fonts\geez\OFL.txt</Name><Description>File OFL.txt</Description><CopyLocation>0</CopyLocation><FileType>.txt</FileType></File><File><Name>..\..\..\shared\fonts\geez\GNU-GPLv2.txt</Name><Description>File GNU-GPLv2.txt</Description><CopyLocation>0</CopyLocation><FileType>.txt</FileType></File><File><Name>..\..\..\gff\gff_amh_7\source\welcome.htm</Name><Description>File Welcome.htm</Description><CopyLocation>0</CopyLocation><FileType>.htm</FileType></File><File><Name>..\..\..\shared\fonts\geez\AbyssinicaSIL-R.ttf</Name><Description>Font Abyssinica SIL</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\fantuwua.ttf</Name><Description>Font Ethiopic Fantuwua</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\FreeSerif.otf</Name><Description>Font Free Serif</Description><CopyLocation>0</CopyLocation><FileType>.otf</FileType></File><File><Name>..\..\..\shared\fonts\geez\goffer.ttf</Name><Description>Font Ethiopic Yigezu Bisrat Goffer</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\hiwua.ttf</Name><Description>Font Ethiopic Hiwua</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\jiret.ttf</Name><Description>Font Ethiopia Jiret</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\jiretsl.ttf</Name><Description>Font Ethiopia Jiret Slant</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\tint.ttf</Name><Description>Font Ethiopic Tint</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\washrab.ttf</Name><Description>Font Ethiopic WashRa Bold</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\washrabsl.ttf</Name><Description>Font Ethiopic WashRa Bold Slant</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\washrasb.ttf</Name><Description>Font Ethiopic WashRa SemiBold</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\washrasbsl.ttf</Name><Description>Font Ethiopic WashRa SemiBold Slant</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\wookianos.ttf</Name><Description>Font Ethiopic Wookianos</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\shared\fonts\geez\yebse.ttf</Name><Description>Font Ethiopic Yebse</Description><CopyLocation>0</CopyLocation><FileType>.ttf</FileType></File><File><Name>..\..\..\gff\gff_amh_7\build\gff_amh_7.kvk</Name><Description>File gff_amh_7.kvk</Description><CopyLocation>0</CopyLocation><FileType>.kvk</FileType></File><File><Name>..\..\..\gff\gff_amh_7\build\gff_amh_7.kmx</Name><Description>Keyboard Amharic</Description><CopyLocation>0</CopyLocation><FileType>.kmx</FileType></File><File><Name>..\..\..\gff\gff_ethiopic_7\build\gff_ethiopic_7.kvk</Name><Description>File gff_ethiopic_7.kvk</Description><CopyLocation>0</CopyLocation><FileType>.kvk</FileType></File><File><Name>..\..\..\gff\gff_ethiopic_7\build\gff_ethiopic_7.kmx</Name><Description>Keyboard Ethiopic - (Language Neutral)</Description><CopyLocation>0</CopyLocation><FileType>.kmx</FileType></File></Files><Strings/></Package>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>12.0.52.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Options>
+    <ExecuteProgram></ExecuteProgram>
+    <ReadMeFile>readme.htm</ReadMeFile>
+    <GraphicFile>sideimage.bmp</GraphicFile>
+    <MSIFileName></MSIFileName>
+    <MSIOptions></MSIOptions>
+  </Options>
+  <StartMenu>
+    <Folder>GFF Amharic Keyboard</Folder>
+    <AddUninstallEntry/>
+    <Items>
+      <Item>
+        <Name>Welcome</Name>
+        <FileName>..\..\..\gff\gff_amh_7\source\welcome.htm</FileName>
+        <Arguments></Arguments>
+        <Icon></Icon>
+        <Location>psmelStartMenu</Location>
+      </Item>
+      <Item>
+        <Name>Amharic Keyboard Manual (Amharic)</Name>
+        <FileName>AmharicTyping-Amharic.pdf</FileName>
+        <Arguments></Arguments>
+        <Icon></Icon>
+        <Location>psmelStartMenu</Location>
+      </Item>
+      <Item>
+        <Name>Amharic Keyboard Manual (English)</Name>
+        <FileName>AmharicTyping-English.pdf</FileName>
+        <Arguments></Arguments>
+        <Icon></Icon>
+        <Location>psmelStartMenu</Location>
+      </Item>
+      <Item>
+        <Name>OFL (Abyssinica SIL Licence)</Name>
+        <FileName>OFL.txt</FileName>
+        <Arguments></Arguments>
+        <Icon></Icon>
+        <Location>psmelStartMenu</Location>
+      </Item>
+      <Item>
+        <Name>GPL (WashRa + Free Serif Licence)</Name>
+        <FileName>GNU-GPLv2.txt</FileName>
+        <Arguments></Arguments>
+        <Icon></Icon>
+        <Location>psmelStartMenu</Location>
+      </Item>
+    </Items>
+  </StartMenu>
+  <Info>
+    <WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite>
+    <Version URL="">8.0.0</Version>
+    <Name URL="">GFF Amharic Keyboard</Name>
+    <Copyright URL="">Creative Commons Attribution 3.0</Copyright>
+    <Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author>
+  </Info>
+  <Files>
+    <File>
+      <Name>readme.htm</Name>
+      <Description>File readme.htm</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.htm</FileType>
+    </File>
+    <File>
+      <Name>sideimage.bmp</Name>
+      <Description>File sideimage.bmp</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.bmp</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\gff\gff_amh_7\source\AmharicTyping-Amharic.pdf</Name>
+      <Description>File AmharicTyping-Amharic.pdf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.pdf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\gff\gff_amh_7\source\AmharicTyping-English.pdf</Name>
+      <Description>File AmharicTyping-English.pdf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.pdf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\OFL.txt</Name>
+      <Description>File OFL.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\GNU-GPLv2.txt</Name>
+      <Description>File GNU-GPLv2.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\gff\gff_amh_7\source\welcome.htm</Name>
+      <Description>File Welcome.htm</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.htm</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\AbyssinicaSIL-R.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\fantuwua.ttf</Name>
+      <Description>Font Ethiopic Fantuwua</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\FreeSerif.otf</Name>
+      <Description>Font Free Serif</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.otf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\goffer.ttf</Name>
+      <Description>Font Ethiopic Yigezu Bisrat Goffer</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\hiwua.ttf</Name>
+      <Description>Font Ethiopic Hiwua</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\jiret.ttf</Name>
+      <Description>Font Ethiopia Jiret</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\jiretsl.ttf</Name>
+      <Description>Font Ethiopia Jiret Slant</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\tint.ttf</Name>
+      <Description>Font Ethiopic Tint</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\washrab.ttf</Name>
+      <Description>Font Ethiopic WashRa Bold</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\washrabsl.ttf</Name>
+      <Description>Font Ethiopic WashRa Bold Slant</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\washrasb.ttf</Name>
+      <Description>Font Ethiopic WashRa SemiBold</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\washrasbsl.ttf</Name>
+      <Description>Font Ethiopic WashRa SemiBold Slant</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\wookianos.ttf</Name>
+      <Description>Font Ethiopic Wookianos</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\yebse.ttf</Name>
+      <Description>Font Ethiopic Yebse</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\build\gff_amh_7.kvk</Name>
+      <Description>File gff_amh_7.kvk</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kvk</FileType>
+    </File>
+    <File>
+      <Name>..\build\gff_amh_7.kmx</Name>
+      <Description>Keyboard Amharic</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+    <File>
+      <Name>..\build\gff_ethiopic_7.kvk</Name>
+      <Description>File gff_ethiopic_7.kvk</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kvk</FileType>
+    </File>
+    <File>
+      <Name>..\build\gff_ethiopic_7.kmx</Name>
+      <Description>Keyboard Ethiopic - (Language Neutral)</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Amharic</Name>
+      <ID>gff_amh_7</ID>
+      <Version>1.4</Version>
+      <Languages>
+        <Language ID="am">Amharic</Language>
+      </Languages>
+    </Keyboard>
+    <Keyboard>
+      <Name>Ethiopic - (Language Neutral)</Name>
+      <ID>gff_ethiopic_7</ID>
+      <Version>1.0</Version>
+      <Languages/>
+    </Keyboard>
+  </Keyboards>
+  <Strings/>
+</Package>

--- a/release/packages/syriac_aramaic/source/syriac_aramaic.kps
+++ b/release/packages/syriac_aramaic/source/syriac_aramaic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>10.0.1200.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.52.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -262,55 +262,55 @@
       <FileType>.htm</FileType>
     </File>
     <File>
-      <Name>..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.js</Name>
+      <Name>..\build\aramaic_hebrew.js</Name>
       <Description>File aramaic_hebrew.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.kvk</Name>
+      <Name>..\build\aramaic_hebrew.kvk</Name>
       <Description>File aramaic_hebrew.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.kmx</Name>
+      <Name>..\build\aramaic_hebrew.kmx</Name>
       <Description>Keyboard Aramaic (Hebrew layout)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_arabic\build\syriac_arabic.js</Name>
+      <Name>..\build\syriac_arabic.js</Name>
       <Description>File syriac_arabic.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_arabic\build\syriac_arabic.kvk</Name>
+      <Name>..\build\syriac_arabic.kvk</Name>
       <Description>File syriac_arabic.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_arabic\build\syriac_arabic.kmx</Name>
+      <Name>..\build\syriac_arabic.kmx</Name>
       <Description>Keyboard Syriac (Arabic layout)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_phonetic\build\syriac_phonetic.js</Name>
+      <Name>..\build\syriac_phonetic.js</Name>
       <Description>File syriac_phonetic.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_phonetic\build\syriac_phonetic.kvk</Name>
+      <Name>..\build\syriac_phonetic.kvk</Name>
       <Description>File syriac_phonetic.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\..\s\syriac_phonetic\build\syriac_phonetic.kmx</Name>
+      <Name>..\build\syriac_phonetic.kmx</Name>
       <Description>Keyboard Syriac (Phonetic layout)</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
@@ -339,6 +339,7 @@
       <Name>Aramaic (Hebrew layout)</Name>
       <ID>aramaic_hebrew</ID>
       <Version>1.2</Version>
+      <RTL>True</RTL>
       <OSKFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</DisplayFont>
       <Languages>
@@ -364,6 +365,7 @@
       <Name>Syriac (Arabic layout)</Name>
       <ID>syriac_arabic</ID>
       <Version>1.2</Version>
+      <RTL>True</RTL>
       <OSKFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</DisplayFont>
       <Languages>
@@ -389,6 +391,7 @@
       <Name>Syriac (Phonetic layout)</Name>
       <ID>syriac_phonetic</ID>
       <Version>1.2</Version>
+      <RTL>True</RTL>
       <OSKFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\meltho\SyrCOMEdessa.otf</DisplayFont>
       <Languages>

--- a/release/packages/syriac_aramaic/syriac_aramaic.kpj
+++ b/release/packages/syriac_aramaic/syriac_aramaic.kpj
@@ -4,6 +4,8 @@
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -17,6 +19,64 @@
         <Copyright>© 2007-2018 SIL International</Copyright>
         <Version>1.2</Version>
       </Details>
+    </File>
+    <File>
+      <ID>id_0732f75fb48c145dcbda33c66bff57c5</ID>
+      <Filename>aramaic_hebrew.kmn</Filename>
+      <Filepath>..\..\a\aramaic_hebrew\source\aramaic_hebrew.kmn</Filepath>
+      <FileVersion>1.2</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Aramaic (Hebrew layout)</Name>
+        <Copyright>© 2007-2018 SIL International</Copyright>
+        <Message>Keyboard originally created by Illan Gonen</Message>
+      </Details>
+    </File>
+    <File>
+      <ID>id_54088a4d6848b09eaa0d7bd9de6e946d</ID>
+      <Filename>syriac_arabic.kmn</Filename>
+      <Filepath>..\..\s\syriac_arabic\source\syriac_arabic.kmn</Filepath>
+      <FileVersion>1.2</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Syriac (Arabic layout)</Name>
+        <Copyright>© 2007-2018 SIL International</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>id_452b340c04b5947a9a0b7f067c15f09b</ID>
+      <Filename>syriac_phonetic.kmn</Filename>
+      <Filepath>..\..\s\syriac_phonetic\source\syriac_phonetic.kmn</Filepath>
+      <FileVersion>1.2</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Syriac (Phonetic layout)</Name>
+        <Copyright>(C) 2007-2018 SIL International</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>id_8260990860a4d1eda78aec5d65be3bd1</ID>
+      <Filename>aramaic_hebrew.ico</Filename>
+      <Filepath>..\..\a\aramaic_hebrew\source\aramaic_hebrew.ico</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ico</FileType>
+      <ParentFileID>id_0732f75fb48c145dcbda33c66bff57c5</ParentFileID>
+    </File>
+    <File>
+      <ID>id_0f2aa2593fa0e00ae48a8421e23245aa</ID>
+      <Filename>syriac_arabic.ico</Filename>
+      <Filepath>..\..\s\syriac_arabic\source\syriac_arabic.ico</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ico</FileType>
+      <ParentFileID>id_54088a4d6848b09eaa0d7bd9de6e946d</ParentFileID>
+    </File>
+    <File>
+      <ID>id_ad9e9627c7110db40756890561c85d3e</ID>
+      <Filename>syriac_phonetic.ico</Filename>
+      <Filepath>..\..\s\syriac_phonetic\source\syriac_phonetic.ico</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ico</FileType>
+      <ParentFileID>id_452b340c04b5947a9a0b7f067c15f09b</ParentFileID>
     </File>
     <File>
       <ID>id_82d95b97fc6f2472fbe268fc19122ec2</ID>
@@ -339,73 +399,73 @@
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_97a72d8343120d6d8401eb19b952672f</ID>
+      <ID>id_56c299f80c97917ef74eca1a2a539e2e</ID>
       <Filename>aramaic_hebrew.js</Filename>
-      <Filepath>source\..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.js</Filepath>
+      <Filepath>source\..\build\aramaic_hebrew.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_40fadb4bc5ea258ef181fe315c99e66f</ID>
+      <ID>id_539d02b4ad46bcac7a5e76c3086fc648</ID>
       <Filename>aramaic_hebrew.kvk</Filename>
-      <Filepath>source\..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.kvk</Filepath>
+      <Filepath>source\..\build\aramaic_hebrew.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_3bd05d709feb5d9ad71a99b58f000f82</ID>
+      <ID>id_44a7e75f03e54406b962c090d8039dc3</ID>
       <Filename>aramaic_hebrew.kmx</Filename>
-      <Filepath>source\..\..\..\a\aramaic_hebrew\build\aramaic_hebrew.kmx</Filepath>
+      <Filepath>source\..\build\aramaic_hebrew.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_2d35e35d81fee8d672397b8b8fbc1beb</ID>
+      <ID>id_65b8c0abbeb2f1ca377c1f8faa6d7dbe</ID>
       <Filename>syriac_arabic.js</Filename>
-      <Filepath>source\..\..\..\s\syriac_arabic\build\syriac_arabic.js</Filepath>
+      <Filepath>source\..\build\syriac_arabic.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_c93cf74cf507140959704daddc0cac52</ID>
+      <ID>id_94085d360a45fceb3d4e802d8ffd6481</ID>
       <Filename>syriac_arabic.kvk</Filename>
-      <Filepath>source\..\..\..\s\syriac_arabic\build\syriac_arabic.kvk</Filepath>
+      <Filepath>source\..\build\syriac_arabic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_813467b3d6ac60ebf06a7a08a696cc0b</ID>
+      <ID>id_51cdf80becc47c3842c41b12a1afa55f</ID>
       <Filename>syriac_arabic.kmx</Filename>
-      <Filepath>source\..\..\..\s\syriac_arabic\build\syriac_arabic.kmx</Filepath>
+      <Filepath>source\..\build\syriac_arabic.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_36b56bd4539db7286423ceccdc51ccaa</ID>
+      <ID>id_cb31852d7e2018b5656a30eb450b144c</ID>
       <Filename>syriac_phonetic.js</Filename>
-      <Filepath>source\..\..\..\s\syriac_phonetic\build\syriac_phonetic.js</Filepath>
+      <Filepath>source\..\build\syriac_phonetic.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_d2e68bd0e1a1a43e4675df68bd55d894</ID>
+      <ID>id_f00a676045d938276a3f399c779c2fde</ID>
       <Filename>syriac_phonetic.kvk</Filename>
-      <Filepath>source\..\..\..\s\syriac_phonetic\build\syriac_phonetic.kvk</Filepath>
+      <Filepath>source\..\build\syriac_phonetic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
     </File>
     <File>
-      <ID>id_d81fa488483586a6d8899ef9c6cd853c</ID>
+      <ID>id_969dcc46cec8a54295208ed7ac35694c</ID>
       <Filename>syriac_phonetic.kmx</Filename>
-      <Filepath>source\..\..\..\s\syriac_phonetic\build\syriac_phonetic.kmx</Filepath>
+      <Filepath>source\..\build\syriac_phonetic.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
@@ -433,64 +493,6 @@
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
       <ParentFileID>id_a933f75dd1e6b0f894efc8f886fc5798</ParentFileID>
-    </File>
-    <File>
-      <ID>id_0732f75fb48c145dcbda33c66bff57c5</ID>
-      <Filename>aramaic_hebrew.kmn</Filename>
-      <Filepath>..\..\a\aramaic_hebrew\source\aramaic_hebrew.kmn</Filepath>
-      <FileVersion>1.2</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Aramaic (Hebrew layout)</Name>
-        <Copyright>© 2007-2018 SIL International</Copyright>
-        <Message>Keyboard originally created by Illan Gonen</Message>
-      </Details>
-    </File>
-    <File>
-      <ID>id_8260990860a4d1eda78aec5d65be3bd1</ID>
-      <Filename>aramaic_hebrew.ico</Filename>
-      <Filepath>..\..\a\aramaic_hebrew\source\aramaic_hebrew.ico</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ico</FileType>
-      <ParentFileID>id_0732f75fb48c145dcbda33c66bff57c5</ParentFileID>
-    </File>
-    <File>
-      <ID>id_54088a4d6848b09eaa0d7bd9de6e946d</ID>
-      <Filename>syriac_arabic.kmn</Filename>
-      <Filepath>..\..\s\syriac_arabic\source\syriac_arabic.kmn</Filepath>
-      <FileVersion>1.2</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Syriac (Arabic layout)</Name>
-        <Copyright>© 2007-2018 SIL International</Copyright>
-      </Details>
-    </File>
-    <File>
-      <ID>id_0f2aa2593fa0e00ae48a8421e23245aa</ID>
-      <Filename>syriac_arabic.ico</Filename>
-      <Filepath>..\..\s\syriac_arabic\source\syriac_arabic.ico</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ico</FileType>
-      <ParentFileID>id_54088a4d6848b09eaa0d7bd9de6e946d</ParentFileID>
-    </File>
-    <File>
-      <ID>id_452b340c04b5947a9a0b7f067c15f09b</ID>
-      <Filename>syriac_phonetic.kmn</Filename>
-      <Filepath>..\..\s\syriac_phonetic\source\syriac_phonetic.kmn</Filepath>
-      <FileVersion>1.2</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>Syriac (Phonetic layout)</Name>
-        <Copyright>(C) 2007-2018 SIL International</Copyright>
-      </Details>
-    </File>
-    <File>
-      <ID>id_ad9e9627c7110db40756890561c85d3e</ID>
-      <Filename>syriac_phonetic.ico</Filename>
-      <Filepath>..\..\s\syriac_phonetic\source\syriac_phonetic.ico</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ico</FileType>
-      <ParentFileID>id_452b340c04b5947a9a0b7f067c15f09b</ParentFileID>
     </File>
   </Files>
 </KeymanDeveloperProject>


### PR DESCRIPTION
Fixes keymanapp/keyman#2338.

The dependencies for release packages were referring to other paths.
The pattern for the packages folder is to include the source kmn files
in the project so that they will be built along with the package.

However, the .kps files themselves still referred to the built kmx/js
in the original folders, rather than the expected ..\build\ path.

Given this change is a compile-phase-only change, there is no need to
update version numbers or make new releases.

This will fix the situation where bundled release package installers
are failing to build.

Note: I originally started off thinking we'd need to add a dependency
file into the keyboard folders that had dependencies and build those 
dependencies first, but this is a cleaner fix that avoids 
infrastructure that would only work with shell scripts and not Keyman 
Developer GUI.