### PR TITLE
[fv_all] Add JS keyboards to FirstVoices keyboard package

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.2 (9 Apr 2020)
+* Add touch layout keyboards
+
 ## 12.1 (3 Apr 2020)
 * Added fv_haisla
 

--- a/release/packages/fv_all/README.md
+++ b/release/packages/fv_all/README.md
@@ -7,7 +7,7 @@ Version 12.1
 
 __DESCRIPTION__
 
-This package includes all the FirstVoices keyboards for Windows. It is distributed as part of the FirstVoices project.
+This package includes all the FirstVoices keyboards for Windows, Android, and iOS. It is distributed as part of the FirstVoices project.
 
 Note that the package will not be listed under the languages included in the package on keyman.com, as we have 
 excluded them from the .keyboard_info. This is intentional: the package is included as a convenience for the distribution
@@ -17,5 +17,7 @@ Supported Platforms
 -------------------
  * Windows
  * macOS
+ * Android
+ * iOS
 
 

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# This script builds a single keyboard package for the FirstVoices app.
 set -e
 set -u
 
@@ -44,19 +44,22 @@ for key in "$@"; do
   fi
 done
 
-# For each keyboard in the fv/ folder, if a .kmx exists, add it to the package source file, reading the requisite keyboard name and version from the .kps file
+# For each keyboard in the following folders:
+# fv/*, inuktitut_*, sil_euro_latin, and basic_kbdcan
+# If a .kmx or .js exists, add it to the package source file, reading the requisite keyboard name and version from the .kps file
 # The fonts which are shared across the packages are already listed in fv_all.kps.in.
 # If fonts need changing, manually update the file.
 
 FILE_LINES=
 KEYBOARD_LINES=
 
-for keyboard in ../../fv/*/ ; do
+for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../../basic/basic_kbdcan/ ; do
   id=$(basename "$keyboard")
+  group=$(basename $(dirname $keyboard))
+
+  # Only interested in keyboards with a .kmx / .js
   
-  # Only interested in keyboards with a .kmx
-  
-  if [[ ! -f $keyboard/build/$id.kmx ]]; then continue; fi
+  if [[ ! -f $keyboard/build/$id.kmx ]] && [[ ! -f $keyboard/build/$id.js ]]; then continue; fi
 
   echo "Extracting $id"
   
@@ -69,16 +72,27 @@ for keyboard in ../../fv/*/ ; do
   langname=${kpsdata[3]}
   
   # Build a file entry
-  
-  FILE_LINES_0='
-    <File>
-      <Name>..\..\..\fv\'"$id"'\build\'"$id"'.kmx</Name>
-      <Description>File '"$id"'.kmx</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.kmx</FileType>
-    </File>'
-
-  FILE_LINES="$FILE_LINES$FILE_LINES_0"
+  FILE_LINES_0=''
+  FILE_LINES_1=''
+  if [ -f $keyboard/build/$id.kmx ]; then
+    FILE_LINES_0='
+      <File>
+        <Name>..\..\..\'"$group"'\'"$id"'\build\'"$id"'.kmx</Name>
+        <Description>File '"$id"'.kmx</Description>
+        <CopyLocation>0</CopyLocation>
+        <FileType>.kmx</FileType>
+      </File>'
+  fi
+  if [ -f $keyboard/build/$id.js ]; then
+    FILE_LINES_1='
+      <File>
+        <Name>..\..\..\'"$group"'\'"$id"'\build\'"$id"'.js</Name>
+        <Description>File '"$id"'.js</Description>
+        <CopyLocation>0</CopyLocation>
+        <FileType>.js</FileType>
+      </File>'
+  fi
+  FILE_LINES="$FILE_LINES$FILE_LINES_0$FILE_LINES_1"
   
   # Build a keyboard entry
     

--- a/release/packages/fv_all/fv_all.keyboard_info
+++ b/release/packages/fv_all/fv_all.keyboard_info
@@ -1,5 +1,5 @@
 {
     "license": "mit",
     "languages": [],
-    "description": "This package includes FirstVoices keyboards for Windows. It is distributed as part of the FirstVoices project"
+    "description": "This package includes FirstVoices keyboards for Windows, Android, and iOS. It is distributed as part of the FirstVoices project"
 }


### PR DESCRIPTION
Currently, fv_all/build.sh gathers First Voices .kmx keyboards into a single package.
For Keyman 14, the mobile apps will be dealing strictly with .kmp keyboard packages.

This PR updates the build.sh script to also include touch layout keyboards needed for the mobile First Voices app.