### PR TITLE
[khmer_angkor] Add Mondulkiri font to keyboard_info

### DIFF
--- a/release/k/khmer_angkor/khmer_angkor.keyboard_info
+++ b/release/k/khmer_angkor/khmer_angkor.keyboard_info
@@ -1,10 +1,20 @@
 {
-    "license": "mit",
-    "languages": [
-        "km"
-    ],
-	"description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.</p>",
-    "related": {
-      "khmer10": { "deprecates": true }
+  "license": "mit",
+  "languages": {
+    "km": {
+      "font": {
+        "family": "Mondulkiri",
+        "source": [
+          "Mondulkiri-R.ttf"
+        ]
+      }
     }
+  },
+  "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.</p>",
+  "related": {
+    "khmer10": { 
+      "deprecates": true 
+    }
+  }
 }
+


### PR DESCRIPTION
Addresses keymanapp/keyman#2977

The OSK for khmer_angkor isn't rendering on older Android devices.
The keyboard package includes the Mondulkiri font, but the cloud server doesn't deliver it.
See also keymanapp/s.keyman.com#20

This updates the keyboard_info file to associate the Mondulriki font.