### PR TITLE
chore: add examples to release keyboards from related legacy keyboards

### DIFF
--- a/release/basic/basic_kbdal/basic_kbdal.keyboard_info
+++ b/release/basic/basic_kbdal/basic_kbdal.keyboard_info
@@ -1,10 +1,16 @@
 {
-    "license": "mit",
-    "languages": [
-        "sq",
-        "als-Latn"
-    ],
-	  "description": "This keyboard layout is designed for Albanian.",
+  "license": "mit",
+  "languages": {
+    "sq": {},
+    "als-Latn": {
+      "example": {
+        "keys": "Kor[[;",
+        "text": "Korçë",
+        "note": "A city in southeastern Albania"
+      }
+    }
+  },
+  "description": "This keyboard layout is designed for Albanian.",
   "related": {
     "albanian": {
       "deprecates": true

--- a/release/basic/basic_kbdarme/basic_kbdarme.keyboard_info
+++ b/release/basic/basic_kbdarme/basic_kbdarme.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "hy"
-    ],
-	  "description": "Armenian Eastern Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "hy": {
+      "example": {
+        "keys": "ha3yryn lyzow",
+        "text": "հայերեն լեզու",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Armenian Eastern Basic generated from template",
   "related": {
     "armenian_east": {
       "deprecates": true

--- a/release/basic/basic_kbdarmw/basic_kbdarmw.keyboard_info
+++ b/release/basic/basic_kbdarmw/basic_kbdarmw.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "hy"
-    ],
-	  "description": "Armenian Western Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "hy": {
+      "example": {
+        "keys": "ha3yryn lyzov",
+        "text": "հայերեն լեզու",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Armenian Western Basic generated from template",
   "related": {
     "armenian_west": {
       "deprecates": true

--- a/release/basic/basic_kbdbe/basic_kbdbe.keyboard_info
+++ b/release/basic/basic_kbdbe/basic_kbdbe.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "fr"
-    ],
-	  "description": "Belgian French Basic generated from template. This keyboard matches the following Windows 10 input methods: Belgian French and Belgian (Period).",
+  "license": "mit",
+  "languages": {
+    "fr": {
+      "example": {
+        "keys": "C[[ote d4Or",
+        "text": "Côte d'Or",
+        "note": "Brand of Belgian chocolate"
+      }
+    }
+  },
+  "description": "Belgian French Basic generated from template. This keyboard matches the following Windows 10 input methods: Belgian French and Belgian (Period).",
   "related": {
     "belgian_period": {
       "deprecates": true
@@ -16,4 +22,3 @@
     }
   }
 }
-

--- a/release/basic/basic_kbdbene/basic_kbdbene.keyboard_info
+++ b/release/basic/basic_kbdbene/basic_kbdbene.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "fr"
-    ],
-	  "description": "Belgian (Comma) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "fr": {
+      "example": {
+        "keys": "C[[ote d4Or",
+        "text": "Côte d'Or",
+        "note": "Brand of Belgian chocolate"
+      }
+    }
+  },
+  "description": "Belgian (Comma) Basic generated from template",
   "related": {
     "belgian_comma": {
       "deprecates": true

--- a/release/basic/basic_kbdblr/basic_kbdblr.keyboard_info
+++ b/release/basic/basic_kbdblr/basic_kbdblr.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "be"
-    ],
-	  "description": "Belarusian Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "be": {
+      "example": {
+        "keys": ",tkfhecrfz vjdf",
+        "text": "беларуская мова",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Belarusian Basic generated from template",
   "related": {
     "belarusian": {
       "deprecates": true

--- a/release/basic/basic_kbdbulg/basic_kbdbulg.keyboard_info
+++ b/release/basic/basic_kbdbulg/basic_kbdbulg.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "bg"
-    ],
-	  "description": "Bulgarian Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "bg": {
+      "example": {
+        "keys": "/c.hd,iur epru",
+        "text": "български език",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Bulgarian Basic generated from template",
   "related": {
     "bulgarian": {
       "deprecates": true

--- a/release/basic/basic_kbdca/basic_kbdca.keyboard_info
+++ b/release/basic/basic_kbdca/basic_kbdca.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "fr-CA"
-    ],
-	  "description": "Canadian French Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "fr-CA": {
+      "example": {
+        "keys": "Qu/bec",
+        "text": "Québec",
+        "note": "Province of Canada"
+      }
+    }
+  },
+  "description": "Canadian French Basic generated from template",
   "related": {
     "canadian_french": {
       "deprecates": true

--- a/release/basic/basic_kbdcan/basic_kbdcan.keyboard_info
+++ b/release/basic/basic_kbdcan/basic_kbdcan.keyboard_info
@@ -1,18 +1,25 @@
 {
-    "license": "mit",
-    "languages": {
-      "fr": {
+  "license": "mit",
+  "languages": {
+    "fr": {
       "example": {
         "keys": "Qu/bec",
-        "text": "Qu\u00E9bec",
+        "text": "Québec",
         "note": "Province of Canada"
       }
     },
     "fr-ca": {
+      "example": {
+        "keys": "Qu/bec",
+        "text": "Québec",
+        "note": "Province of Canada"
+      }
     }
   },
-	  "description": "Canadian Multilingual Standard Basic generated from template",
-	  "related": {
-	  "canadian_ms": { "deprecates": true }
-			 }
+  "description": "Canadian Multilingual Standard Basic generated from template",
+  "related": {
+    "canadian_ms": {
+      "deprecates": true
+    }
+  }
 }

--- a/release/basic/basic_kbdcr/basic_kbdcr.keyboard_info
+++ b/release/basic/basic_kbdcr/basic_kbdcr.keyboard_info
@@ -1,9 +1,17 @@
 {
-    "license": "mit",
-    "languages": [
-        "sl", "hr", "bs"
-    ],
-	  "description": "Croatian/Slovenian Basic generated from template. This keyboard matches the following Windows 10 input methods: Croatian and Slovenian.",
+  "license": "mit",
+  "languages": {
+    "sl": {},
+    "hr": {
+      "example": {
+        "keys": "O;e na[[",
+        "text": "Oče naš",
+        "note": "\"Our Father\""
+      }
+    },
+    "bs": {}
+  },
+  "description": "Croatian/Slovenian Basic generated from template. This keyboard matches the following Windows 10 input methods: Croatian and Slovenian.",
   "related": {
     "slovenian": {
       "deprecates": true

--- a/release/basic/basic_kbdcz/basic_kbdcz.keyboard_info
+++ b/release/basic/basic_kbdcz/basic_kbdcz.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "cs"
-    ],
-	  "description": "Czech Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "cs": {
+      "example": {
+        "keys": "4e3tina",
+        "text": "čeština",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Czech Basic generated from template",
   "related": {
     "czech": {
       "deprecates": true

--- a/release/basic/basic_kbdcz1/basic_kbdcz1.keyboard_info
+++ b/release/basic/basic_kbdcz1/basic_kbdcz1.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "cs"
-    ],
-	  "description": "Czech (QWERTY) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "cs": {
+      "example": {
+        "keys": "4e3tina",
+        "text": "čeština",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Czech (QWERTY) Basic generated from template",
   "related": {
     "czech_qwerty": {
       "deprecates": true

--- a/release/basic/basic_kbdcz2/basic_kbdcz2.keyboard_info
+++ b/release/basic/basic_kbdcz2/basic_kbdcz2.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "cs"
-    ],
-	  "description": "Czech Programmers Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "cs": {
+      "example": {
+        "keys": "[CA4]e[CA3]tina",
+        "text": "čeština",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Czech Programmers Basic generated from template",
   "related": {
     "czech_prog": {
       "deprecates": true

--- a/release/basic/basic_kbddv/basic_kbddv.keyboard_info
+++ b/release/basic/basic_kbddv/basic_kbddv.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "en"
-    ],
-	  "description": "United States-Dvorak Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "en": {
+      "example": {
+        "keys": "Kjd xfgiv nos,l ysb",
+        "text": "The quick brown fox",
+        "note": "\"The quick brown fox\""
+      }
+    }
+  },
+  "description": "United States-Dvorak Basic generated from template",
   "related": {
     "dvorak": {
       "deprecates": true

--- a/release/basic/basic_kbdfi1/basic_kbdfi1.keyboard_info
+++ b/release/basic/basic_kbdfi1/basic_kbdfi1.keyboard_info
@@ -1,9 +1,17 @@
 {
-    "license": "mit",
-    "languages": [
-        "se-Latn", "fi", "sv"
-    ],
-	  "description": "Finnish-Swedish with Sami Basic generated from template. This keyboard matches the following Windows 10 input methods: Swedish with Sami and Finnish with Sami.",
+  "license": "mit",
+  "languages": {
+    "se-Latn": {},
+    "fi": {
+      "example": {
+        "keys": "Hyv'' y;t'",
+        "text": "Hyvää yötä",
+        "note": "\"Good night\""
+      }
+    },
+    "sv": {}
+  },
+  "description": "Finnish-Swedish with Sami Basic generated from template. This keyboard matches the following Windows 10 input methods: Swedish with Sami and Finnish with Sami.",
   "related": {
     "kbdfi1": {
       "deprecates": true

--- a/release/basic/basic_kbdfo/basic_kbdfo.keyboard_info
+++ b/release/basic/basic_kbdfo/basic_kbdfo.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "fo"
-    ],
-	  "description": "Faeroese Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "fo": {
+      "example": {
+        "keys": "F'royskt",
+        "text": "Føroyskt",
+        "note": "Name of Language"
+      }
+    }
+  },
+  "description": "Faeroese Basic generated from template",
   "related": {
     "faeroese": {
       "deprecates": true

--- a/release/basic/basic_kbdfr/basic_kbdfr.keyboard_info
+++ b/release/basic/basic_kbdfr/basic_kbdfr.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "fr"
-    ],
-	  "description": "French Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "fr": {
+      "example": {
+        "keys": "Frqn9qis",
+        "text": "Français",
+        "note": "Name of Language"
+      }
+    }
+  },
+  "description": "French Basic generated from template",
   "related": {
     "french": {
       "deprecates": true

--- a/release/basic/basic_kbdgr/basic_kbdgr.keyboard_info
+++ b/release/basic/basic_kbdgr/basic_kbdgr.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "de"
-    ],
-	  "description": "German Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "de": {
+      "example": {
+        "keys": "Schuhgr;-e",
+        "text": "Schuhgröße",
+        "note": "\"Shoe size\""
+      }
+    }
+  },
+  "description": "German Basic generated from template",
   "related": {
     "german": {
       "deprecates": true

--- a/release/basic/basic_kbdhe/basic_kbdhe.keyboard_info
+++ b/release/basic/basic_kbdhe/basic_kbdhe.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "el"
-    ],
-	  "description": "Greek Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "el": {
+      "example": {
+        "keys": "kal;h m;era, ti k;aneiwq",
+        "text": "καλή μέρα, τι κάνεις;",
+        "note": "\"Good morning, how are you?\""
+      }
+    }
+  },
+  "description": "Greek Basic generated from template",
   "related": {
     "greek": {
       "deprecates": true

--- a/release/basic/basic_kbdhe220/basic_kbdhe220.keyboard_info
+++ b/release/basic/basic_kbdhe220/basic_kbdhe220.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "el"
-    ],
-	  "description": "Greek (220) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "el": {
+      "example": {
+        "keys": "kal;h m;era, ti k;aneiwq",
+        "text": "καλή μέρα, τι κάνεις;",
+        "note": "\"Good morning, how are you?\""
+      }
+    }
+  },
+  "description": "Greek (220) Basic generated from template",
   "related": {
     "greek_220": {
       "deprecates": true

--- a/release/basic/basic_kbdhe319/basic_kbdhe319.keyboard_info
+++ b/release/basic/basic_kbdhe319/basic_kbdhe319.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "el"
-    ],
-	  "description": "Greek (319) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "el": {
+      "example": {
+        "keys": "kal;h m;era, ti k;aneiw<",
+        "text": "καλή μέρα, τι κάνεις;",
+        "note": "\"Good morning, how are you?\""
+      }
+    }
+  },
+  "description": "Greek (319) Basic generated from template",
   "related": {
     "greek_319": {
       "deprecates": true

--- a/release/basic/basic_kbdhu1/basic_kbdhu1.keyboard_info
+++ b/release/basic/basic_kbdhu1/basic_kbdhu1.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "hu"
-    ],
-	  "description": "Hungarian 101-key Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "hu": {
+      "example": {
+        "keys": "Pet[[fi S'ndor",
+        "text": "Petőfi Sándor",
+        "note": "\"Petofi Sandor\", Hungarian national poet"
+      }
+    }
+  },
+  "description": "Hungarian 101-key Basic generated from template",
   "related": {
     "hungarian_101": {
       "deprecates": true

--- a/release/basic/basic_kbdinbe2/basic_kbdinbe2.keyboard_info
+++ b/release/basic/basic_kbdinbe2/basic_kbdinbe2.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "bn"
-    ],
-	  "description": "Bengali - INSCRIPT Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "bn": {
+      "example": {
+        "keys": "bexne nfhf",
+        "text": "বাংলা লিপি",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Bengali - INSCRIPT Basic generated from template",
   "related": {
     "bengali_inscript": {
       "deprecates": true

--- a/release/basic/basic_kbdinben/basic_kbdinben.keyboard_info
+++ b/release/basic/basic_kbdinben/basic_kbdinben.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "bn"
-    ],
-	  "description": "Bengali Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "bn": {
+      "example": {
+        "keys": "bexne nfhf",
+        "text": "বাংলা লিপি",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Bengali Basic generated from template",
   "related": {
     "bengali": {
       "deprecates": true
@@ -13,4 +19,3 @@
     }
   }
 }
-

--- a/release/basic/basic_kbdindev/basic_kbdindev.keyboard_info
+++ b/release/basic/basic_kbdindev/basic_kbdindev.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "hi"
-    ],
-	  "description": "Devanagari - INSCRIPT Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "hi": {
+      "example": {
+        "keys": "ufvdor",
+        "text": "हिन्दी",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Devanagari - INSCRIPT Basic generated from template",
   "related": {
     "dev_inscript": {
       "deprecates": true

--- a/release/basic/basic_kbdinguj/basic_kbdinguj.keyboard_info
+++ b/release/basic/basic_kbdinguj/basic_kbdinguj.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "gu"
-    ],
-	  "description": "Gujarati Basic generated from template. This keyboard matches the Inscript layout.",
+  "license": "mit",
+  "languages": {
+    "gu": {
+      "example": {
+        "keys": "igpjelr",
+        "text": "ગુજરાતી",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Gujarati Basic generated from template. This keyboard matches the Inscript layout.",
   "related": {
     "gujarati_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdinhin/basic_kbdinhin.keyboard_info
+++ b/release/basic/basic_kbdinhin/basic_kbdinhin.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "hi"
-    ],
-	  "description": "Hindi Traditional Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "hi": {
+      "example": {
+        "keys": "ufvdor",
+        "text": "हिन्दी",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Hindi Traditional Basic generated from template",
   "related": {
     "hindi_traditional_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdinkan/basic_kbdinkan.keyboard_info
+++ b/release/basic/basic_kbdinkan/basic_kbdinkan.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "kn"
-    ],
-	  "description": "Kannada Basic generated from template. This keyboard follows the Inscript layout.",
+  "license": "mit",
+  "languages": {
+    "kn": {
+      "example": {
+        "keys": "kvdv[[",
+        "text": "ಕನ್ನಡ",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Kannada Basic generated from template. This keyboard follows the Inscript layout.",
   "related": {
     "kannada_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdinmal/basic_kbdinmal.keyboard_info
+++ b/release/basic/basic_kbdinmal/basic_kbdinmal.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "ml"
-    ],
-	  "description": "Malayalam Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "ml": {
+      "example": {
+        "keys": "cn/eNx",
+        "text": "മലയാളം",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Malayalam Basic generated from template",
   "related": {
     "malayalam": {
       "deprecates": true

--- a/release/basic/basic_kbdinmar/basic_kbdinmar.keyboard_info
+++ b/release/basic/basic_kbdinmar/basic_kbdinmar.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "mr"
-    ],
-	  "description": "Marathi Basic generated from template. The default and shift layers of this keyboard are based on the Inscript layout.",
+  "license": "mit",
+  "languages": {
+    "mr": {
+      "example": {
+        "keys": "cje\"r",
+        "text": "मराठी",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Marathi Basic generated from template. The default and shift layers of this keyboard are based on the Inscript layout.",
   "related": {
     "kbdinmar": {
       "deprecates": true

--- a/release/basic/basic_kbdinpun/basic_kbdinpun.keyboard_info
+++ b/release/basic/basic_kbdinpun/basic_kbdinpun.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "pa"
-    ],
-	  "description": "Punjabi Basic generated from template. This keyboard matches the Inscript layout.",
+  "license": "mit",
+  "languages": {
+    "pa": {
+      "example": {
+        "keys": "hxpeyr",
+        "text": "ਪੰਜਾਬੀ",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Punjabi Basic generated from template. This keyboard matches the Inscript layout.",
   "related": {
     "punjabi_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdintam/basic_kbdintam.keyboard_info
+++ b/release/basic/basic_kbdintam/basic_kbdintam.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "ta"
-    ],
-	  "description": "Tamil Basic generated from template. This keyboard is based on the Tamil Inscript Layout.",
+  "license": "mit",
+  "languages": {
+    "ta": {
+      "example": {
+        "keys": "lcfBd",
+        "text": "தமிழ்",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Tamil Basic generated from template. This keyboard is based on the Tamil Inscript Layout.",
   "related": {
     "tamil_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdintel/basic_kbdintel.keyboard_info
+++ b/release/basic/basic_kbdintel/basic_kbdintel.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "te"
-    ],
-	  "description": "Telugu Basic generated from template. This keyboard matches the Inscript layout.",
+  "license": "mit",
+  "languages": {
+    "te": {
+      "example": {
+        "keys": "lzngig",
+        "text": "తెలుగు",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Telugu Basic generated from template. This keyboard matches the Inscript layout.",
   "related": {
     "telegu_kab": {
       "deprecates": true

--- a/release/basic/basic_kbdit/basic_kbdit.keyboard_info
+++ b/release/basic/basic_kbdit/basic_kbdit.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "it"
-    ],
-	  "description": "Italian Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "it": {
+      "example": {
+        "keys": "perch{",
+        "text": "perché",
+        "note": "\"Why\""
+      }
+    }
+  },
+  "description": "Italian Basic generated from template",
   "related": {
     "italian": {
       "deprecates": true

--- a/release/basic/basic_kbdit142/basic_kbdit142.keyboard_info
+++ b/release/basic/basic_kbdit142/basic_kbdit142.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "it"
-    ],
-	  "description": "Italian (142) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "it": {
+      "example": {
+        "keys": "perch{",
+        "text": "perché",
+        "note": "\"Why\""
+      }
+    }
+  },
+  "description": "Italian (142) Basic generated from template",
   "related": {
     "italian_142": {
       "deprecates": true

--- a/release/basic/basic_kbdla/basic_kbdla.keyboard_info
+++ b/release/basic/basic_kbdla/basic_kbdla.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "es"
-    ],
-	  "description": "Latin American Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "es": {
+      "example": {
+        "keys": "Espa;ol",
+        "text": "Español",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Latin American Basic generated from template",
   "related": {
     "latin_american": {
       "deprecates": true

--- a/release/basic/basic_kbdlt/basic_kbdlt.keyboard_info
+++ b/release/basic/basic_kbdlt/basic_kbdlt.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "lt"
-    ],
-	  "description": "Lithuanian IBM Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "lt": {
+      "example": {
+        "keys": "lietuvi; kalba",
+        "text": "lietuvių kalba",
+        "note": "Name of Language"
+      }
+    }
+  },
+  "description": "Lithuanian IBM Basic generated from template",
   "related": {
     "lithuanian_ibm": {
       "deprecates": true

--- a/release/basic/basic_kbdlt1/basic_kbdlt1.keyboard_info
+++ b/release/basic/basic_kbdlt1/basic_kbdlt1.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "lt"
-    ],
-	  "description": "Lithuanian Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "lt": {
+      "example": {
+        "keys": "lietuvi7 kalba",
+        "text": "lietuvių kalba",
+        "note": "Name of Language"
+      }
+    }
+  },
+  "description": "Lithuanian Basic generated from template",
   "related": {
     "lithuanian": {
       "deprecates": true

--- a/release/basic/basic_kbdmacst/basic_kbdmacst.keyboard_info
+++ b/release/basic/basic_kbdmacst/basic_kbdmacst.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "mk"
-    ],
-	  "description": "Macedonian (FYROM) - Standard Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "mk": {
+      "example": {
+        "keys": "makedonski jazik",
+        "text": "македонски јазик",
+        "note": "Name of Language"
+      }
+    }
+  },
+  "description": "Macedonian (FYROM) - Standard Basic generated from template",
   "related": {
     "macedonian_fyro": {
       "deprecates": true

--- a/release/basic/basic_kbdmlt47/basic_kbdmlt47.keyboard_info
+++ b/release/basic/basic_kbdmlt47/basic_kbdmlt47.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "mt"
-    ],
-	  "description": "Maltese 47-Key Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "mt": {
+      "example": {
+        "keys": "i\\-|ieda mat-Tag]rif",
+        "text": "iż-Żieda mat-Tagħrif",
+        "note": "\"Writing in Maltese\" guidebook"
+      }
+    }
+  },
+  "description": "Maltese 47-Key Basic generated from template",
   "related": {
     "maltese_47": {
       "deprecates": true

--- a/release/basic/basic_kbdpl/basic_kbdpl.keyboard_info
+++ b/release/basic/basic_kbdpl/basic_kbdpl.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "pl"
-    ],
-	  "description": "Polish (214) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "pl": {
+      "example": {
+        "keys": "ko]ci\\;",
+        "text": "kościół",
+        "note": "\"Church\""
+      }
+    }
+  },
+  "description": "Polish (214) Basic generated from template",
   "related": {
     "polish": {
       "deprecates": true

--- a/release/basic/basic_kbdru/basic_kbdru.keyboard_info
+++ b/release/basic/basic_kbdru/basic_kbdru.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "ru"
-    ],
-	  "description": "Russian Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "ru": {
+      "example": {
+        "keys": "heccrbq zpsr",
+        "text": "русский язык",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Russian Basic generated from template",
   "related": {
     "russian": {
       "deprecates": true

--- a/release/basic/basic_kbdru1/basic_kbdru1.keyboard_info
+++ b/release/basic/basic_kbdru1/basic_kbdru1.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "ru"
-    ],
-	  "description": "Russian (Typewriter) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "ru": {
+      "example": {
+        "keys": "heccrbq zpsr",
+        "text": "русский язык",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Russian (Typewriter) Basic generated from template",
   "related": {
     "russian_type": {
       "deprecates": true

--- a/release/basic/basic_kbdsf/basic_kbdsf.keyboard_info
+++ b/release/basic/basic_kbdsf/basic_kbdsf.keyboard_info
@@ -1,9 +1,23 @@
 {
-    "license": "mit",
-    "languages": [
-        "fr", "fr-CH", "lb"
-    ],
-	  "description": "Swiss French Basic generated from template. This keyboard matches the following Windows 10 input methods: Luxembourgish and Swiss French.",
+  "license": "mit",
+  "languages": {
+    "fr": {
+      "example": {
+        "keys": "d;jeuner et d=iner",
+        "text": "déjeuner et dîner",
+        "note": "\"Breakfast and lunch\""
+      }
+    },
+    "fr-CH": {
+      "example": {
+        "keys": "d;jeuner et d=iner",
+        "text": "déjeuner et dîner",
+        "note": "\"Breakfast and lunch\""
+      }
+    },
+    "lb": {}
+  },
+  "description": "Swiss French Basic generated from template. This keyboard matches the following Windows 10 input methods: Luxembourgish and Swiss French.",
   "related": {
     "kbdsf": {
       "deprecates": true
@@ -13,4 +27,3 @@
     }
   }
 }
-

--- a/release/basic/basic_kbdsyr1/basic_kbdsyr1.keyboard_info
+++ b/release/basic/basic_kbdsyr1/basic_kbdsyr1.keyboard_info
@@ -1,9 +1,16 @@
 {
-    "license": "mit",
-    "languages": [
-        "cld-Syrc", "syc-Syrc"
-    ],
-	  "description": "Syriac Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "cld-Syrc": {},
+    "syc-Syrc": {
+      "example": {
+        "keys": "gakh s,vddh",
+        "text": "ܠܫܢܐ ܣܘܪܝܝܐ",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Syriac Basic generated from template",
   "related": {
     "syriac": {
       "deprecates": true

--- a/release/basic/basic_kbdsyr2/basic_kbdsyr2.keyboard_info
+++ b/release/basic/basic_kbdsyr2/basic_kbdsyr2.keyboard_info
@@ -1,9 +1,16 @@
 {
-    "license": "mit",
-    "languages": [
-        "cld-Syrc", "syc-Syrc"
-    ],
-	  "description": "Syriac Phonetic Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "cld-Syrc": {},
+    "syc-Syrc": {
+      "example": {
+        "keys": "lvna swryya",
+        "text": "ܠܫܢܐ ܣܘܪܝܝܐ",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Syriac Phonetic Basic generated from template",
   "related": {
     "syriac_phon": {
       "deprecates": true

--- a/release/basic/basic_kbdth0/basic_kbdth0.keyboard_info
+++ b/release/basic/basic_kbdth0/basic_kbdth0.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "th"
-    ],
-	  "description": "Thai Kedmanee Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "th": {
+      "example": {
+        "keys": "4kKkwmp",
+        "text": "ภาษาไทย",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Thai Kedmanee Basic generated from template",
   "related": {
     "thai_kedmanee": {
       "deprecates": true

--- a/release/basic/basic_kbdth1/basic_kbdth1.keyboard_info
+++ b/release/basic/basic_kbdth1/basic_kbdth1.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "th"
-    ],
-	  "description": "Thai Pattachote Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "th": {
+      "example": {
+        "keys": "VjTj;se",
+        "text": "ภาษาไทย",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Thai Pattachote Basic generated from template",
   "related": {
     "thai_pattachote": {
       "deprecates": true

--- a/release/basic/basic_kbdth2/basic_kbdth2.keyboard_info
+++ b/release/basic/basic_kbdth2/basic_kbdth2.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "th"
-    ],
-	  "description": "Thai Kedmanee (non-ShiftLock) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "th": {
+      "example": {
+        "keys": "4kKkwmp",
+        "text": "ภาษาไทย",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Thai Kedmanee (non-ShiftLock) Basic generated from template",
   "related": {
     "thai_kedmanee_nsl": {
       "deprecates": true

--- a/release/basic/basic_kbdth3/basic_kbdth3.keyboard_info
+++ b/release/basic/basic_kbdth3/basic_kbdth3.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "th"
-    ],
-	  "description": "Thai Pattachote (non-ShiftLock) Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "th": {
+      "example": {
+        "keys": "VjTj;se",
+        "text": "ภาษาไทย",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "Thai Pattachote (non-ShiftLock) Basic generated from template",
   "related": {
     "thai_pattachote_nsl": {
       "deprecates": true

--- a/release/basic/basic_kbduk/basic_kbduk.keyboard_info
+++ b/release/basic/basic_kbduk/basic_kbduk.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "en"
-    ],
-	  "description": "United Kingdom Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "en": {
+      "example": {
+        "keys": "The quick brown fox",
+        "text": "The quick brown fox",
+        "note": "\"The quick brown fox\""
+      }
+    }
+  },
+  "description": "United Kingdom Basic generated from template",
   "related": {
     "uk": {
       "deprecates": true

--- a/release/basic/basic_kbdus/basic_kbdus.keyboard_info
+++ b/release/basic/basic_kbdus/basic_kbdus.keyboard_info
@@ -1,31 +1,41 @@
 {
-    "license": "mit",
-    "languages": [
-        "en",
-        "bg-Latn",
-        "id",
-        "io-Latn",
-        "ia-Latn",
-        "zlm-Latn",
-        "ms",
-        "bi-Latn",
-        "gil-Latn",
-        "ht",
-        "mwl-Latn",
-        "blc-Latn",
-        "roo-Latn",
-        "so",
-        "sw",
-        "tl",
-        "ty-Latn",
-        "to",
-        "uli-Latn",
-        "uz-Latn",
-        "yap-Latn"
-    ],
-	  "description": "This keyboard is designed for the English language. It will also be useful for other languages that do not require special characters. This keyboard matches the following Windows 10 input methods: Chinese (Traditional) - US, US, Chinese (Simplified) - US, Chinese (Traditional, Hong Kong S.A.R.) - US, Chinese (Simplified, Singapore) - US, Chinese (Traditional, Macao S.A.R.) - US, Bulgarian (Latin).",
-    "related": {
-      "kbdus": { "deprecates": true },
-      "us": { "deprecates": true }    
+  "license": "mit",
+  "languages": {
+    "en": {
+      "example": {
+        "keys": "The quick brown fox",
+        "text": "The quick brown fox",
+        "note": "\"The quick brown fox\""
+      }
+    },
+    "bg-Latn": {},
+    "id": {},
+    "io-Latn": {},
+    "ia-Latn": {},
+    "zlm-Latn": {},
+    "ms": {},
+    "bi-Latn": {},
+    "gil-Latn": {},
+    "ht": {},
+    "mwl-Latn": {},
+    "blc-Latn": {},
+    "roo-Latn": {},
+    "so": {},
+    "sw": {},
+    "tl": {},
+    "ty-Latn": {},
+    "to": {},
+    "uli-Latn": {},
+    "uz-Latn": {},
+    "yap-Latn": {}
+  },
+  "description": "This keyboard is designed for the English language. It will also be useful for other languages that do not require special characters. This keyboard matches the following Windows 10 input methods: Chinese (Traditional) - US, US, Chinese (Simplified) - US, Chinese (Traditional, Hong Kong S.A.R.) - US, Chinese (Simplified, Singapore) - US, Chinese (Traditional, Macao S.A.R.) - US, Bulgarian (Latin).",
+  "related": {
+    "kbdus": {
+      "deprecates": true
+    },
+    "us": {
+      "deprecates": true
     }
+  }
 }

--- a/release/basic/basic_kbdusl/basic_kbdusl.keyboard_info
+++ b/release/basic/basic_kbdusl/basic_kbdusl.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "en"
-    ],
-	  "description": "United States-Dvorak for left hand Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "en": {
+      "example": {
+        "keys": "Ghj wtmds eyibn 5ix",
+        "text": "The quick brown fox",
+        "note": "\"The quick brown fox\""
+      }
+    }
+  },
+  "description": "United States-Dvorak for left hand Basic generated from template",
   "related": {
     "us_dvorak_lh": {
       "deprecates": true

--- a/release/basic/basic_kbdusr/basic_kbdusr.keyboard_info
+++ b/release/basic/basic_kbdusr/basic_kbdusr.keyboard_info
@@ -1,9 +1,15 @@
 {
-    "license": "mit",
-    "languages": [
-        "en"
-    ],
-	  "description": "United States-Dvorak for right hand Basic generated from template",
+  "license": "mit",
+  "languages": {
+    "en": {
+      "example": {
+        "keys": "Jhg eibl; pytmn 8tc",
+        "text": "The quick brown fox",
+        "note": "\"The quick brown fox\""
+      }
+    }
+  },
+  "description": "United States-Dvorak for right hand Basic generated from template",
   "related": {
     "us_dvorak_rh": {
       "deprecates": true

--- a/release/g/galaxie_greek_positional/galaxie_greek_positional.keyboard_info
+++ b/release/g/galaxie_greek_positional/galaxie_greek_positional.keyboard_info
@@ -1,12 +1,28 @@
 {
-    "license": "mit",
-    "languages": [
-        "grc-Grek",
-        "el"
-    ],
-    "description": "This keyboard layout is designed for Koine Greek, a trade language of the ancient Mediterranean and the language of the New Testament and Septuagint Scriptures.",
-    "related": {
-      "galaxiegreekandhebrew": { "deprecates": true },
-      "galaxiegreekkm6": { "deprecates": true }
+  "license": "mit",
+  "languages": {
+    "grc-Grek": {
+      "example": {
+        "keys": "e]davkrusen o[[ I]hsou~s ",
+        "text": "ἐδάκρυσεν ὁ Ἰησοῦς ",
+        "note": "\"Jesus wept\", John 11:35; note final sigma entered using s then spacebar"
+      }
+    },
+    "el": {
+      "example": {
+        "keys": "edakrusen o Ihsous ",
+        "text": "εδακρυσεν ο Ιησους ",
+        "note": "\"Jesus wept\", John 11:35; note final sigma entered using s then spacebar"
+      }
     }
+  },
+  "description": "This keyboard layout is designed for Koine Greek, a trade language of the ancient Mediterranean and the language of the New Testament and Septuagint Scriptures.",
+  "related": {
+    "galaxiegreekandhebrew": {
+      "deprecates": true
+    },
+    "galaxiegreekkm6": {
+      "deprecates": true
+    }
+  }
 }

--- a/release/g/galaxie_hebrew_positional/galaxie_hebrew_positional.keyboard_info
+++ b/release/g/galaxie_hebrew_positional/galaxie_hebrew_positional.keyboard_info
@@ -1,9 +1,22 @@
 {
-    "license": "mit",
-    "languages": ["hbo-Hebr","he"],
-    "description": "This keyboard is designed for Biblical Hebrew, a Semitic language of the ancient Near East and the language of the Hebrew Bible",
-    "related": {
-      "galaxiegreekandhebrew": { "deprecates": true },
-      "galaxiehebrewkm6": { "deprecates": true }
+  "license": "mit",
+  "languages": {
+    "hbo-Hebr": {
+      "example": {
+        "keys": "b\\=r@av!yt",
+        "text": "בְּרֵאשִׁית",
+        "note": "\"In the beginning\" or \"Genesis\""
+      }
+    },
+    "he": {}
+  },
+  "description": "This keyboard is designed for Biblical Hebrew, a Semitic language of the ancient Near East and the language of the Hebrew Bible",
+  "related": {
+    "galaxiegreekandhebrew": {
+      "deprecates": true
+    },
+    "galaxiehebrewkm6": {
+      "deprecates": true
     }
+  }
 }

--- a/release/gff/gff_blin/gff_blin.keyboard_info
+++ b/release/gff/gff_blin/gff_blin.keyboard_info
@@ -1,15 +1,21 @@
 {
-	"license": "mit",
-	"languages": {
-		"byn-Ethi": {}
-	},
-	"description": "An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.",
-	"related": {
-		"gff-byn-powerpack-7": {
-			"deprecates": true
-		},
-		"gff_byn_7": {
-			"deprecates": true
-		}
-	}
+  "license": "mit",
+  "languages": {
+    "byn-Ethi": {
+      "example": {
+        "keys": "blina",
+        "text": "ብሊና",
+        "note": "Name of language"
+      }
+    }
+  },
+  "description": "An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.",
+  "related": {
+    "gff-byn-powerpack-7": {
+      "deprecates": true
+    },
+    "gff_byn_7": {
+      "deprecates": true
+    }
+  }
 }

--- a/release/s/sabdalipi_assamese/sabdalipi_assamese.keyboard_info
+++ b/release/s/sabdalipi_assamese/sabdalipi_assamese.keyboard_info
@@ -1,9 +1,21 @@
 {
-    "license": "mit",
-    "languages": ["as-IN"],
-    "description": "This keyboard is designed for the Assamese language. It is a phonetic keyboard, which means the characters are arranged according to the letters of the English keyboard.",
-    "related": {
-      "sabdalipiunicode": { "deprecates": true },
-      "sabdalipi assamese": { "deprecates": true }
+  "license": "mit",
+  "languages": {
+    "as-IN": {
+      "example": {
+        "keys": "AsmExa",
+        "text": "অসমীয়া",
+        "note": "Name of language"
+      }
     }
+  },
+  "description": "This keyboard is designed for the Assamese language. It is a phonetic keyboard, which means the characters are arranged according to the letters of the English keyboard.",
+  "related": {
+    "sabdalipiunicode": {
+      "deprecates": true
+    },
+    "sabdalipi assamese": {
+      "deprecates": true
+    }
+  }
 }

--- a/release/t/tibetan_direct_input/tibetan_direct_input.keyboard_info
+++ b/release/t/tibetan_direct_input/tibetan_direct_input.keyboard_info
@@ -12,6 +12,11 @@
           "DDC_Uchen.ttf",
           "ddc_uchen-webfont.svg#ddc_uchenregular"
         ]
+      },
+      "example": {
+        "keys": "rJ*o, [[",
+        "text": "རྫོང་ཁ",
+        "note": "Name of language"
       }
     },
     "bo-Tibt": {
@@ -28,7 +33,7 @@
       },
       "example": {
         "keys": "bod sa  +k da ",
-        "text": "\u0F56\u0F7C\u0F51\u0F0B\u0F66\u0F90\u0F51",
+        "text": "བོད་སྐད",
         "note": "Name of language"
       }
     },
@@ -370,7 +375,7 @@
         ]
       }
     },
-        "zau-Tibt": {    },
+    "zau-Tibt": {},
     "tsj": {
       "font": {
         "family": "TibetanWeb",
@@ -398,10 +403,16 @@
       }
     }
   },
-    "description": "Tibetan Direct Input is designed to type all Tibetan characters and stacks directly, without any Alt or transliteration+Space combinations. The keyboard types in a phonetic style based on the English (QWERTY) layout.",
-    "related": {
-      "tibetan_unicode_direct_input": { "deprecates": true },
-      "tibetan_direct_unicode": { "deprecates": true },
-      "tibetan unicode direct input": { "deprecates": true }
-   }
+  "description": "Tibetan Direct Input is designed to type all Tibetan characters and stacks directly, without any Alt or transliteration+Space combinations. The keyboard types in a phonetic style based on the English (QWERTY) layout.",
+  "related": {
+    "tibetan_unicode_direct_input": {
+      "deprecates": true
+    },
+    "tibetan_direct_unicode": {
+      "deprecates": true
+    },
+    "tibetan unicode direct input": {
+      "deprecates": true
+    }
+  }
 }

--- a/tools/fixups/.gitignore
+++ b/tools/fixups/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+fixupExamples.js

--- a/tools/fixups/fixupExamples.ts
+++ b/tools/fixups/fixupExamples.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+
+const rootPath = 'c:\\projects\\keyman\\keyboards\\';
+
+function stripBom(s: string): string {
+    if(s.startsWith('\uFEFF')) return s.substr(1);
+    return s;
+}
+
+function keyboardInfoFilename(dir: string, name: string) {
+    return dir + '\\' + name + '.keyboard_info';
+}
+
+function loadKeyboardInfo(dir: string, name: string) {
+    return JSON.parse(stripBom(fs.readFileSync(keyboardInfoFilename(dir, name), 'utf8')));
+}
+
+function transformLanguagesToObject(o) {
+    let result = {};
+    for(let lang in o) {
+        result[o[lang]] = {};
+    }
+    return result;
+}
+
+function mapExamples(oki, nki) {
+    if(!oki.languages || !nki.languages) return null;
+
+    let found: Boolean = false;
+
+    //console.log(nki.languages);
+
+    if(Array.isArray(nki.languages)) {
+        nki.languages = transformLanguagesToObject(nki.languages);
+    }
+    if(Array.isArray(oki.languages)) {
+        oki.languages = transformLanguagesToObject(oki.languages);
+    }
+
+    //console.log(nki.languages);
+
+    for(let lang in nki.languages) {
+        console.log('Found language '+lang);
+        if(nki.languages[lang].example) {
+            console.log('Language '+lang+' already has an example.');
+            continue;
+        }
+
+        let lang0 = lang.replace(/-.+$/, '') ;
+        console.log('Looking for '+lang0+' in legacy');
+        if(oki.languages[lang0] && oki.languages[lang0].example) {
+            nki.languages[lang].example = oki.languages[lang0].example;
+            console.log('Found example for '+lang0+', assigning to '+lang0+'!');
+            found = true;
+        }
+    }
+    return found ? nki : null;
+}
+
+function processKeyboard(dir: string, name: string) {
+    console.log(name);
+    let keyboard_info = loadKeyboardInfo(dir, name);
+    if(keyboard_info.related) {
+        for(let related in keyboard_info.related) {
+            if(keyboard_info.related[related].deprecates) {
+                if(legacy[related]) {
+                    console.log('  Found deprecated keyboard at '+related+' at '+legacy[related]);
+                    let legacy_keyboard_info = loadKeyboardInfo(legacy[related], related);                    
+                    let new_keyboard_info = mapExamples(legacy_keyboard_info, keyboard_info);
+                    if(new_keyboard_info) {
+                        fs.writeFileSync(keyboardInfoFilename(dir, name), JSON.stringify(new_keyboard_info, null, 2), 'utf8');
+                        return true;
+                        /*console.log(JSON.stringify(keyboard_info, null, 2));
+                        console.log(JSON.stringify(legacy_keyboard_info, null, 2));
+                        console.log('--- mapped to ---');
+                        console.log(JSON.stringify(new_keyboard_info, null, 2));*/
+                        //process.exit(0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+function processRepo(base) {
+    let result = {};
+    let root = rootPath + base;
+    let rdir = fs.opendirSync(root);
+    let entry;
+    
+    while((entry = rdir.readSync()) != null) {
+        if(entry.name == '.' || entry.name == '..') continue;
+        if(entry.isFile()) continue;
+        if(entry.name == 'shared' || entry.name == 'packages') continue;
+        
+        let edir = fs.opendirSync(root + '\\' + entry.name);
+        let kbddir;
+        while((kbddir = edir.readSync()) != null) {
+            if(kbddir.name == '.' || kbddir.name == '..') continue;
+            if(kbddir.isFile()) continue;
+            result[kbddir.name] = root + '\\' + entry.name + '\\' + kbddir.name;
+        }
+    }
+    return result;
+}
+
+let release = processRepo('release');
+let legacy = processRepo('legacy');
+
+//processKeyboard(rootPath + 'release\\basic\\basic_kbdal', 'basic_kbdal');
+
+for(let rk in release) {
+    processKeyboard(release[rk], rk);
+    //console.log(rk + ": " + release[rk]);
+}

--- a/tools/fixups/package-lock.json
+++ b/tools/fixups/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "fixups",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+    }
+  }
+}

--- a/tools/fixups/package.json
+++ b/tools/fixups/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fixups",
+  "version": "1.0.0",
+  "description": "",
+  "main": "fixupExamples.js",
+  "scripts": {
+    "test": "npm run build && node fixupExamples.js",
+    "build": "tsc fixupExamples.ts"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "typescript": "^3.7.5"
+  },
+  "devDependencies": {
+    "@types/node": "^13.7.0"
+  }
+}


### PR DESCRIPTION
Fixes #1006.

This adds examples to .keyboard_info files for release keyboards that replace legacy keyboards. The changes were automatically generated by script, and ignore all subtags of the bcp47 code (apart from the basic language subtag) in making the matches. (No other language tag transform was done -- so if there were e.g. ISO639-3 -> ISO639-1 transforms, they'll have been missed. Also, where a keyboard was associated with the wrong language, no example will be included.)

The code for parsing and making the transform is included in tools/fixups/ in the hope it could be used in future for other such batch jobs.

Note: in reviewing, you might want to select 'Ignore whitespace changes' under the settings cog!