### PR TITLE
[nrc_crk_cans] fix Y final; add rare nwV syllabics

### DIFF
--- a/release/nrc/nrc_crk_cans/HISTORY.md
+++ b/release/nrc/nrc_crk_cans/HISTORY.md
@@ -1,6 +1,13 @@
 nrc_crk_cans Keyboard Change History
 ====================================
 
+1.2.0 (24 Jun 2020)
+-------------------
+
+ * Added: rare nwV syllabics, found in the `Unified Canadian Aboriginal Syllabics Extended` block of Unicode
+ * Change: use U+1429 CANADIAN SYLLABICS FINAL PLUS instead of U+1540 CANADIAN SYLLABICS WEST-CREE Y
+    - despite the name, the former is _not_ preferred by West Cree syllabics writers
+
 1.1.0 (30 Mar 2020)
 -------------------
 

--- a/release/nrc/nrc_crk_cans/nrc_crk_cans.kpj
+++ b/release/nrc/nrc_crk_cans/nrc_crk_cans.kpj
@@ -12,7 +12,7 @@
       <ID>id_cf34c0681ea36a07f10a7a73721b7d30</ID>
       <Filename>nrc_crk_cans.kmn</Filename>
       <Filepath>source\nrc_crk_cans.kmn</Filepath>
-      <FileVersion>1.1.0</FileVersion>
+      <FileVersion>1.2.0</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Cree Syllabics</Name>
@@ -79,19 +79,19 @@
       <ParentFileID>id_42283670a0f70443682146e342beda3a</ParentFileID>
     </File>
     <File>
-      <ID>id_1bfed3cf5d900ff0f0334758e6d8586c</ID>
-      <Filename>layout-numeric.jpg</Filename>
-      <Filepath>source\welcome\layout-numeric.jpg</Filepath>
+      <ID>id_ed4990a3fdaf6bf75c1b6a46458643fe</ID>
+      <Filename>layout-numeric.png</Filename>
+      <Filepath>source\welcome\layout-numeric.png</Filepath>
       <FileVersion></FileVersion>
-      <FileType>.jpg</FileType>
+      <FileType>.png</FileType>
       <ParentFileID>id_42283670a0f70443682146e342beda3a</ParentFileID>
     </File>
     <File>
-      <ID>id_3fcfdbf67a2e27b971382a366ef1add3</ID>
-      <Filename>layout-punctuation.jpg</Filename>
-      <Filepath>source\welcome\layout-punctuation.jpg</Filepath>
+      <ID>id_3153d6971b055589cf1f4fd623b94d49</ID>
+      <Filename>layout-punctuation.png</Filename>
+      <Filepath>source\welcome\layout-punctuation.png</Filepath>
       <FileVersion></FileVersion>
-      <FileType>.jpg</FileType>
+      <FileType>.png</FileType>
       <ParentFileID>id_42283670a0f70443682146e342beda3a</ParentFileID>
     </File>
     <File>

--- a/release/nrc/nrc_crk_cans/source/nrc_crk_cans.keyman-touch-layout
+++ b/release/nrc/nrc_crk_cans/source/nrc_crk_cans.keyman-touch-layout
@@ -24,8 +24,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -221,8 +221,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -427,8 +427,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -633,8 +633,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -840,8 +840,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -1046,8 +1046,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -1253,8 +1253,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -1459,8 +1459,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -1666,8 +1666,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -1872,8 +1872,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -2080,8 +2080,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -2286,8 +2286,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -2493,8 +2493,8 @@
                 "sp": "8"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -2699,8 +2699,8 @@
                 "sp": "8"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -2710,19 +2710,22 @@
                 "sp": "8"
               },
               {
-                "id": "",
-                "sp": "9",
-                "text": ""
+                "id": "U_18C6",
+                "text": "ᣆ",
+                "nextlayer": "default",
+                "sp": "2"
               },
               {
-                "id": "",
-                "sp": "9",
-                "text": ""
+                "id": "U_18C8",
+                "text": "ᣈ",
+                "nextlayer": "default",
+                "sp": "2"
               },
               {
-                "id": "",
-                "sp": "9",
-                "text": ""
+                "id": "U_18CC",
+                "text": "ᣌ",
+                "nextlayer": "default",
+                "sp": "2"
               }
             ]
           },
@@ -2762,9 +2765,10 @@
                 "sp": "2"
               },
               {
-                "id": "",
-                "sp": "9",
-                "text": ""
+                "id": "U_18CA",
+                "text": "ᣊ",
+                "nextlayer": "default",
+                "sp": "2"
               },
               {
                 "id": "U_1552",
@@ -2901,8 +2905,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -3107,8 +3111,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV"
               },
               {
@@ -3314,8 +3318,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV",
                 "sp": "8"
               },
@@ -3520,8 +3524,8 @@
                 "nextlayer": "nV"
               },
               {
-                "id": "U_1540",
-                "text": "ᕀ",
+                "id": "U_1429",
+                "text": "ᐩ",
                 "nextlayer": "yV",
                 "sp": "8"
               },

--- a/release/nrc/nrc_crk_cans/source/nrc_crk_cans.kmn
+++ b/release/nrc/nrc_crk_cans/source/nrc_crk_cans.kmn
@@ -3,7 +3,7 @@ store(&VERSION) '10.0'
 store(&TARGETS) 'mobile'
 store(&NAME) 'Cree Syllabics'
 store(&COPYRIGHT) 'Copyright © 2019, 2020 National Research Council Canada'
-store(&KEYBOARDVERSION) '1.1.0'
+store(&KEYBOARDVERSION) '1.2.0'
 
 store(&LAYOUTFILE) 'nrc_crk_cans.keyman-touch-layout'
 
@@ -20,7 +20,7 @@ store(cwV) 'ᒓᒕᒗᒙᒛᒝᒟ'
 store(mV) 'ᒣᒥᒦᒧᒨᒪᒫ'
 store(mwV) 'ᒭᒯᒱᒳᒵᒷᒹ'
 store(nV) 'ᓀᓂᓃᓄᓅᓇᓈ'
-store(nwV) 'ᓊᓌᓎ'
+store(nwV) 'ᓊᓌᓎᣆᣈᣊᣌ'
 store(sV) 'ᓭᓯᓰᓱᓲᓴᓵ'
 store(swV) 'ᓷᓹᓻᓽᓿᔁᔃ'
 store(yV) 'ᔦᔨᔩᔪᔫᔭᔮ'
@@ -225,34 +225,42 @@ group(main) using keys
   U+1422 U+1424 + [U_140A] > U+1501 layer('default') c ᐢ ᐤ + [ ᐊ ] > ᔁ
   U+1422 U+1424 + [U_1503] > U+1503 layer('default') c ᐢ ᐤ + [ ᔃ ] > ᔃ
   U+1422 U+1424 + [U_140B] > U+1503 layer('default') c ᐢ ᐤ + [ ᐋ ] > ᔃ
-  U+1540 + [U_1526] > U+1526 layer('default') c ᕀ + [ ᔦ ] > ᔦ
-  U+1540 + [U_1401] > U+1526 layer('default') c ᕀ + [ ᐁ ] > ᔦ
-  U+1540 + [U_1528] > U+1528 layer('default') c ᕀ + [ ᔨ ] > ᔨ
-  U+1540 + [U_1403] > U+1528 layer('default') c ᕀ + [ ᐃ ] > ᔨ
-  U+1540 + [U_1529] > U+1529 layer('default') c ᕀ + [ ᔩ ] > ᔩ
-  U+1540 + [U_1404] > U+1529 layer('default') c ᕀ + [ ᐄ ] > ᔩ
-  U+1540 + [U_152A] > U+152A layer('default') c ᕀ + [ ᔪ ] > ᔪ
-  U+1540 + [U_1405] > U+152A layer('default') c ᕀ + [ ᐅ ] > ᔪ
-  U+1540 + [U_152B] > U+152B layer('default') c ᕀ + [ ᔫ ] > ᔫ
-  U+1540 + [U_1406] > U+152B layer('default') c ᕀ + [ ᐆ ] > ᔫ
-  U+1540 + [U_152D] > U+152D layer('default') c ᕀ + [ ᔭ ] > ᔭ
-  U+1540 + [U_140A] > U+152D layer('default') c ᕀ + [ ᐊ ] > ᔭ
-  U+1540 + [U_152E] > U+152E layer('default') c ᕀ + [ ᔮ ] > ᔮ
-  U+1540 + [U_140B] > U+152E layer('default') c ᕀ + [ ᐋ ] > ᔮ
-  U+1540 U+1424 + [U_1530] > U+1530 layer('default') c ᕀ ᐤ + [ ᔰ ] > ᔰ
-  U+1540 U+1424 + [U_1401] > U+1530 layer('default') c ᕀ ᐤ + [ ᐁ ] > ᔰ
-  U+1540 U+1424 + [U_1532] > U+1532 layer('default') c ᕀ ᐤ + [ ᔲ ] > ᔲ
-  U+1540 U+1424 + [U_1403] > U+1532 layer('default') c ᕀ ᐤ + [ ᐃ ] > ᔲ
-  U+1540 U+1424 + [U_1534] > U+1534 layer('default') c ᕀ ᐤ + [ ᔴ ] > ᔴ
-  U+1540 U+1424 + [U_1404] > U+1534 layer('default') c ᕀ ᐤ + [ ᐄ ] > ᔴ
-  U+1540 U+1424 + [U_1536] > U+1536 layer('default') c ᕀ ᐤ + [ ᔶ ] > ᔶ
-  U+1540 U+1424 + [U_1405] > U+1536 layer('default') c ᕀ ᐤ + [ ᐅ ] > ᔶ
-  U+1540 U+1424 + [U_1538] > U+1538 layer('default') c ᕀ ᐤ + [ ᔸ ] > ᔸ
-  U+1540 U+1424 + [U_1406] > U+1538 layer('default') c ᕀ ᐤ + [ ᐆ ] > ᔸ
-  U+1540 U+1424 + [U_153A] > U+153A layer('default') c ᕀ ᐤ + [ ᔺ ] > ᔺ
-  U+1540 U+1424 + [U_140A] > U+153A layer('default') c ᕀ ᐤ + [ ᐊ ] > ᔺ
-  U+1540 U+1424 + [U_153C] > U+153C layer('default') c ᕀ ᐤ + [ ᔼ ] > ᔼ
-  U+1540 U+1424 + [U_140B] > U+153C layer('default') c ᕀ ᐤ + [ ᐋ ] > ᔼ
+  U+1429 + [U_1526] > U+1526 layer('default') c ᐩ + [ ᔦ ] > ᔦ
+  U+1429 + [U_1401] > U+1526 layer('default') c ᐩ + [ ᐁ ] > ᔦ
+  U+1429 + [U_1528] > U+1528 layer('default') c ᐩ + [ ᔨ ] > ᔨ
+  U+1429 + [U_1403] > U+1528 layer('default') c ᐩ + [ ᐃ ] > ᔨ
+  U+1429 + [U_1529] > U+1529 layer('default') c ᐩ + [ ᔩ ] > ᔩ
+  U+1429 + [U_1404] > U+1529 layer('default') c ᐩ + [ ᐄ ] > ᔩ
+  U+1429 + [U_152A] > U+152A layer('default') c ᐩ + [ ᔪ ] > ᔪ
+  U+1429 + [U_1405] > U+152A layer('default') c ᐩ + [ ᐅ ] > ᔪ
+  U+1429 + [U_152B] > U+152B layer('default') c ᐩ + [ ᔫ ] > ᔫ
+  U+1429 + [U_1406] > U+152B layer('default') c ᐩ + [ ᐆ ] > ᔫ
+  U+1429 + [U_152D] > U+152D layer('default') c ᐩ + [ ᔭ ] > ᔭ
+  U+1429 + [U_140A] > U+152D layer('default') c ᐩ + [ ᐊ ] > ᔭ
+  U+1429 + [U_152E] > U+152E layer('default') c ᐩ + [ ᔮ ] > ᔮ
+  U+1429 + [U_140B] > U+152E layer('default') c ᐩ + [ ᐋ ] > ᔮ
+  U+1429 U+1424 + [U_1530] > U+1530 layer('default') c ᐩ ᐤ + [ ᔰ ] > ᔰ
+  U+1429 U+1424 + [U_1401] > U+1530 layer('default') c ᐩ ᐤ + [ ᐁ ] > ᔰ
+  U+1429 U+1424 + [U_1532] > U+1532 layer('default') c ᐩ ᐤ + [ ᔲ ] > ᔲ
+  U+1429 U+1424 + [U_1403] > U+1532 layer('default') c ᐩ ᐤ + [ ᐃ ] > ᔲ
+  U+1429 U+1424 + [U_1534] > U+1534 layer('default') c ᐩ ᐤ + [ ᔴ ] > ᔴ
+  U+1429 U+1424 + [U_1404] > U+1534 layer('default') c ᐩ ᐤ + [ ᐄ ] > ᔴ
+  U+1429 U+1424 + [U_1536] > U+1536 layer('default') c ᐩ ᐤ + [ ᔶ ] > ᔶ
+  U+1429 U+1424 + [U_1405] > U+1536 layer('default') c ᐩ ᐤ + [ ᐅ ] > ᔶ
+  U+1429 U+1424 + [U_1538] > U+1538 layer('default') c ᐩ ᐤ + [ ᔸ ] > ᔸ
+  U+1429 U+1424 + [U_1406] > U+1538 layer('default') c ᐩ ᐤ + [ ᐆ ] > ᔸ
+  U+1429 U+1424 + [U_153A] > U+153A layer('default') c ᐩ ᐤ + [ ᔺ ] > ᔺ
+  U+1429 U+1424 + [U_140A] > U+153A layer('default') c ᐩ ᐤ + [ ᐊ ] > ᔺ
+  U+1429 U+1424 + [U_153C] > U+153C layer('default') c ᐩ ᐤ + [ ᔼ ] > ᔼ
+  U+1429 U+1424 + [U_140B] > U+153C layer('default') c ᐩ ᐤ + [ ᐋ ] > ᔼ
+  U+1423 U+1424 + [U_18C6] > U+18C6 layer('default') c ᐣ ᐤ + [ ᣆ ] > ᣆ
+  U+1423 U+1424 + [U_1403] > U+18C6 layer('default') c ᐣ ᐤ + [ ᐃ ] > ᣆ
+  U+1423 U+1424 + [U_18C8] > U+18C8 layer('default') c ᐣ ᐤ + [ ᣈ ] > ᣈ
+  U+1423 U+1424 + [U_1404] > U+18C8 layer('default') c ᐣ ᐤ + [ ᐄ ] > ᣈ
+  U+1423 U+1424 + [U_18CA] > U+18CA layer('default') c ᐣ ᐤ + [ ᣊ ] > ᣊ
+  U+1423 U+1424 + [U_1405] > U+18CA layer('default') c ᐣ ᐤ + [ ᐅ ] > ᣊ
+  U+1423 U+1424 + [U_18CC] > U+18CC layer('default') c ᐣ ᐤ + [ ᣌ ] > ᣌ
+  U+1423 U+1424 + [U_1406] > U+18CC layer('default') c ᐣ ᐤ + [ ᐆ ] > ᣌ
   c Backspace rules: break apart a syllable on backspace
   any(wV) + [K_BKSP] > U+1424 layer('wV')
   any(pV) + [K_BKSP] > U+144A layer('pV')
@@ -269,5 +277,5 @@ group(main) using keys
   any(nwV) + [K_BKSP] > U+1423 U+1424 layer('nwV')
   any(sV) + [K_BKSP] > U+1422 layer('sV')
   any(swV) + [K_BKSP] > U+1422 U+1424 layer('swV')
-  any(yV) + [K_BKSP] > U+1540 layer('yV')
-  any(ywV) + [K_BKSP] > U+1540 U+1424 layer('ywV')
+  any(yV) + [K_BKSP] > U+1429 layer('yV')
+  any(ywV) + [K_BKSP] > U+1429 U+1424 layer('ywV')

--- a/release/nrc/nrc_crk_cans/source/nrc_crk_cans.kps
+++ b/release/nrc/nrc_crk_cans/source/nrc_crk_cans.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.103.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>13.0.109.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -106,7 +106,7 @@
     <Keyboard>
       <Name>Cree Syllabics</Name>
       <ID>nrc_crk_cans</ID>
-      <Version>1.1.0</Version>
+      <Version>1.2.0</Version>
       <Languages>
         <Language ID="crk-Cans">ᓀᐦᐃᔭᐍᐏᐣ</Language>
       </Languages>


### PR DESCRIPTION
This changes the Y-final, as in #1258, and also adds rare nwV syllabics that were missing from the previous versions of this keyboard.