### PR TITLE
Update burushaski_girminas.kps

### DIFF
--- a/release/b/burushaski_girminas/source/burushaski_girminas.kps
+++ b/release/b/burushaski_girminas/source/burushaski_girminas.kps
@@ -17,8 +17,8 @@
   </StartMenu>
   <Info>
     <Name URL="">Burushaski Girminas</Name>
-    <Copyright URL="">© Quwat K. Sunny</Copyright>
-    <Author URL=""></Author>
+    <Copyright URL="">2018 © Quwat K. Sunny</Copyright>
+    <Author URL="https://www.facebook.com/qsunny">Quwat K. Sunny</Author>
   </Info>
   <Files>
     <File>
@@ -58,9 +58,9 @@
       <ID>burushaski_girminas</ID>
       <Version>1.0</Version>
     <Languages>
-        <Language ID="scl-Latn">Shina (Latin)</Language>
         <Language ID="bsk-Latn">Burushaski (Latin)</Language>
         <Language ID="khw-Latn">Khowar (Latin)</Language>
+       <Language ID="scl-Latn">Shina (Latin)</Language>
       </Languages>
     </Keyboard>
   </Keyboards>


### PR DESCRIPTION
For some reason, the windows task bar shows Shina as the name of the keyboard while the primary language for the keyboard is inteded to be Burushaski. It possiblly was due the order of the languages and I have reordered the languages.