### PR TITLE
[haroi] Add additional rules to handle either NFC or NFD vowels

### DIFF
--- a/release/h/haroi/HISTORY.md
+++ b/release/h/haroi/HISTORY.md
@@ -1,6 +1,9 @@
 Haroi Keyboard Change History
 =======================
 
+1.1 (10 Jan 2020)
+* Add additional rules to handle either NFC or NFD vowels
+
 1.0 (5 June 2019)
 -----------------
 

--- a/release/h/haroi/README.md
+++ b/release/h/haroi/README.md
@@ -1,9 +1,7 @@
 Haroi Keyboard
 =====================
 
-Copyright (c) 2019 SIL International
-
-Version 1.0
+Copyright (c) 2019-2020 SIL International
 
 __DESCRIPTION__
 This keyboard is adapted from VNI.

--- a/release/h/haroi/haroi.keyboard_info
+++ b/release/h/haroi/haroi.keyboard_info
@@ -1,6 +1,7 @@
 {
     "license": "mit",
     "languages": [
+        "hro-Latn-VN",
         "hro-Latn",
         "vi"
     ],	

--- a/release/h/haroi/haroi.kpj
+++ b/release/h/haroi/haroi.kpj
@@ -5,13 +5,14 @@
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>True</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
       <ID>id_11adc6ce83f2aa6ca1a1c25976fd9e21</ID>
       <Filename>haroi.kmn</Filename>
       <Filepath>source\haroi.kmn</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Haroi</Name>
@@ -23,12 +24,11 @@
       <ID>id_fa62b90c0bceb6363f2210cf1eae0f4e</ID>
       <Filename>haroi.kps</Filename>
       <Filepath>source\haroi.kps</Filepath>
-      <FileVersion>1</FileVersion>
+      <FileVersion></FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Haroi</Name>
         <Copyright>© 2019 SIL International</Copyright>
-        <Version>1</Version>
       </Details>
     </File>
     <File>

--- a/release/h/haroi/source/haroi.kmn
+++ b/release/h/haroi/source/haroi.kmn
@@ -4,7 +4,7 @@ store(&TARGETS) 'any'
 store(&BITMAP) 'haroi.ico'
 store(&VISUALKEYBOARD) 'haroi.kvks'
 store(&LAYOUTFILE) 'haroi.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.1'
 store(&COPYRIGHT) '© 2019 SIL International'
 store(&MESSAGE) 'This keyboard is adapted from VNI.'
 
@@ -136,12 +136,21 @@ U+0043 + [K_8]  > U+010C
 
 
 c Vowel lengths in Haroi, long vowels: a e ê i o ô ơ u ư  î  û 
-store(haroilongvowelslower)  U+00E2 U+00EA U+00F4 U+01A1 U+01B0 U+00EE U+00FB 
-store(haroilongvowelsupper)  U+00C2 U+00CA U+00D4 U+01A0 U+01AF U+00CE U+00DB
-store(haroianylongvowel)     outs(haroilongvowelslower) outs(haroilongvowelsupper)
+store(haroilongvowelsloweracute) U+00E2 U+00EA U+00F4 U+00EE U+00FB 
+store(haroilongvowelsupperacute) U+00C2 U+00CA U+00D4 U+00CE U+00DB
+store(haroianylongvowelacute) outs(haroilongvowelsloweracute) outs(haroilongvowelsupperacute)
+store(haroilongvowelslowerhorn)  U+01A1 U+01B0  
+store(haroilongvowelsupperhorn)  U+01A0 U+01AF
+store(haroianylongvowelhorn) outs(haroilongvowelslowerhorn) outs(haroilongvowelsupperhorn)
+store(haroianylongvowel)     outs(haroianylongvowelacute) outs(haroianylongvowelhorn)
+store(haroilongvowelsbaseacute)  'a' 'e' 'o' 'i' 'u' 'A' 'E' 'O' 'I' 'U'
+store(haroilongvowelsbasehorn)   'o' 'u' 'O' 'U'
 
 any(haroianylongvowel) + [K_8]   > index(haroianylongvowel,1) U+0306  c generate â̆ ê̆ ô̆ ơ̆ ư̆ î̆ û̆ (v+2 accents (v quality + shortness))
 
+c Cope with decomposed context too
+any(haroilongvowelsbaseacute) U+0302 + [K_8]  > index(haroianylongvowelacute,1) U+0306  c aeoiuy 6 + 8 > â̆ ê̆ ô̆ ơ̆ ư̆ î̆ û̆ and their capital counterpart
+any(haroilongvowelsbasehorn) U+031B + [K_8]  > index(haroianylongvowelhorn,1) U+0306  c aeoiuy 6 + 8 > â̆ ê̆ ô̆ ơ̆ ư̆ î̆ û̆ and their capital counterpart
 
 c Additional strokes needed to Vietnamese keyboard:
 c v + 2 accents (shortness and tones) 

--- a/release/h/haroi/source/haroi.kps
+++ b/release/h/haroi/source/haroi.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1356.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -16,7 +16,7 @@
     <Items/>
   </StartMenu>
   <Info>
-    <Version URL="">1</Version>
+    <Version URL=""></Version>
     <Name URL="">Haroi</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
   </Info>
@@ -138,6 +138,7 @@
       <OSKFont>..\..\..\shared\fonts\sil\charis_sil\CharisSIL-R.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\charis_sil\CharisSIL-R.ttf</DisplayFont>
       <Languages>
+        <Language ID="hro-Latn-VN">Haroi (Latin, Viet Nam)</Language>
         <Language ID="hro-Latn">Haroi (Latin)</Language>
         <Language ID="vi">Vietnamese</Language>
       </Languages>

--- a/release/h/haroi/source/help/haroi.php
+++ b/release/h/haroi/source/help/haroi.php
@@ -9,7 +9,7 @@
 
 
 <p style='margin: 16px 0 0 0'>
-Haroi Keyboard 1.0 is adapted from VNI.
+Haroi Keyboard 1.1 is adapted from VNI.
 </p>
 <p>If square boxes are displayed instead of characters when using this keyboard (and in the keyboard layouts below), please read our <a href="/troubleshooting/#boxes">troubleshooting guide</a>.
 </p>

--- a/release/h/haroi/source/readme.htm
+++ b/release/h/haroi/source/readme.htm
@@ -14,10 +14,10 @@
 <h1>Haroi Keyboard</h1>
 
 <p>
-    Haroi Keyboard 1.0 is adapted from VNI.
+    Haroi Keyboard 1.1 is adapted from VNI.
 </p>
 
-<p>(c) 2019 SIL International</p>
+<p>(c) 2019-2020 SIL International</p>
 
 </body>
 </html>

--- a/release/h/haroi/source/welcome/welcome.htm
+++ b/release/h/haroi/source/welcome/welcome.htm
@@ -15,7 +15,7 @@
 <h1>Start Using Haroi Keyboard</h1>
 
 <p>
-    Haroi Keyboard 1.0 is adapted from VNI.
+    Haroi Keyboard 1.1 is adapted from VNI.
 </p>
 
 <h1>Keyboard Layout</h1>
@@ -139,7 +139,7 @@
  <tr><td style="font-weight: bold; background-color: grey;">u68</td><td>û̆́</td><td>û̆̀</td><td>û̆̉</td><td>û̆̃</td><td>ụ̂̆</td></tr>
  <tr><td style="font-weight: bold; background-color: grey;">u78</td><td>ư̆́</td><td>ư̆̀</td><td>ư̆̉</td><td>ư̆̃</td><td>ự̆</td></tr>
 </tbody></table>
-<p>© 2019 SIL International</p>
+<p>© 2019-2020 SIL International</p>
 
 </body>
 </html>


### PR DESCRIPTION
This PR applies @tim-eves ' fixes which address a user's issue where the Haroi Keyman keyboard is handling NFC vowels, but the Flex application is NFD.

The key sequence `to68ng` should result in `tô̆ng` but Flex was rendering `tô8ng`

* Also added the fully-specified language tag `hro-Latn-VN`.

Tested on Windows 10, Flex 9.0 RC and Keyman Desktop 12.0.64.0 