### PR TITLE
[bod] Take 3 - Adding packageFilename to keyboard_info

### DIFF
--- a/legacy/b/bod/bod.keyboard_info
+++ b/legacy/b/bod/bod.keyboard_info
@@ -2,6 +2,7 @@
   "id": "bod",
   "name": "Bod",
   "jsFilename": "bod.js",
+  "packageFilename" : "bod.kmp",
   "platformSupport": {
     "desktopWeb": "full",
     "ios": "full",
@@ -21,5 +22,5 @@
       }
     }
   },
-  "lastModifiedDate": "2015-02-16T07:34:55Z"
+  "lastModifiedDate": "2020-04-24"
 }

--- a/legacy/b/bod_transliterating/bod_transliterating.keyboard_info
+++ b/legacy/b/bod_transliterating/bod_transliterating.keyboard_info
@@ -2,6 +2,7 @@
   "id": "bod_transliterating",
   "name": "Bod Transliterating",
   "jsFilename": "bod_transliterating.js",
+  "packageFilename" : "bod_transliterating.kmp",
   "platformSupport": {
     "desktopWeb": "full",
     "ios": "full",
@@ -21,5 +22,5 @@
       }
     }
   },
-  "lastModifiedDate": "2015-02-16T07:34:55Z"
+  "lastModifiedDate": "2020-04-24"
 }


### PR DESCRIPTION
Documentation (https://help.keyman.com/developer/cloud/keyboard_info/1.0/) indicates this is necessary for packages in the legacy folder:
> string, filename of the .kmp file that will be distributed, relative to the keyboard base folder, including extension, required for experimental/ and legacy/ folders. If no .kmp exists, then keyboard is js only. For release/ folders, this must be id/build/id.kmp.