### PR TITLE
fix: fail ci early if assets unavailable

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -93,7 +93,7 @@ function run {
 ## GET https://downloads.keyman.com/api/version/windows/2.0
 ##
 function check_latest_stable_keymandesktop {
-  local API_VERSION_JSON=`curl -s "$DOWNLOADS_KEYMAN_COM_URL/api/version/windows/2.0"`
+  local API_VERSION_JSON=`curl -f -s "$DOWNLOADS_KEYMAN_COM_URL/api/version/windows/2.0"`
   if [ -z "$API_VERSION_JSON" ]; then
     die "Unable to download version data"
   fi
@@ -101,6 +101,14 @@ function check_latest_stable_keymandesktop {
   MSI_FILENAME=`echo $API_VERSION_JSON | $JQ -r '.windows.stable.files[].file | match("^keymandesktop.*.msi$").string'`
   MSI_MD5=`echo $API_VERSION_JSON | $JQ -r '.windows.stable.files["'$MSI_FILENAME'"].md5'`
   SETUP_MD5=`echo $API_VERSION_JSON | $JQ -r '.windows.stable.files["setup.exe"].md5'`
+
+  if [ -z "$KEYMANDESKTOP_VERSION" ]; then
+    die "Keyman Desktop version could not be extracted from $API_VERSION_JSON"
+  fi
+
+  if [ -z "$MSI_FILENAME" ]; then
+    die "MSI filename could not be extracted from $API_VERSION_JSON"
+  fi
 
   SETUP_EXE_URL=$DOWNLOADS_KEYMAN_COM_URL/windows/stable/$KEYMANDESKTOP_VERSION/setup.exe
   MSI_URL=$DOWNLOADS_KEYMAN_COM_URL/windows/stable/$KEYMANDESKTOP_VERSION/$MSI_FILENAME
@@ -167,7 +175,7 @@ function check_and_download {
   fi
 
   echo "Downloading $url"
-  curl -# -o "$CI_CACHE/$filename" "$url"
+  curl -f -# -o "$CI_CACHE/$filename" "$url" || die "Unable to download $url"
 }
 
 ##


### PR DESCRIPTION
This is a partial fix to a race condition in our build. When we are
doing a release build of Keyman Desktop, the files are uploaded to
downloads.keyman.com as the final step. While the files are uploading,
there is a window of time where the downloads.keyman.com version API
(e.g. https://downloads.keyman.com/api/version/windows/2.0) starts to
return the new version, but the new version is not yet fully uploaded.

Normally, this would be a tiny issue that at worst would result in a
failed download for a single user if they happened to download within
that second. It wouldn't necessarily be something to be concerned about.

Now that we have bundled installers building on a download trigger, this
caused a fun issue. The build agent started a bundled build for the new
version, and requested files from downloads.keyman.com (via Cloudflare),
that  were not *quite* available. And so of course downloads sensibly
returns a 404 for, e.g.
https://downloads.keyman.com/windows/stable/12.0.57.0/setup.exe. This
caused the build to fail (although not as early as it should have; read
on), and all was good until the build finished, right?

Enter Cloudflare. You can probably see where this is going. The server
has returned a 404 for a file. Cloudflare caches that 404. Now all the
subsequent builds start failing. Yay! Until the cached objects expire
or we do a manual purge (which is what I did today).

Moral of the story: nothing is easy. We are doomed. As a race, I mean.

Oh yeah, this fix does nothing to resolve the root cause but at least
makes it a little bit easier to understand *what* is going on and
hopefully if this ever arises again will be quicker to pinpoint the
problem and resolve it. (A full mitigation would be to change the way
the version API reads the current version and/or make the upload of a
new version atomicly transactional "somehow").

/end essay