### PR TITLE
[fv_all] Add Aboriginal Serif font to applicable touch layouts

### DIFF
--- a/release/fv/fv_dene_mb/HISTORY.md
+++ b/release/fv/fv_dene_mb/HISTORY.md
@@ -1,6 +1,10 @@
 ᑌᓀ ᔭᕠᐁ Change History
 ============================
 
+9.2 (16 July 2020)
+------------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_dene_mb/fv_dene_mb.keyboard_info
+++ b/release/fv/fv_dene_mb/fv_dene_mb.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_dene_mb",
     "license": "mit",
-    "languages": [ "chp-Cans" ],
+    "languages": {
+      "chp-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᑌᓀ ᔭᕠᐁ language of the Western Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_dene_mb_kmw": { "deprecates": true }

--- a/release/fv/fv_dene_mb/source/fv_dene_mb.kmn
+++ b/release/fv/fv_dene_mb/source/fv_dene_mb.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "chp"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_dene_mb/source/fv_dene_mb.kps
+++ b/release/fv/fv_dene_mb/source/fv_dene_mb.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᑌᓀ ᔭᕠᐁ</Name>
       <ID>fv_dene_mb</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="chp-Cans">Chipewyan (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_dene_nt/HISTORY.md
+++ b/release/fv/fv_dene_nt/HISTORY.md
@@ -1,6 +1,10 @@
 ᑌᓀ ᔭᕱᐁ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_dene_nt/fv_dene_nt.keyboard_info
+++ b/release/fv/fv_dene_nt/fv_dene_nt.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_dene_nt",
     "license": "mit",
-    "languages": [ "chp-Cans" ],
+    "languages": { 
+      "chp-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᑌᓀ ᔭᕱᐁ language of the Western Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_dene_nt_kmw": { "deprecates": true }

--- a/release/fv/fv_dene_nt/source/fv_dene_nt.kmn
+++ b/release/fv/fv_dene_nt/source/fv_dene_nt.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "chp"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_dene_nt/source/fv_dene_nt.kps
+++ b/release/fv/fv_dene_nt/source/fv_dene_nt.kps
@@ -33,12 +33,26 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>style.css</Name>
+      <Description>File style.css</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.css</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᑌᓀ ᔭᕱᐁ</Name>
       <ID>fv_dene_nt</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="chp-Cans">Chipewyan (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_dene_nt/source/style.css
+++ b/release/fv/fv_dene_nt/source/style.css
@@ -1,0 +1,5 @@
+@font-face {
+    font-family: 'Aboriginal Serif';
+    src: url('AboriginalSerifREGULAR.ttf');
+  }
+  body {font-family: "Aboriginal Serif"; }

--- a/release/fv/fv_eastern_canadian_inuktitut/HISTORY.md
+++ b/release/fv/fv_eastern_canadian_inuktitut/HISTORY.md
@@ -1,6 +1,10 @@
 ᐃᓄᒃᑎᑐᑦ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_eastern_canadian_inuktitut/fv_eastern_canadian_inuktitut.keyboard_info
+++ b/release/fv/fv_eastern_canadian_inuktitut/fv_eastern_canadian_inuktitut.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_eastern_canadian_inuktitut",
     "license": "mit",
-    "languages": [ "ike-Cans" ],
+    "languages": {
+      "ike-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᐃᓄᒃᑎᑐᑦ language of the Arctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_eastern_canadian_inuktitut_kmw": { "deprecates": true }

--- a/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kmn
+++ b/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "ike"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kps
+++ b/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐃᓄᒃᑎᑐᑦ</Name>
       <ID>fv_eastern_canadian_inuktitut</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ike-Cans">Eastern Canadian Inuktitut (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_moose_cree/HISTORY.md
+++ b/release/fv/fv_moose_cree/HISTORY.md
@@ -1,6 +1,10 @@
 ᐃᓕᓖᒧᐎᓐ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_moose_cree/fv_moose_cree.keyboard_info
+++ b/release/fv/fv_moose_cree/fv_moose_cree.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_moose_cree",
     "license": "mit",
-    "languages": [ "crm-Cans" ],
+    "languages": {
+      "crm-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᐃᓕᓖᒧᐎᓐ language of the Eastern Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_moose_cree_kmw": { "deprecates": true }

--- a/release/fv/fv_moose_cree/source/fv_moose_cree.kmn
+++ b/release/fv/fv_moose_cree/source/fv_moose_cree.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "crm"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_moose_cree/source/fv_moose_cree.kps
+++ b/release/fv/fv_moose_cree/source/fv_moose_cree.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐃᓕᓖᒧᐎᓐ</Name>
       <ID>fv_moose_cree</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="crm-Cans">Moose Cree (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_naskapi/HISTORY.md
+++ b/release/fv/fv_naskapi/HISTORY.md
@@ -1,6 +1,10 @@
 ᓇᔅᑲᐱ Naskapi Change History
 ============================
 
+9.3 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.2 (9 May 2019)
 ----------------
 * Added .kps file

--- a/release/fv/fv_naskapi/fv_naskapi.keyboard_info
+++ b/release/fv/fv_naskapi/fv_naskapi.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_naskapi",
     "license": "mit",
-    "languages": [ "nsk-Cans" ],
+    "languages": {
+      "nsk-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᓇᔅᑲᐱ language of the Eastern Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_naskapi_kmw": { "deprecates": true }

--- a/release/fv/fv_naskapi/source/fv_naskapi.kmn
+++ b/release/fv/fv_naskapi/source/fv_naskapi.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.2"
+store(&KEYBOARDVERSION) "9.3"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "nsk"
 store(&COPYRIGHT) "(c) 2015-2019 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_naskapi/source/fv_naskapi.kps
+++ b/release/fv/fv_naskapi/source/fv_naskapi.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᓇᔅᑲᐱ</Name>
       <ID>fv_naskapi</ID>
-      <Version>9.2</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="nsk-Cans">Naskapi (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_northern_east_cree/HISTORY.md
+++ b/release/fv/fv_northern_east_cree/HISTORY.md
@@ -1,6 +1,10 @@
 ᐄᔨᔫ-ᐄᓅ ᐊᔨᒨᓐ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_northern_east_cree/fv_northern_east_cree.keyboard_info
+++ b/release/fv/fv_northern_east_cree/fv_northern_east_cree.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_northern_east_cree",
     "license": "mit",
-    "languages": [ "crl-Cans" ],
+    "languages": {
+      "crl-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᐄᔨᔫ-ᐄᓅ ᐊᔨᒨᓐ language of the Eastern Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_northern_east_cree_kmw": { "deprecates": true }

--- a/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kmn
+++ b/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "crl"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kps
+++ b/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐄᔨᔫ-ᐄᓅ ᐊᔨᒨᓐ</Name>
       <ID>fv_northern_east_cree</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="crl-Cans">Northern East Cree (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_ojibwa/HISTORY.md
+++ b/release/fv/fv_ojibwa/HISTORY.md
@@ -1,6 +1,10 @@
 ᐊᓂᔑᓇᐯᒧᐎᓐ Change History
 ============================
 
+9.3 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.2 (9 May 2019)
 ----------------
 * Added .kps file

--- a/release/fv/fv_ojibwa/fv_ojibwa.keyboard_info
+++ b/release/fv/fv_ojibwa/fv_ojibwa.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_ojibwa",
     "license": "mit",
-    "languages": [ "ojb-Cans" ],
+    "languages": {
+      "ojb-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᐊᓂᔑᓇᐯᒧᐎᓐ (Ojibwa) language of the Eastern Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_ojibwa_kmw": { "deprecates": true }

--- a/release/fv/fv_ojibwa/source/fv_ojibwa.kmn
+++ b/release/fv/fv_ojibwa/source/fv_ojibwa.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.2"
+store(&KEYBOARDVERSION) "9.3"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "ojb"
 store(&COPYRIGHT) "(c) 2015-2019 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_ojibwa/source/fv_ojibwa.kps
+++ b/release/fv/fv_ojibwa/source/fv_ojibwa.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐊᓂᔑᓇᐯᒧᐎᓐ</Name>
       <ID>fv_ojibwa</ID>
-      <Version>9.2</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ojb-Cans">Northwestern Ojibwa (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_plains_cree/HISTORY.md
+++ b/release/fv/fv_plains_cree/HISTORY.md
@@ -1,6 +1,10 @@
 ᓀᐦᐃᔭᐍᐏᐣ Change History
 ============================
 
+10.0.2 (16 Jul 2020)
+--------------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 10.0.1 (23 Jun 2020)
 --------------------
 * Change: use U+1429 CANADIAN SYLLABICS FINAL PLUS instead of U+1540 CANADIAN SYLLABICS WEST-CREE Y

--- a/release/fv/fv_plains_cree/fv_plains_cree.keyboard_info
+++ b/release/fv/fv_plains_cree/fv_plains_cree.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_plains_cree",
     "license": "mit",
-    "languages": [ "crk-Cans" ],
+    "languages": {
+      "crk-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᓀᐦᐃᔭᐍᐏᐣ language of the Prairies region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_plains_cree_kmw": { "deprecates": true }

--- a/release/fv/fv_plains_cree/source/fv_plains_cree.kmn
+++ b/release/fv/fv_plains_cree/source/fv_plains_cree.kmn
@@ -2,7 +2,7 @@
 store(&TARGETS) "mobile tablet"
 store(&COPYRIGHT) '(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' U+0027 ' Cultural Foundation'
 store(&NAME) 'ᓀᐦᐃᔭᐍᐏᐣ'
-store(&KEYBOARDVERSION) '10.0.1'
+store(&KEYBOARDVERSION) '10.0.2'
 store(&LAYOUTFILE) 'fv_plains_cree.keyman-touch-layout'
 
 begin Unicode > use(main)

--- a/release/fv/fv_plains_cree/source/fv_plains_cree.kps
+++ b/release/fv/fv_plains_cree/source/fv_plains_cree.kps
@@ -34,12 +34,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᓀᐦᐃᔭᐍᐏᐣ</Name>
       <ID>fv_plains_cree</ID>
-      <Version>10.0</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="crk-Cans">ᓀᐦᐃᔭᐍᐏᐣ (Cree syllabics)</Language>
       </Languages>

--- a/release/fv/fv_severn_ojibwa/HISTORY.md
+++ b/release/fv/fv_severn_ojibwa/HISTORY.md
@@ -1,6 +1,10 @@
 ᐊᓂᔑᓂᓂᒧᐎᐣ Change History
 ============================
 
+9.3 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.2 (9 May 2019)
 ----------------
 * Added .kps file

--- a/release/fv/fv_severn_ojibwa/fv_severn_ojibwa.keyboard_info
+++ b/release/fv/fv_severn_ojibwa/fv_severn_ojibwa.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_severn_ojibwa",
     "license": "mit",
-    "languages": [ "ojs-Cans" ],
+    "languages": {
+      "ojs-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᐊᓂᔑᓂᓂᒧᐎᐣ (Severn Ojibwa) language of the Eastern Subarctic region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_severn_ojibwa_kmw": { "deprecates": true }

--- a/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kmn
+++ b/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.2"
+store(&KEYBOARDVERSION) "9.3"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "ojs"
 store(&COPYRIGHT) "(c) 2015-2019 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kps
+++ b/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐊᓂᔑᓂᓂᒧᐎᐣ</Name>
       <ID>fv_severn_ojibwa</ID>
-      <Version>9.2</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ojs-Cans">Severn Ojibwa (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_southern_carrier/HISTORY.md
+++ b/release/fv/fv_southern_carrier/HISTORY.md
@@ -1,6 +1,10 @@
 ᑐᑊᘁᗕᑋᗸ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_southern_carrier/fv_southern_carrier.keyboard_info
+++ b/release/fv/fv_southern_carrier/fv_southern_carrier.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_southern_carrier",
     "license": "mit",
-    "languages": [ "caf-Cans" ],
+    "languages": {
+      "caf-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᑐᑊᘁᗕᑋᗸ language of the BC Interior region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_southern_carrier_kmw": { "deprecates": true }

--- a/release/fv/fv_southern_carrier/source/fv_southern_carrier.kmn
+++ b/release/fv/fv_southern_carrier/source/fv_southern_carrier.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "caf"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_southern_carrier/source/fv_southern_carrier.kps
+++ b/release/fv/fv_southern_carrier/source/fv_southern_carrier.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᑐᑊᘁᗕᑋᗸ</Name>
       <ID>fv_southern_carrier</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="caf-Cans">Southern Carrier (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/fv/fv_swampy_cree/HISTORY.md
+++ b/release/fv/fv_swampy_cree/HISTORY.md
@@ -1,6 +1,10 @@
 ᐃᓂᓂᒧᐎᐣ Change History
 ============================
 
+9.2 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 9.1 (26 Oct 2018)
 -----------------
 * Changed file names to remove "_kmw" in preparation for a future Desktop version

--- a/release/fv/fv_swampy_cree/fv_swampy_cree.keyboard_info
+++ b/release/fv/fv_swampy_cree/fv_swampy_cree.keyboard_info
@@ -1,7 +1,16 @@
 {
     "id": "fv_swampy_cree",
     "license": "mit",
-    "languages": [ "csw-Cans" ],
+    "languages": {
+      "csw-Cans": {
+        "font": {
+          "family": "AboriginalSerif",
+          "source": [
+            "AboriginalSerifREGULAR.ttf"
+          ]
+        }
+      }
+    },
     "description": "This keyboard is designed for the ᑐᑊᘁᗕᑋᗸ language of the BC Interior region of Canada. This is part of a set of keyboards from FirstVoices.",
     "related": {
       "fv_swampy_cree_kmw": { "deprecates": true }

--- a/release/fv/fv_swampy_cree/source/fv_swampy_cree.kmn
+++ b/release/fv/fv_swampy_cree/source/fv_swampy_cree.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1"
+store(&KEYBOARDVERSION) "9.2"
 store(&TARGETS) "mobile tablet"
 c store(&ETHNOLOGUECODE) "csw"
 store(&COPYRIGHT) "(c) 2015-2018 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation"

--- a/release/fv/fv_swampy_cree/source/fv_swampy_cree.kps
+++ b/release/fv/fv_swampy_cree/source/fv_swampy_cree.kps
@@ -33,12 +33,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ᐃᓂᓂᒧᐎᐣ</Name>
       <ID>fv_swampy_cree</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="csw-Cans">Swampy Cree (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/i/inuktitut_latin/HISTORY.md
+++ b/release/i/inuktitut_latin/HISTORY.md
@@ -1,6 +1,10 @@
 Qaliujaaqpait | ᖃᓕᐅᔮᖅᐸᐃᑦ Change History
 =======================================
 
+1.4 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 1.3 (20 Sept 2019)
 ------------
 * Change license to MIT with permission of author

--- a/release/i/inuktitut_latin/inuktitut_latin.keyboard_info
+++ b/release/i/inuktitut_latin/inuktitut_latin.keyboard_info
@@ -3,7 +3,14 @@
     "name": "Qaliujaaqpait | \u1583\u14d5\u1405\u152e\u1585\u1438\u1403\u1466",
     "license": "mit",
     "languages": {
-        "ike-Latn": {}
+        "ike-Latn": {
+            "font": {
+                "family": "AboriginalSerif",
+                "source": [
+                  "AboriginalSerifREGULAR.ttf"
+                ]
+            }
+        }
     },
     "description": "A Latin script keyboard for Inuktut languages."
 }

--- a/release/i/inuktitut_latin/source/inuktitut_latin.kmn
+++ b/release/i/inuktitut_latin/source/inuktitut_latin.kmn
@@ -8,7 +8,7 @@ c store(&WINDOWSLANGUAGES) 'x085D'
 store(&LAYOUTFILE) 'inuktitut_latin.keyman-touch-layout'
 store(&NAME) 'Qaliujaaqpait | ᖃᓕᐅᔮᖅᐸᐃᑦ'
 store(&KMW_EMBEDCSS) 'inuktitut_latin.css'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
 begin Unicode > use(main)
 
 

--- a/release/i/inuktitut_latin/source/inuktitut_latin.kps
+++ b/release/i/inuktitut_latin/source/inuktitut_latin.kps
@@ -26,12 +26,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Qaliujaaqpait | ᖃᓕᐅᔮᖅᐸᐃᑦ</Name>
       <ID>inuktitut_latin</ID>
-      <Version>1.3</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ike-Latn">Eastern Canadian Inuktitut (Latin)</Language>
       </Languages>

--- a/release/i/inuktitut_naqittaut/HISTORY.md
+++ b/release/i/inuktitut_naqittaut/HISTORY.md
@@ -1,6 +1,10 @@
 Qaniujaaqpait | ᖃᓂᐅᔮᖅᐸᐃᑦ Change History
 ==================================
 
+1.6 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 1.5 (20 Sept 2019)
 ---------------
 * Changed license to MIT with permission of author

--- a/release/i/inuktitut_naqittaut/README.md
+++ b/release/i/inuktitut_naqittaut/README.md
@@ -3,7 +3,7 @@ Qaniujaaqpait | ᖃᓂᐅᔮᖅᐸᐃᑦ keyboard
 
 Copyright (C) 2015-2019 Pirurvik Centre and SIL International
 
-Version 1.5
+Version 1.6
 
 A Canadian Aboriginal Syllabics script keyboard for Inuktut languages
 

--- a/release/i/inuktitut_naqittaut/inuktitut_naqittaut.keyboard_info
+++ b/release/i/inuktitut_naqittaut/inuktitut_naqittaut.keyboard_info
@@ -3,7 +3,14 @@
     "name": "Qaniujaaqpait | \u1583\u14c2\u1405\u152e\u1585\u1438\u1403\u1466",
     "license": "mit",
     "languages": {
-        "ike-Cans": {}
+        "ike-Cans": {
+            "font": {
+                "family": "AboriginalSerif",
+                "source": [
+                  "AboriginalSerifREGULAR.ttf"
+                ]
+            }
+        }
     },
     "description": "A Canadian Aboriginal Syllabics script keyboard for Inuktut languages."
 }

--- a/release/i/inuktitut_naqittaut/source/inuktitut_naqittaut.kmn
+++ b/release/i/inuktitut_naqittaut/source/inuktitut_naqittaut.kmn
@@ -9,7 +9,7 @@ store(&COPYRIGHT) '(c) 2015-2019 Pirurvik Center and SIL International'
 store(&VISUALKEYBOARD) 'inuktitut_naqittaut.kvks'
 store(&LAYOUTFILE) 'inuktitut_naqittaut.keyman-touch-layout'
 store(&KMW_EMBEDCSS) 'inuktitut_naqittaut.css'
-store(&KEYBOARDVERSION) '1.5'
+store(&KEYBOARDVERSION) '1.6'
 
 begin Unicode > use(main)
 

--- a/release/i/inuktitut_naqittaut/source/inuktitut_naqittaut.kps
+++ b/release/i/inuktitut_naqittaut/source/inuktitut_naqittaut.kps
@@ -38,12 +38,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Qaniujaaqpait | ᖃᓂᐅᔮᖅᐸᐃᑦ</Name>
       <ID>inuktitut_naqittaut</ID>
-      <Version>1.5</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ike-Cans">Eastern Canadian Inuktitut (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/i/inuktitut_pirurvik/HISTORY.md
+++ b/release/i/inuktitut_pirurvik/HISTORY.md
@@ -1,6 +1,10 @@
 Kiputtijjut | ᑭᐳᑦᑎᔾᔪᑦ Change History
 ===================================
 
+1.4 (16 Jul 2020)
+-----------------
+* Use AboriginalSerifREGULAR.ttf font for touch layout
+
 1.3 (20 Sept 2019)
 ---------------
 * Change license to MIT with permission of author

--- a/release/i/inuktitut_pirurvik/README.md
+++ b/release/i/inuktitut_pirurvik/README.md
@@ -3,7 +3,7 @@ Kiputtijjut | ᑭᐳᑦᑎᔾᔪᑦ keyboard
 
 Copyright (C) 2015-2019 Pirurvik Centre and SIL International
 
-Version 1.3
+Version 1.4
 
 A transliteration keyboard for Inuktut languages,
 Canadian Aboriginal Syllabics script

--- a/release/i/inuktitut_pirurvik/inuktitut_pirurvik.keyboard_info
+++ b/release/i/inuktitut_pirurvik/inuktitut_pirurvik.keyboard_info
@@ -3,7 +3,14 @@
     "name": "Kiputtijjut | \u146d\u1433\u1466\u144e\u153e\u152a\u1466",
     "license": "mit",
     "languages": {
-        "ike-Cans": {}
+        "ike-Cans": {
+            "font": {
+                "family": "AboriginalSerif",
+                "source": [
+                  "AboriginalSerifREGULAR.ttf"
+                ]
+            }
+        }
     },
     "description": "A transliteration keyboard for Inuktut languages, Canadian Aboriginal Syllabics script."
 }

--- a/release/i/inuktitut_pirurvik/source/inuktitut_pirurvik.kmn
+++ b/release/i/inuktitut_pirurvik/source/inuktitut_pirurvik.kmn
@@ -8,7 +8,7 @@ c store(&LANGUAGE) 'x045D'
 c store(&WINDOWSLANGUAGES) 'x045D'
 store(&LAYOUTFILE) 'inuktitut_pirurvik.keyman-touch-layout'
 store(&KMW_EMBEDCSS) 'inuktitut_pirurvik.css'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
 begin Unicode > use(main)
 
 store(punct) ".,:;'\/!?" d34 

--- a/release/i/inuktitut_pirurvik/source/inuktitut_pirurvik.kps
+++ b/release/i/inuktitut_pirurvik/source/inuktitut_pirurvik.kps
@@ -26,12 +26,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</Name>
+      <Description>File AboriginalSerifREGULAR.ttf</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Kiputtijjut | ᑭᐳᑦᑎᔾᔪᑦ</Name>
       <ID>inuktitut_pirurvik</ID>
-      <Version>1.2</Version>
+      <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSerifREGULAR.ttf</DisplayFont>
       <Languages>
         <Language ID="ike-Cans">Eastern Canadian Inuktitut (Unified Canadian Aboriginal Syllabics)</Language>
       </Languages>

--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.3 (16 Jul 2020)
+* Add Aboriginal Serif font to touch layout keyboards
+
 ## 12.2 (29 Apr 2020)
 * Add touch layout keyboards and DejaVuSans.ttf font
 

--- a/release/packages/fv_all/README.md
+++ b/release/packages/fv_all/README.md
@@ -3,7 +3,7 @@ FirstVoices Keyboard Package
 
 (c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
-Version 12.2
+Version 12.3
 
 __DESCRIPTION__
 

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -70,7 +70,9 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   version=${kpsdata[1]}
   bcp47=${kpsdata[2]}
   langname=${kpsdata[3]}
-  
+  oskFont=${kpsdata[4]}
+  displayFont=${kpsdata[5]}
+
   # Build a file entry
   FILE_LINES_0=''
   FILE_LINES_1=''
@@ -95,12 +97,24 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   FILE_LINES="$FILE_LINES$FILE_LINES_0$FILE_LINES_1"
   
   # Build a keyboard entry
-    
+
+  # Check for font info (relative path already adjusted)
+  OSK_FONT_LINES_0=''
+  if [ -f "$oskFont" ]; then
+    OSK_FONT_LINES_0='
+      <OSKFont>'"$oskFont"'</OSKFont>'
+  fi
+  DISPLAY_FONT_LINES_0=''
+  if [ -f "$displayFont" ]; then
+    DISPLAY_FONT_LINES_0='
+      <DisplayFont>'"$displayFont"'</DisplayFont>'
+  fi
+
   KEYBOARD_LINES_0='
     <Keyboard>
       <Name>'"$name"'</Name>
       <ID>'"$id"'</ID>
-      <Version>'"$version"'</Version>
+      <Version>'"$version"'</Version>'"$OSK_FONT_LINES_0$DISPLAY_FONT_LINES_0"'
       <Languages>
         <Language ID="'"$bcp47"'">'"$langname"'</Language>
       </Languages>

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -3,6 +3,14 @@
 set -e
 set -u
 
+function die () {
+    # TODO: Incorporate build-utils.sh for keyboards repo
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
 # Parse parameters
 
 FLAG_SILENT=
@@ -36,7 +44,7 @@ for key in "$@"; do
         PROJECT_TARGET="$key"
         if [[ "$PROJECT_TARGET" != "fv_all.kps" ]]; then 
           echo "Skipping fv_all.kps"
-          exit 0; 
+          exit 0;
         fi
         ;;
     esac
@@ -44,7 +52,7 @@ for key in "$@"; do
   fi
 done
 
-# For each keyboard in the following folders:
+# For each keyboard in the following release folders:
 # fv/*, inuktitut_*, sil_euro_latin, and basic_kbdcan
 # If a .kmx or .js exists, add it to the package source file, reading the requisite keyboard name and version from the .kps file
 # The fonts which are shared across the packages are already listed in fv_all.kps.in.
@@ -121,6 +129,11 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
 
   KEYBOARD_LINES="$KEYBOARD_LINES$KEYBOARD_LINES_0"
 done
+
+# Verify keyboards exist
+if [[ $KEYBOARD_LINES = '' ]]; then
+  die "No built keyboards exist for fv_all"
+fi
 
 # Insert replaced text into fv_all.kps
 

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -96,20 +96,19 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   fi
   FILE_LINES="$FILE_LINES$FILE_LINES_0$FILE_LINES_1"
   
-  # Build a keyboard entry
-
-  # Check for font info (relative path already adjusted)
+  # Check for optional font info
   OSK_FONT_LINES_0=''
-  if [ -f "$oskFont" ]; then
+  if [[ "$oskFont" != 'none' ]]; then
     OSK_FONT_LINES_0='
       <OSKFont>'"$oskFont"'</OSKFont>'
   fi
   DISPLAY_FONT_LINES_0=''
-  if [ -f "$displayFont" ]; then
+  if [[ "$displayFont" != 'none' ]]; then
     DISPLAY_FONT_LINES_0='
       <DisplayFont>'"$displayFont"'</DisplayFont>'
   fi
 
+  # Build a keyboard entry
   KEYBOARD_LINES_0='
     <Keyboard>
       <Name>'"$name"'</Name>

--- a/release/packages/fv_all/parse_kps.pl
+++ b/release/packages/fv_all/parse_kps.pl
@@ -14,5 +14,10 @@ my $name = $1 if($kps =~ /\<Keyboard\>\s*\<Name\>(.*?)\<\/Name\>/);
 my $version = $1 if($kps =~ /\<Keyboard\>.+<Version\>(.*?)\<\/Version\>/s);
 my $bcp47 = $1 if($kps =~ /\<Keyboard\>.+<Language\s+ID="(.+?)"\>/s);
 my $langname = $1 if($kps =~ /\<Keyboard\>.+<Language.+?\>(.+?)\<\/Language\>/s);
+# Regex for font paths will intentionally skip 1 level
+my $oskFont = ' ';
+$oskFont = $1 if($kps =~ /\<Keyboard\>.+<OSKFont\>\.\.\\(.*?)\<\/OSKFont\>/s);
+my $displayFont = ' ';
+$displayFont = $1 if($kps =~ /\<Keyboard\>.+<DisplayFont\>\.\.\\(.*?)\<\/DisplayFont\>/s);
 
-print "$name\n$version\n$bcp47\n$langname";
+print "$name\n$version\n$bcp47\n$langname\n$oskFont\n$displayFont";

--- a/release/packages/fv_all/parse_kps.pl
+++ b/release/packages/fv_all/parse_kps.pl
@@ -14,10 +14,10 @@ my $name = $1 if($kps =~ /\<Keyboard\>\s*\<Name\>(.*?)\<\/Name\>/);
 my $version = $1 if($kps =~ /\<Keyboard\>.+<Version\>(.*?)\<\/Version\>/s);
 my $bcp47 = $1 if($kps =~ /\<Keyboard\>.+<Language\s+ID="(.+?)"\>/s);
 my $langname = $1 if($kps =~ /\<Keyboard\>.+<Language.+?\>(.+?)\<\/Language\>/s);
-# Regex for font paths will intentionally skip 1 level
-my $oskFont = ' ';
-$oskFont = $1 if($kps =~ /\<Keyboard\>.+<OSKFont\>\.\.\\(.*?)\<\/OSKFont\>/s);
+# Font paths are optional
+my $oskFont = 'none';
+$oskFont = $1 if($kps =~ /\<Keyboard\>.+<OSKFont\>(.*?)\<\/OSKFont\>/s);
 my $displayFont = ' ';
-$displayFont = $1 if($kps =~ /\<Keyboard\>.+<DisplayFont\>\.\.\\(.*?)\<\/DisplayFont\>/s);
+$displayFont = $1 if($kps =~ /\<Keyboard\>.+<DisplayFont\>(.*?)\<\/DisplayFont\>/s);
 
 print "$name\n$version\n$bcp47\n$langname\n$oskFont\n$displayFont";

--- a/release/packages/fv_all/parse_kps.pl
+++ b/release/packages/fv_all/parse_kps.pl
@@ -17,7 +17,7 @@ my $langname = $1 if($kps =~ /\<Keyboard\>.+<Language.+?\>(.+?)\<\/Language\>/s)
 # Font paths are optional
 my $oskFont = 'none';
 $oskFont = $1 if($kps =~ /\<Keyboard\>.+<OSKFont\>(.*?)\<\/OSKFont\>/s);
-my $displayFont = ' ';
+my $displayFont = 'none';
 $displayFont = $1 if($kps =~ /\<Keyboard\>.+<DisplayFont\>(.*?)\<\/DisplayFont\>/s);
 
 print "$name\n$version\n$bcp47\n$langname\n$oskFont\n$displayFont";

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -18,7 +18,7 @@
     <Copyright URL="">(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.2</Version>
+    <Version URL="">12.3</Version>
   </Info>
   <Files>
     <File>

--- a/release/packages/fv_all/source/readme.htm
+++ b/release/packages/fv_all/source/readme.htm
@@ -11,7 +11,7 @@
 
 <p style='margin:0px'>(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
        
-<p>This package includes all the FirstVoices keyboards for Windows. It is distributed as part of the FirstVoices project.</p>
+<p>This package includes all the FirstVoices keyboards for Windows and mobile. It is distributed as part of the FirstVoices project.</p>
 
 </body>
 </html>


### PR DESCRIPTION
Fixes #1286 

This PR adds font information to the fv touch layout keyboards (primarily for Unified Canadian Aboriginal Syllabics script).
Though there's many available `/release/shared/fonts/canadian_aboriginal/Aboriginal*.ttf` fonts to choose from, I ended up with **AboriginalSerifREGULAR.ttf** primarily because it's already deployed at
http://s.keyman.com/font/deploy/AboriginalSerifREGULAR.ttf


Also updated the fv_all build script that aggregates the keyboard package to distribute with the FirstVoices apps.

Also fixes #971 by adding a check in the fv_all build script for built keyboards.

### Not in the scope of this PR
I note the OSK for inuktitut_pirurvik doesn't seem correct (see existing help documentation https://help.keyman.com/keyboard/inuktitut_pirurvik/1.3/inuktitut_pirurvik )