### PR TITLE
Abyssinica SIL 2.000 migration & Doc Fixes

### DIFF
--- a/release/gff/gff_amharic/HISTORY.md
+++ b/release/gff/gff_amharic/HISTORY.md
@@ -1,6 +1,10 @@
 gff_amharic Change History
 ==========================
 
+1.9 (22 Jan 2020)
+-----------------
+* Package migration to Abyssinica SIL 2.000
+
 1.8 (9 Mar 2019)
 ----------------
 * Fix to recognize apostrophe after Salis forms.

--- a/release/gff/gff_amharic/LICENSE.md
+++ b/release/gff/gff_amharic/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 1997-2019 Ge'ez Frontier Foundation
+Copyright (c) 1997-2020 Ge'ez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_amharic/README.md
+++ b/release/gff/gff_amharic/README.md
@@ -21,6 +21,8 @@ Links
 Supported Platforms
 -------------------
  * Windows
+ * macOS
+ * Linux
  * Web
  * Mobile Web
  * iOS

--- a/release/gff/gff_amharic/README.md
+++ b/release/gff/gff_amharic/README.md
@@ -1,9 +1,9 @@
 አማርኛ (Amharic) Keyboard
 =======================
 
-Copyright (C) 1997-2019 Ge'ez Frontier Foundation, SIL International
+Copyright (C) 1997-2020 Ge'ez Frontier Foundation, SIL International
 
-Version 1.8
+Version 1.9
 
 This is an Amharic (amh, አማርኛ) language mnemonic input method.  It requires a font supporting
 Ethiopic script under the Unicode 4.1 standard.

--- a/release/gff/gff_amharic/gff_amharic.kpj
+++ b/release/gff/gff_amharic/gff_amharic.kpj
@@ -12,11 +12,11 @@
       <ID>id_2b4892f370fe6944d5657f8f945d76ee</ID>
       <Filename>gff_amharic.kmn</Filename>
       <Filepath>source\gff_amharic.kmn</Filepath>
-      <FileVersion>1.8</FileVersion>
+      <FileVersion>1.9</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>አማርኛ (Amharic)</Name>
-        <Copyright>© 1997-2019 Ge'ez Frontier Foundation, SIL International</Copyright>
+        <Copyright>© 1997-2020 Ge'ez Frontier Foundation, SIL International</Copyright>
         <Message>This is an Amharic language mnemonic input method for Ethiopic script that requires Unicode 4.1 support.</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Amharic Keyboard</Name>
-        <Copyright>© 1997-2019 Ge'ez Frontier Foundation, SIL International</Copyright>
+        <Copyright>© 1997-2020 Ge'ez Frontier Foundation, SIL International</Copyright>
       </Details>
     </File>
     <File>

--- a/release/gff/gff_amharic/gff_amharic.kpj
+++ b/release/gff/gff_amharic/gff_amharic.kpj
@@ -5,6 +5,7 @@
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -46,7 +47,7 @@
       <ParentFileID>id_2b4892f370fe6944d5657f8f945d76ee</ParentFileID>
     </File>
     <File>
-      <ID>id_7e395e680102cadf911acf98318ad071</ID>
+      <ID>id_aeaf5bd1ab60ff73dd2fe4756d7fc2db</ID>
       <Filename>readme.htm</Filename>
       <Filepath>source\..\..\..\shared\gff\readme.htm</Filepath>
       <FileVersion></FileVersion>
@@ -54,7 +55,7 @@
       <ParentFileID>id_9b33a5106149f49794860303f13f2a50</ParentFileID>
     </File>
     <File>
-      <ID>id_dfa5064ab8f7155af8df3fb96ed63631</ID>
+      <ID>id_4dac821376a66e3dd471d6d4d6c77c7e</ID>
       <Filename>sideimage.bmp</Filename>
       <Filepath>source\..\..\..\shared\gff\sideimage.bmp</Filepath>
       <FileVersion></FileVersion>
@@ -222,14 +223,6 @@
       <ParentFileID>id_9b33a5106149f49794860303f13f2a50</ParentFileID>
     </File>
     <File>
-      <ID>id_035801836ad6ef65fdc136e03ce7396c</ID>
-      <Filename>AbyssinicaSIL-R.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_9b33a5106149f49794860303f13f2a50</ParentFileID>
-    </File>
-    <File>
       <ID>id_1cf609e3b924a25eaff15a4316006dd2</ID>
       <Filename>Brana-Regular.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\Brana-Regular.ttf</Filepath>
@@ -243,6 +236,14 @@
       <Filepath>source\..\build\gff_amharic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
+      <ParentFileID>id_9b33a5106149f49794860303f13f2a50</ParentFileID>
+    </File>
+    <File>
+      <ID>id_4363caa0e944c8464fd764595ad9e5a2</ID>
+      <Filename>AbyssinicaSIL-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_9b33a5106149f49794860303f13f2a50</ParentFileID>
     </File>
   </Files>

--- a/release/gff/gff_amharic/source/gff_amharic.kmn
+++ b/release/gff/gff_amharic/source/gff_amharic.kmn
@@ -4,7 +4,7 @@ c The Ge'ez Frontier Foundation's mnemonic input method for Amharic script on US
 c keyboards for SIL Keyman, compliant with Unicode 4.1 and later.
 c 
 c Keyman        :  http://www.keyman.com/
-c Documentation :  https://help.keyman.com/keyboard/gff_amharic/1.8/gff_amharic.php
+c Documentation :  https://help.keyman.com/keyboard/gff_amharic/1.9/gff_amharic.php
 c Source        :  https://github.com/keymanapp/keyboards/tree/master/release/gff/gff_amharic
 c License       :  https://opensource.org/licenses/MIT
 c Bugs          :  https://github.com/keymanapp/keyboards/issues
@@ -16,7 +16,7 @@ c
 store(&NAME) 'አማርኛ (Amharic)'
 c $keymanonly:store(&MnemonicLayout) "1"
   store(&CapsAlwaysOff) "0"
-store(&COPYRIGHT) '© 1997-2019 Ge' U+0027 'ez Frontier Foundation, SIL International'
+store(&COPYRIGHT) '© 1997-2020 Ge' U+0027 'ez Frontier Foundation, SIL International'
   store(&Message) "This is an Amharic language mnemonic input method for Ethiopic script that requires Unicode 4.1 support."
 store(&WINDOWSLANGUAGES) 'x045E'
 store(&LANGUAGE) 'x045E'
@@ -95,7 +95,7 @@ c =====================End Data Section=========================================
 c =====================Begin Functional Section=================================================
 c 
 store(&LAYOUTFILE) 'gff_amharic.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.8'
+store(&KEYBOARDVERSION) '1.9'
 store(&TARGETS) 'any windows macosx'
 store(&BITMAP) 'gff_amharic.ico'
 

--- a/release/gff/gff_amharic/source/gff_amharic.kps
+++ b/release/gff/gff_amharic/source/gff_amharic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1352.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -201,12 +201,6 @@
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Name>
-      <Description>Font Abyssinica SIL</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
       <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
       <Description>Font Brana</Description>
       <CopyLocation>0</CopyLocation>
@@ -218,14 +212,18 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>አማርኛ (Amharic)</Name>
       <ID>gff_amharic</ID>
       <Version>1.8</Version>
-      <OSKFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</OSKFont>
-      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</DisplayFont>
       <Languages>
         <Language ID="am">am</Language>
       </Languages>

--- a/release/gff/gff_amharic/source/gff_amharic.kps
+++ b/release/gff/gff_amharic/source/gff_amharic.kps
@@ -64,7 +64,7 @@
     <WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite>
     <Name URL="">GFF Amharic Keyboard</Name>
     <Version URL=""></Version>
-    <Copyright URL="">© 1997-2019 Ge'ez Frontier Foundation, SIL International</Copyright>
+    <Copyright URL="">© 1997-2020 Ge'ez Frontier Foundation, SIL International</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author>
   </Info>
   <Files>
@@ -223,7 +223,7 @@
     <Keyboard>
       <Name>አማርኛ (Amharic)</Name>
       <ID>gff_amharic</ID>
-      <Version>1.8</Version>
+      <Version>1.9</Version>
       <Languages>
         <Language ID="am">am</Language>
       </Languages>

--- a/release/gff/gff_amharic/source/help/gff_amharic.php
+++ b/release/gff/gff_amharic/source/help/gff_amharic.php
@@ -1,11 +1,11 @@
 ﻿<?php /*
   Name:             Keyboard_gff_amhamaric
-  Copyright:        Keyboard ©1997-2019 The Ge'ez Frontier Foundation 
+  Copyright:        Keyboard ©1997-2020 The Ge'ez Frontier Foundation 
   Documentation:    
   Description:      
   Create Date:      18 Sep 2009
 
-  Modified Date:    14 Mar 2019
+  Modified Date:    22 Jan 2020
   Authors:          dyacob, mcdurdin, pbaehr
   Related Files:    
   Dependencies:     
@@ -28,7 +28,7 @@ EXTRA;
   require_once('header.php');
 ?>
 
-<p style='margin:0px'>Keyboard &#169; 1997-2019. Ge'ez Frontier Foundation.</p>
+<p style='margin:0px'>Keyboard &#169; 1997-2020. Ge'ez Frontier Foundation.</p>
 
 <br/>
 <a href="#Overview">Overview</a><br/>
@@ -184,6 +184,8 @@ for full details on how to type all Amharic letters, numbers and punctuation.
 <div id="VersionHistory">
 <h3>Version History</h3>
 <dl>
+  <dt>Version 1.9, 22 Jan 2020</dt>
+  <dd>Package migration to Abyssinica SIL 2.000</dd>
   <dt>Version 1.8, 9 Mar 2019</dt>
   <dd>Fix to recognize apostrophe after Salis forms.</dd>
   <dt>Version 1.7, 1 Dec 2018</dt>

--- a/release/gff/gff_amharic/source/welcome.htm
+++ b/release/gff/gff_amharic/source/welcome.htm
@@ -598,7 +598,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>ፈቃድ</h2>
 
-<p>ይህ የታይፕ ሰሌዳ የቅጂ መብት (copyright) አለው © ግዕዝ ፍሮንቲር ድርጅት፣ 1997-2019. በMIT ነፃ ሶፍትዌር ፈቃድ ስር ይከፋፈላል፦</p>
+<p>ይህ የታይፕ ሰሌዳ የቅጂ መብት (copyright) አለው © ግዕዝ ፍሮንቲር ድርጅት፣ 1997-2020. በMIT ነፃ ሶፍትዌር ፈቃድ ስር ይከፋፈላል፦</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_amharic/source/welcome.htm
+++ b/release/gff/gff_amharic/source/welcome.htm
@@ -352,7 +352,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 1997-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 1997-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_blin/HISTORY.md
+++ b/release/gff/gff_blin/HISTORY.md
@@ -1,5 +1,8 @@
 # ብሊን (Blin) Change History
 
+## 2020-01-22 1.4
+* Package migration to Abyssinica SIL 2.000
+
 ## 2019-04-05 1.3
  * New side image added at the recommendation of Tekie Alibekit.
  * Packing uses new shared folder for GFF keyboards.

--- a/release/gff/gff_blin/LICENSE.md
+++ b/release/gff/gff_blin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2019 Ge'ez Frontier Foundation
+Copyright (c) 2009-2020 Ge'ez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_blin/README.md
+++ b/release/gff/gff_blin/README.md
@@ -18,5 +18,5 @@ Links
 Supported Platforms
 -------------------
  * Windows
- * macOs
+ * macOS
  * Linux

--- a/release/gff/gff_blin/README.md
+++ b/release/gff/gff_blin/README.md
@@ -1,9 +1,9 @@
 ብሊን (Blin) Keyboard
 ====================
 
-Copyright (C) 2009-2019 Ge'ez Frontier Foundation
+Copyright (C) 2009-2020 Ge'ez Frontier Foundation
 
-Version 1.3
+Version 1.4
 
 This is a Blin (ብሊን, ISO-639-2 byn) language mnemonic input method.  It requires a font
 supporting Ethiopic script under the Unicode 4.1 standard.

--- a/release/gff/gff_blin/gff_blin.kpj
+++ b/release/gff/gff_blin/gff_blin.kpj
@@ -12,11 +12,11 @@
       <ID>id_eb3530a70ba231dcc2bd509ba34c12db</ID>
       <Filename>gff_blin.kmn</Filename>
       <Filepath>source\gff_blin.kmn</Filepath>
-      <FileVersion>1.3</FileVersion>
+      <FileVersion>1.4</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ብሊን (Blin)</Name>
-        <Copyright>© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>© 2009-2020 Ge'ez Frontier Foundation</Copyright>
         <Message>This is a Blin language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Blin Keyboard</Name>
-        <Copyright>© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>© 2009-2020 Ge'ez Frontier Foundation</Copyright>
       </Details>
     </File>
     <File>

--- a/release/gff/gff_blin/gff_blin.kpj
+++ b/release/gff/gff_blin/gff_blin.kpj
@@ -5,6 +5,7 @@
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -71,14 +72,6 @@
       <ParentFileID>id_3d4bdf200e922dfa84eebc432800ef7f</ParentFileID>
     </File>
     <File>
-      <ID>id_035801836ad6ef65fdc136e03ce7396c</ID>
-      <Filename>AbyssinicaSIL-R.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_3d4bdf200e922dfa84eebc432800ef7f</ParentFileID>
-    </File>
-    <File>
       <ID>id_1cf609e3b924a25eaff15a4316006dd2</ID>
       <Filename>Brana-Regular.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\Brana-Regular.ttf</Filepath>
@@ -108,6 +101,14 @@
       <Filepath>source\sideimage-blin-lady.png</Filepath>
       <FileVersion></FileVersion>
       <FileType>.png</FileType>
+      <ParentFileID>id_3d4bdf200e922dfa84eebc432800ef7f</ParentFileID>
+    </File>
+    <File>
+      <ID>id_4363caa0e944c8464fd764595ad9e5a2</ID>
+      <Filename>AbyssinicaSIL-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_3d4bdf200e922dfa84eebc432800ef7f</ParentFileID>
     </File>
   </Files>

--- a/release/gff/gff_blin/source/gff_blin.kmn
+++ b/release/gff/gff_blin/source/gff_blin.kmn
@@ -4,7 +4,7 @@ c The Ge'ez Frontier Foundation's mnemonic input method for Blin script under Er
 c keyboards for SIL Keyman, compliant with Unicode 4.1 and later.
 c 
 c Keyman        :  http://www.keyman.com/
-c Documentation :  https://help.keyman.com/keyboard/gff_blin/1.2/gff_blin.php
+c Documentation :  https://help.keyman.com/keyboard/gff_blin/1.4/gff_blin.php
 c Source        :  https://github.com/keymanapp/keyboards/gff_blin
 c License       :  https://opensource.org/licenses/MIT
 c Bugs          :  https://github.com/keymanapp/keyboards/issues
@@ -13,10 +13,10 @@ c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
   store(&Version) '9.0'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
   store(&Name) 'ብሊን (Blin)'    
   store(&EthnologueCode) 'byn'
-store(&COPYRIGHT) '© 2009-2019 Ge' U+0027 'ez Frontier Foundation'
+store(&COPYRIGHT) '© 2009-2020 Ge' U+0027 'ez Frontier Foundation'
   store(&Message) 'This is a Blin language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.'
   store(&CapsAlwaysOff) '1'
   store(&HotKey) '[CTRL ALT K_B]'

--- a/release/gff/gff_blin/source/gff_blin.kps
+++ b/release/gff/gff_blin/source/gff_blin.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1352.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -79,12 +79,6 @@
       <FileType>.pdf</FileType>
     </File>
     <File>
-      <Name>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Name>
-      <Description>Font Abyssinica SIL</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
       <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
       <Description>Font Brana Regular</Description>
       <CopyLocation>0</CopyLocation>
@@ -108,14 +102,18 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.png</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ብሊን (Blin)</Name>
       <ID>gff_blin</ID>
       <Version>1.2</Version>
-      <OSKFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</OSKFont>
-      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</DisplayFont>
       <Languages>
         <Language ID="byn-Ethi">Bilin</Language>
       </Languages>

--- a/release/gff/gff_blin/source/gff_blin.kps
+++ b/release/gff/gff_blin/source/gff_blin.kps
@@ -49,7 +49,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">GFF Blin Keyboard</Name>
-    <Copyright URL="">© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+    <Copyright URL="">© 2009-2020 Ge'ez Frontier Foundation</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author>
     <WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite>
   </Info>

--- a/release/gff/gff_blin/source/help/gff_blin.php
+++ b/release/gff/gff_blin/source/help/gff_blin.php
@@ -271,7 +271,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_blin/source/welcome.htm
+++ b/release/gff/gff_blin/source/welcome.htm
@@ -275,7 +275,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_tigrinya_eritrea/HISTORY.md
+++ b/release/gff/gff_tigrinya_eritrea/HISTORY.md
@@ -1,5 +1,8 @@
 # ትግርኛ-ኤርትራ (Tigrinya Keyboard for Eritrean Conventions) Change History
 
+## 2020-01-22 1.3
+* Package migration to Abyssinica SIL 2.000
+
 ## 2019-03-09 1.2
 * Fix to recognize apostrophe after Salis forms.
 * Change "Wx" and transliterated store names to localized names.

--- a/release/gff/gff_tigrinya_eritrea/LICENSE.md
+++ b/release/gff/gff_tigrinya_eritrea/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2019 Ge'ez Frontier Foundation
+Copyright (c) 2009-2020 Ge'ez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_tigrinya_eritrea/README.md
+++ b/release/gff/gff_tigrinya_eritrea/README.md
@@ -1,9 +1,9 @@
 ትግርኛ-ኤርትራ (Tigrinya Keyboard for Eritrean Conventions)
 ========================================================
 
-Copyright (C) 2009-2019 Ge'ez Frontier Foundation
+Copyright (C) 2009-2020 Ge'ez Frontier Foundation
 
-Version 1.2
+Version 1.3
 
 This is a Tigrinya (ti-ER, ትግርኛ-ኤርትራ) language mnemonic input method that applies Eritrean writing conventions.
 It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 

--- a/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.kpj
+++ b/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.kpj
@@ -5,6 +5,7 @@
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -60,14 +61,6 @@
       <Filepath>source\..\build\gff_tigrinya_eritrea.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
-      <ParentFileID>id_62ad26e4e25573d65ca113534aa32a14</ParentFileID>
-    </File>
-    <File>
-      <ID>id_035801836ad6ef65fdc136e03ce7396c</ID>
-      <Filename>AbyssinicaSIL-R.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
       <ParentFileID>id_62ad26e4e25573d65ca113534aa32a14</ParentFileID>
     </File>
     <File>
@@ -236,6 +229,14 @@
       <Filepath>source\sideimage-tir-ER.bmp</Filepath>
       <FileVersion></FileVersion>
       <FileType>.bmp</FileType>
+      <ParentFileID>id_62ad26e4e25573d65ca113534aa32a14</ParentFileID>
+    </File>
+    <File>
+      <ID>id_4363caa0e944c8464fd764595ad9e5a2</ID>
+      <Filename>AbyssinicaSIL-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_62ad26e4e25573d65ca113534aa32a14</ParentFileID>
     </File>
   </Files>

--- a/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.kpj
+++ b/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.kpj
@@ -12,11 +12,11 @@
       <ID>id_6555f64338e6345b1f1d0377adba2259</ID>
       <Filename>gff_tigrinya_eritrea.kmn</Filename>
       <Filepath>source\gff_tigrinya_eritrea.kmn</Filepath>
-      <FileVersion>1.2</FileVersion>
+      <FileVersion>1.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ትግርኛ (Tigrinya)</Name>
-        <Copyright>© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>© 2009-2020 Ge'ez Frontier Foundation</Copyright>
         <Message>This is a Tigrinya language mnemonic input method that applies Eritrean writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Tigrinya-Eritrean Keyboard</Name>
-        <Copyright>2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>2009-2020 Ge'ez Frontier Foundation</Copyright>
       </Details>
     </File>
     <File>

--- a/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kmn
+++ b/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kmn
@@ -4,7 +4,7 @@ c The Ge'ez Frontier Foundation's mnemonic input method for Tigrinya script unde
 c keyboards for SIL Keyman, compliant with Unicode 3.0 and later.
 c 
 c Keyman        :  http://www.keyman.com/
-c Documentation :  https://help.keyman.com/keyboard/gff_tigrinya_eritrea/1.2/gff_tigrinya_eritrea.php
+c Documentation :  https://help.keyman.com/keyboard/gff_tigrinya_eritrea/1.3/gff_tigrinya_eritrea.php
 c Source        :  https://github.com/keymanapp/keyboards/gff_tigrinya_eritrea
 c License       :  https://opensource.org/licenses/MIT
 c Bugs          :  https://github.com/keymanapp/keyboards/issues
@@ -17,9 +17,9 @@ c
 c  store(&EthnologueCode) 'tir'
 c store(&LANGUAGE) 'x0873'
 c store(&WINDOWSLANGUAGES) 'x0873'
-store(&COPYRIGHT) '© 2009-2019 Ge' U+0027 'ez Frontier Foundation'
+store(&COPYRIGHT) '© 2009-2020 Ge' U+0027 'ez Frontier Foundation'
   store(&Message) 'This is a Tigrinya language mnemonic input method that applies Eritrean writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.'
-store(&KEYBOARDVERSION) '1.2'
+store(&KEYBOARDVERSION) '1.3'
   store(&CapsAlwaysOff) '1'
   store(&HotKey) '[CTRL ALT K_T]'
 store(&BITMAP) 'gff_tigrinya_er.ico'

--- a/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
+++ b/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
@@ -56,7 +56,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">GFF Tigrinya-Eritrean Keyboard</Name>
-    <Copyright URL="">2009-2019 Ge'ez Frontier Foundation</Copyright>
+    <Copyright URL="">2009-2020 Ge'ez Frontier Foundation</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author>
     <WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite>
   </Info>
@@ -216,7 +216,7 @@
     <Keyboard>
       <Name>ትግርኛ (Tigrinya)</Name>
       <ID>gff_tigrinya_eritrea</ID>
-      <Version>1.2</Version>
+      <Version>1.3</Version>
       <Languages>
         <Language ID="ti-Ethi-ER">Tigrinya (Ethiopic, Eritrea)</Language>
       </Languages>

--- a/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
+++ b/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1352.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -78,12 +78,6 @@
       <Description>Keyboard Tigrinya</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Name>
-      <Description>Font Abyssinica SIL</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
     </File>
     <File>
       <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
@@ -211,14 +205,18 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.bmp</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ትግርኛ (Tigrinya)</Name>
       <ID>gff_tigrinya_eritrea</ID>
       <Version>1.2</Version>
-      <OSKFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</OSKFont>
-      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</DisplayFont>
       <Languages>
         <Language ID="ti-Ethi-ER">Tigrinya (Ethiopic, Eritrea)</Language>
       </Languages>

--- a/release/gff/gff_tigrinya_eritrea/source/help/gff_tigrinya_eritrea.php
+++ b/release/gff/gff_tigrinya_eritrea/source/help/gff_tigrinya_eritrea.php
@@ -268,7 +268,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_tigrinya_eritrea/source/welcome.htm
+++ b/release/gff/gff_tigrinya_eritrea/source/welcome.htm
@@ -272,7 +272,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_tigrinya_ethiopia/HISTORY.md
+++ b/release/gff/gff_tigrinya_ethiopia/HISTORY.md
@@ -1,5 +1,8 @@
 # ትግርኛ-ኢትዮጵያ (Tigrinya Keyboard for Ethiopian Conventions) Change History
 
+## 2020-01-22 1.3
+* Package migration to Abyssinica SIL 2.000
+
 ## 2019-03-09 1.2
 * Fix to recognize apostrophe after Salis forms.
 * Change "Wx" and transliterated store names to localized names.

--- a/release/gff/gff_tigrinya_ethiopia/LICENSE.md
+++ b/release/gff/gff_tigrinya_ethiopia/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2019 Ge'ez Frontier Foundation
+Copyright (c) 2009-2020 Ge'ez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_tigrinya_ethiopia/README.md
+++ b/release/gff/gff_tigrinya_ethiopia/README.md
@@ -1,9 +1,9 @@
 ትግርኛ-ኢትዮጵያ (Tigrinya Keyboard for Ethiopian Conventions)
 ==========================================================
 
-Copyright (C) 2009-2019 Ge'ez Frontier Foundation
+Copyright (C) 2009-2020 Ge'ez Frontier Foundation
 
-Version 1.2
+Version 1.3
 
 This is a Tigrinya (ti-ET, ትግርኛ-ኢትዮጵያ) language mnemonic input method that applies Ethiopian writing conventions.  It requires
 a font supporting Ethiopic script under the Unicode 3.0 standard. 

--- a/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
+++ b/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
@@ -12,11 +12,11 @@
       <ID>id_15b398ddd59c4ed96532bf79befbb12c</ID>
       <Filename>gff_tigrinya_ethiopia.kmn</Filename>
       <Filepath>source\gff_tigrinya_ethiopia.kmn</Filepath>
-      <FileVersion>1.2</FileVersion>
+      <FileVersion>1.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ትግርኛ (Tigrinya)</Name>
-        <Copyright>© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>© 2009-2020 Ge'ez Frontier Foundation</Copyright>
         <Message>This is a Tigrinya language mnemonic input method that applies Ethiopian writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Tigrinya-Ethiopia Keyboard</Name>
-        <Copyright>© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+        <Copyright>© 2009-2020 Ge'ez Frontier Foundation</Copyright>
       </Details>
     </File>
     <File>

--- a/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
+++ b/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
@@ -5,6 +5,7 @@
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
@@ -199,14 +200,6 @@
       <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
     </File>
     <File>
-      <ID>id_035801836ad6ef65fdc136e03ce7396c</ID>
-      <Filename>AbyssinicaSIL-R.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
-    </File>
-    <File>
       <ID>id_013ca59571c49a6f4a47830a871d79c5</ID>
       <Filename>GNU-GPLv2.txt</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\GNU-GPLv2.txt</Filepath>
@@ -223,9 +216,9 @@
       <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
     </File>
     <File>
-      <ID>id_7e395e680102cadf911acf98318ad071</ID>
+      <ID>id_aeaf5bd1ab60ff73dd2fe4756d7fc2db</ID>
       <Filename>readme.htm</Filename>
-      <Filepath>source\..\..\shared\readme.htm</Filepath>
+      <Filepath>source\..\..\..\shared\gff\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
       <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
@@ -236,6 +229,14 @@
       <Filepath>source\sideimage-tir-ET.png</Filepath>
       <FileVersion></FileVersion>
       <FileType>.png</FileType>
+      <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
+    </File>
+    <File>
+      <ID>id_4363caa0e944c8464fd764595ad9e5a2</ID>
+      <Filename>AbyssinicaSIL-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
     </File>
   </Files>

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kmn
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kmn
@@ -4,7 +4,7 @@ c The Ge'ez Frontier Foundation's mnemonic input method for Tigrinya script unde
 c keyboards for SIL Keyman, compliant with Unicode 3.0 and later.
 c 
 c Keyman        :  http://www.keyman.com/
-c Documentation :  https://help.keyman.com/keyboard/gff_tigrinya_ethiopia/1.2/gff_tigrinya_ethiopia.php
+c Documentation :  https://help.keyman.com/keyboard/gff_tigrinya_ethiopia/1.3/gff_tigrinya_ethiopia.php
 c Source        :  https://github.com/keymanapp/keyboards/gff_tigrinya_ethiopia
 c License       :  https://opensource.org/licenses/MIT
 c Bugs          :  https://github.com/keymanapp/keyboards/issues
@@ -17,9 +17,9 @@ c
 c store(&ETHNOLOGUECODE) 'tir'
 c store(&LANGUAGE) 'x0473'
 c store(&WINDOWSLANGUAGES) 'x0473'
-store(&COPYRIGHT) '© 2009-2019 Ge' U+0027 'ez Frontier Foundation'
+store(&COPYRIGHT) '© 2009-2020 Ge' U+0027 'ez Frontier Foundation'
   store(&Message) 'This is a Tigrinya language mnemonic input method that applies Ethiopian writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.'
-store(&KEYBOARDVERSION) '1.2'
+store(&KEYBOARDVERSION) '1.3'
   store(&CapsAlwaysOff) '1'
   store(&HotKey) '[CTRL ALT K_T]'
 store(&BITMAP) 'gff_tigrinya_et.ico'

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
@@ -56,7 +56,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">GFF Tigrinya-Ethiopia Keyboard</Name>
-    <Copyright URL="">© 2009-2019 Ge'ez Frontier Foundation</Copyright>
+    <Copyright URL="">© 2009-2020 Ge'ez Frontier Foundation</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Ge'ez Frontier Foundation</Author>
     <WebSite URL="http://keyboards.ethiopic.org">http://keyboards.ethiopic.org</WebSite>
   </Info>
@@ -216,7 +216,7 @@
     <Keyboard>
       <Name>ትግርኛ (Tigrinya)</Name>
       <ID>gff_tigrinya_ethiopia</ID>
-      <Version>1.2</Version>
+      <Version>1.3</Version>
       <Languages>
         <Language ID="ti-Ethi-ET">Tigrinya (Ethiopic, Ethiopia)</Language>
       </Languages>

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1352.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -182,12 +182,6 @@
       <FileType>.ttf</FileType>
     </File>
     <File>
-      <Name>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</Name>
-      <Description>Font Abyssinica SIL</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
       <Name>..\..\..\shared\fonts\geez\GNU-GPLv2.txt</Name>
       <Description>File GNU-GPLv2.txt</Description>
       <CopyLocation>0</CopyLocation>
@@ -211,14 +205,18 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.png</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ትግርኛ (Tigrinya)</Name>
       <ID>gff_tigrinya_ethiopia</ID>
       <Version>1.2</Version>
-      <OSKFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</OSKFont>
-      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica_sil\AbyssinicaSIL-R.ttf</DisplayFont>
       <Languages>
         <Language ID="ti-Ethi-ET">Tigrinya (Ethiopic, Ethiopia)</Language>
       </Languages>

--- a/release/gff/gff_tigrinya_ethiopia/source/help/gff_tigrinya_ethiopia.php
+++ b/release/gff/gff_tigrinya_ethiopia/source/help/gff_tigrinya_ethiopia.php
@@ -283,7 +283,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/gff/gff_tigrinya_ethiopia/source/welcome.htm
+++ b/release/gff/gff_tigrinya_ethiopia/source/welcome.htm
@@ -281,7 +281,7 @@ hitting the punctuation key two or more times until it appears.</p>
 
 <h2>License</h2>
 
-<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2019. It is distributed under the MIT free software license:</p>
+<p>This keyboard is copyright © Ge&rsquo;ez Frontier Foundation, 2009-2020. It is distributed under the MIT free software license:</p>
 
 <div style="margin-left: 1em;">
   <table>

--- a/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.keyboard_info
+++ b/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.keyboard_info
@@ -24,7 +24,7 @@
       }
     }
   },
-  "description": "This package provides both a Gurage and Amharic keyboard.",
+  "description": "This package provides both the GFF Gurage and Amharic keyboards.",
  "platformSupport": {
     "windows": "full",
     "macos": "full",


### PR DESCRIPTION
* KPS files point to Abyssinica-Regular.ttf (new) instead of Abyssinica-R.ttf (old)
* Supported OSs that not listed in ReadMe.md files are added.
* Tweak to gff_gurage_amharic package description in keyboard info file