### PR TITLE
[fv_dakelh] preserve comments from PR for future work

### DIFF
--- a/release/fv/fv_dakelh/README.md
+++ b/release/fv/fv_dakelh/README.md
@@ -22,3 +22,16 @@ Supported Platforms
  * Linux
  * Web
  * Mobile
+
+TODO
+----
+From PR 927 comments:
+
+Minor concerns with touch layout:
+- Default layer: type t then _ (top row, leftmost key): I'd expect an underlined t, but the keyboard actually gives an underlined ts. Maybe this is intentional?
+- Shift layer: After typing a key on the shift layer, the user is returned to the default layer, except when typing a longpress key, which leaves the user on the shift layer. Seems inconsistent.
+- Shift layer: Some longpress keys are not producing what the key shows, for example, on the T key:
+  - underlined Ts produces underlined ts
+  - underlined TS produces underlined t
+  - underlined T produces nothing
+


### PR DESCRIPTION
PR #927 restored a previous version of the touch layout. There were some minor questions about the layout which were not addressed in that PR, but are added to the README.md file by this PR so they will be preserved should for any future work on this keyboard.