### PR TITLE
[gff_amharic] Fix welcome.htm for Linux

### DIFF
--- a/release/gff/gff_amharic/source/welcome.htm
+++ b/release/gff/gff_amharic/source/welcome.htm
@@ -1,8 +1,5 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+﻿<html>
 <head>
-  <!-- meta http-equiv="content-type" content="application/xhtml+xml; charset=utf-8"/ -->
   <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
   <title>The Ge&rsquo;ez Frontier Foundation Keyboard for Amharic (አማርኛ) Language</title>
 
@@ -62,8 +59,8 @@ table.zaima th { text-align: center; background-color: #d7d0b9 }
 table.zaima { border-bottom: hidden }
 table.zaima { empty-cells: show }
 .tabs{
-    // width: 600px;
-    // display: block;
+    /* width: 600px; */
+    /* display: block; */
     margin: 40px auto;
     position: relative;
 }
@@ -93,15 +90,15 @@ table.zaima { empty-cells: show }
 .tabs .content {
     z-index: 0;/* or display: none; */
     overflow: hidden;
-    // width: 600px;
+    /* width: 600px; */
     padding: 25px;
     position: absolute;
     top: 27px;
     left: 0;
-    // background: #303030;
-    // color: #DFDFDF;
+    /* background: #303030; */
+    /* color: #DFDFDF; */
     border: solid black 1px;
-    
+
     opacity:0;
     transition: opacity 400ms ease-out;
 }


### PR DESCRIPTION
Webkit2 seems to have problems displaying XHTML - or at least this
page. This change allows to show `welcome.htm` on Linux.