### PR TITLE
fix: remove obsolete server references in php files

### DIFF
--- a/legacy/b/bengali_inscript/source/help/chart.php
+++ b/legacy/b/bengali_inscript/source/help/chart.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             bengali_inscript
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Inscript Bengali Keyboard Help';
   $pagetitle = 'Inscript Bengali Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
-  $relatedSites = array("http://$site_tavultesoft/bengali" => "Bengali Keyboards Home");
+
+  $relatedSites = array("$keyman_com/bengali" => "Bengali Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Tavultesoft</p>
 
 <br/>
@@ -44,12 +44,12 @@
 <!-- <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4> -->
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
 <p>
-This keyboard lets you type in Bengali (Bangla) with the standardised Inscript layout.  It is easy to use for people familiar with Bengali.  
+This keyboard lets you type in Bengali (Bangla) with the standardised Inscript layout.  It is easy to use for people familiar with Bengali.
 The keyboard uses a normal English (QWERTY) keyboard.
 </p>
 <p class='keymanweb'>
@@ -95,7 +95,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the 35 normal consonants <span class='lang2' style='font-size:200%'>ক খ গ ঘ ঙ চ ছ জ ঝ ঞ ট ঠ ড ঢ ণ ত থ দ ধ ন প ফ ব ভ ম য় র ল শ ষ স হ য ড় ঢ়</span>, the vowels <span class='lang2' style='font-size:200%'>অ আ ই ঈ উ ঊ ঋ এ ঐ ও ঔ  ্ া ি ী ু ূ ৃ ে ৈ ো ৌ</span>, and the <span class='lang2' style='font-size:200%'>্ ত্ ং ঃ ঁ</span> marks.  There are also numbers and punctuation marks.</p>
 
 <p>Bengali vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -154,7 +154,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ঔ</td><td class='lang2' style='font-size:200%'>কৌ</td><td><span class='keys'>kq</span></td>
 	</tr>
-	
+
 </table>
 
 </div>
@@ -796,7 +796,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >৯</span><br/><span class='keys'>9</span></td>
 		<td><span class='lang2' >০</span><br/><span class='keys'>0</span></td>
 	</tr>
-	
+
 	<tr style='text-align:center; font-weight:normal; background-color:#ffffff'>
 		<td colspan=13>&nbsp;</td>
 	</tr>
@@ -809,7 +809,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >ঁ</span><br/><span class='keys'>X</span></td>
 	</tr>
 
-	
+
 </table>
 
 

--- a/legacy/e/ekwbamuni/source/help/chart.php
+++ b/legacy/e/ekwbamuni/source/help/chart.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_ekwbamuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Suratha Bamuni (Bamini) Keyboard Help';
   $pagetitle = 'Suratha Bamuni Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -80,7 +80,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -95,7 +95,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The full keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, four Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ</span> (<span class='lang2'>க்ஷ</span> and <span class='lang2'>ஸ்ரீ</span> are typed with key combinations), eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, vowel diacritics <span class='lang2'>ி ீ ா ர் பெ பே பை </span>, combinants and components <span class='lang2'>சூ கூ மூ டூ ரூ ஞ று நு சு வு லு ரு ழு யு ளு னு கு பு து மு டு ணு டி டீ</span> and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The vowel <span class='lang2'>ஔ</span> is typed using a combination of keystrokes.</p>
 
 <p>Although Tamil characters are typed using separate keys for consonants and diacritics, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -208,7 +208,7 @@ This character is entered by typing <span class='keys'>];uP</span>.  <span class
 
 </div>
 
- 
+
 <div id="Troubleshooting">
 		<!-- How to resolve common issues/difficulties using the keyboard; including link to Square Boxes help page -->
 
@@ -226,9 +226,9 @@ This character is entered by typing <span class='keys'>];uP</span>.  <span class
     <td>&#x0b95;&#x0bcd;&#x0b95;&#x0bcd;&#x0b95;&#x0bcd;&#x0b95;</td>
   </tr>
   </table>
-  
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/legacy/e/ekwbamuni/source/help/ekwbamuni.php
+++ b/legacy/e/ekwbamuni/source/help/ekwbamuni.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_ekwbamuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Suratha Bamuni (Bamini) Keyboard Help';
   $pagetitle = 'Suratha Bamuni Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -45,7 +45,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -81,7 +81,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -96,7 +96,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The full keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, four Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ</span> (<span class='lang2'>க்ஷ</span> and <span class='lang2'>ஸ்ரீ</span> are typed with key combinations), eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, vowel diacritics <span class='lang2'>ி ீ ா ர் பெ பே பை </span>, combinants and components <span class='lang2'>சூ கூ மூ டூ ரூ ஞ று நு சு வு லு ரு ழு யு ளு னு கு பு து மு டு ணு டி டீ</span> and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The vowel <span class='lang2'>ஔ</span> is typed using a combination of keystrokes.</p>
 
 <p>Although Tamil characters are typed using separate keys for consonants and diacritics, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -209,7 +209,7 @@ This character is entered by typing <span class='keys'>];uP</span>.  <span class
 
 </div>
 
- 
+
 <div id="Troubleshooting">
 		<!-- How to resolve common issues/difficulties using the keyboard; including link to Square Boxes help page -->
 
@@ -227,9 +227,9 @@ This character is entered by typing <span class='keys'>];uP</span>.  <span class
     <td>&#x0b95;&#x0bcd;&#x0b95;&#x0bcd;&#x0b95;&#x0bcd;&#x0b95;</td>
   </tr>
   </table>
-  
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/legacy/e/ekwbamuni/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwbamuni/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/e/ekwnewtwuni/source/help/chart.php
+++ b/legacy/e/ekwnewtwuni/source/help/chart.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_ekwnewtwuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Thamizha New Tamil Typewriter Keyboard Help';
   $pagetitle = 'Thamizha New Tamil Typewriter Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -80,7 +80,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -96,7 +96,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the last-typed component will be erased.
@@ -105,7 +105,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <h4>Vowels and Pulli Marks</h4>
 <p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered either by typing a specific key for that combinant or by typing the consonant and vowel components separately.</p>
 
-<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.  
+<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.
 </p>
 <p>
 Because the consonants contain the implicit vowel <span class='highlightExample'>அ</span>, to produce a pure consonant it is necessary to add the Pulli mark <span class='lang2'>்</span> by typing a semicolon <span class='keys'>;</span> immediately after the consonant.  In every case, a consonant-Pulli mark combinant behaves the same way as a consonant-vowel combinant when you use the arrow, Backspace and Delete keys.  Any vowel component that is typed immediately after typing the Pulli mark will not be combined with the consonant.  Also, typing a semicolon after a standalone vowel or a space will produce a semicolon, not the Pulli mark.
@@ -115,7 +115,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>_</span> (Shift+Underscore or Shift+Hyphen).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/e/ekwnewtwuni/source/help/ekwnewtwuni.php
+++ b/legacy/e/ekwnewtwuni/source/help/ekwnewtwuni.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_ekwnewtwuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Thamizha New Tamil Typewriter Keyboard Help';
   $pagetitle = 'Thamizha New Tamil Typewriter Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -45,7 +45,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -81,7 +81,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -97,7 +97,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the last-typed component will be erased.
@@ -106,7 +106,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <h4>Vowels and Pulli Marks</h4>
 <p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered either by typing a specific key for that combinant or by typing the consonant and vowel components separately.</p>
 
-<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.  
+<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.
 </p>
 <p>
 Because the consonants contain the implicit vowel <span class='highlightExample'>அ</span>, to produce a pure consonant it is necessary to add the Pulli mark <span class='lang2'>்</span> by typing a semicolon <span class='keys'>;</span> immediately after the consonant.  In every case, a consonant-Pulli mark combinant behaves the same way as a consonant-vowel combinant when you use the arrow, Backspace and Delete keys.  Any vowel component that is typed immediately after typing the Pulli mark will not be combined with the consonant.  Also, typing a semicolon after a standalone vowel or a space will produce a semicolon, not the Pulli mark.
@@ -116,7 +116,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>_</span> (Shift+Underscore or Shift+Hyphen).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/e/ekwnewtwuni/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwnewtwuni/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/e/ekwtamil99uniext/source/help/chart.php
+++ b/legacy/e/ekwtamil99uniext/source/help/chart.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             keyboard_ekwtamil99uniext
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Tamil99 Extended Keyboard Help';
   $pagetitle = 'Tamil99 Extended Keyboard Help';
   $style = 'lang2 {font-size:130%}';
-  
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 thamizha.com and Tavultesoft</p>
 
 <br/>
@@ -43,7 +43,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -73,7 +73,7 @@ Most computers will automatically download a special font if needed to display t
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>q</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>a</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>x</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>c</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>, type <span class='keys'>b</span> then <span class='keys'>q</span>, and the combinant character will automatically be displayed.  Pressing Backspace once will delete only the vowel component, so the character displayed on the screen will change back to <span class='highlightExample'>ங</span>, and change again if a different vowel is typed.</p>
@@ -91,7 +91,7 @@ Short and long vowels appear next to each other.  For example, <span class='high
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full Tamil99 keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.  This Extended keyboard also includes keys for the characters <span class='lang2'>ஶ</span> and <span class='lang2'>்ரீ</span>.</p>
@@ -265,8 +265,8 @@ This character is entered by typing <span class='keys'>T</span>.  <span class='k
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/legacy/e/ekwtamil99uniext/source/help/ekwtamil99uniext.php
+++ b/legacy/e/ekwtamil99uniext/source/help/ekwtamil99uniext.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             keyboard_ekwtamil99uniext
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Tamil99 Extended Keyboard Help';
   $pagetitle = 'Tamil99 Extended Keyboard Help';
   $style = 'lang2 {font-size:130%}';
-  
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 thamizha.com and Tavultesoft</p>
 
 <br/>
@@ -44,7 +44,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -74,7 +74,7 @@ Most computers will automatically download a special font if needed to display t
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>q</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>a</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>x</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>c</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>, type <span class='keys'>b</span> then <span class='keys'>q</span>, and the combinant character will automatically be displayed.  Pressing Backspace once will delete only the vowel component, so the character displayed on the screen will change back to <span class='highlightExample'>ங</span>, and change again if a different vowel is typed.</p>
@@ -92,7 +92,7 @@ Short and long vowels appear next to each other.  For example, <span class='high
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full Tamil99 keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.  This Extended keyboard also includes keys for the characters <span class='lang2'>ஶ</span> and <span class='lang2'>்ரீ</span>.</p>
@@ -266,8 +266,8 @@ This character is entered by typing <span class='keys'>T</span>.  <span class='k
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/legacy/e/ekwtamil99uniext/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwtamil99uniext/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/e/ekwunitamil/source/help/chart.php
+++ b/legacy/e/ekwunitamil/source/help/chart.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             keyboard_ekwunitamil
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Anjal Paangu Keyboard Help';
   $pagetitle = 'Tamil Anjal Paangu Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
-  
+
+
 <p style='margin:0px'>Keyboard &#169; 2008 thamizha.com and Tavultesoft</p>
 
 
@@ -45,7 +45,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -114,7 +114,7 @@ Most computers will automatically download a special font if needed to display t
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The visible keyboard layout consists of the ten vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஒ ஓ</span> (the vowels <span class='lang2'>ஐ ஔ</span> are typed with two keystrokes), the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the Grantha consonants <span class='lang2'>ஸ ஜ ஹ க்ஷ</span> (<span class='lang2'>ஷ</span> is typed with two keystrokes, and <span class='lang2'>ஸ்ரீ</span> with three) and the Aytham <span class='lang2'>ஃ</span> mark.
@@ -310,8 +310,8 @@ There are two ways of entering this character: <span class='keys'>Sri</span> or 
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 <h4> Fonts</h4>
 <p>This keyboard allows only the standard Tamil characters, so will work with the fonts supplied with Windows.  No further downloads of fonts should be required.</p>

--- a/legacy/e/ekwunitamil/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwunitamil/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/isis/isis_tamil/source/help/tamil_srii.php
+++ b/legacy/isis/isis_tamil/source/help/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/k/khowar/source/help/khowar.php
+++ b/legacy/k/khowar/source/help/khowar.php
@@ -15,11 +15,11 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
     <title>Khowar Help</title>
-    <link rel='icon' href='Khowar.ico'/>     
+    <link rel='icon' href='Khowar.ico'/>
     <link rel="stylesheet" href="style.css" type="text/css" />
     <!--[if lt IE 9]>
     <script src="html5shiv.js"></script>
-    <![endif]-->    
+    <![endif]-->
 </head>
 
 <body>
@@ -27,12 +27,12 @@
   <p>Keyboard &#169; 2013 Tavultesoft</p>
    <section id='overview'>
     <h2>Overview</h2>
-    <p>This is the first Khowar language keyboard created by pakistani linguistic, software engineer and researcher Mr.Rehmat Aziz. This is a Phonetic keyboard for the Khowar Language based on the keyboard layout as developed by Mr.Rehmat Aziz Chitrali in 1996 for Wikipedia and later approved by the Khowar Academy of Pakistan as the standard keyboard for the Khowar language.</p> 
+    <p>This is the first Khowar language keyboard created by pakistani linguistic, software engineer and researcher Mr.Rehmat Aziz. This is a Phonetic keyboard for the Khowar Language based on the keyboard layout as developed by Mr.Rehmat Aziz Chitrali in 1996 for Wikipedia and later approved by the Khowar Academy of Pakistan as the standard keyboard for the Khowar language.</p>
     <h4>Basic Function</h4>
-    <p>You can get many of the Khowar letters on this keyboard by typing the closest English equivalent. For example, type <kbd>n</kbd> to get <samp>ن</samp>. Keys without a direct Khowar equivalent in Enlish get the remaining characters. For example, type <kbd>[</kbd> to get <samp>ٸ</samp>.</p>    
+    <p>You can get many of the Khowar letters on this keyboard by typing the closest English equivalent. For example, type <kbd>n</kbd> to get <samp>ن</samp>. Keys without a direct Khowar equivalent in Enlish get the remaining characters. For example, type <kbd>[</kbd> to get <samp>ٸ</samp>.</p>
     <p>As there are many more letters in the Khowar alphabet then the english alphabet, additional Khowar letters are typed by first holding the SHIFT key or CONTROL + ALT key. For instance, type <kbd>Ctrl</kbd> + <kbd>Alt</kbd> <kbd>a</kbd> to get <samp>ﷲ</samp>.</p>
     <h4>Fonts</h4>
-    <p>This is a Unicode keyboard and works with any Unicode font which has support for the Nastaleeq Script such as NafeesPakistaniWebNaskh. To find other fonts on your computer which support this keyboard, use the Keyman <a href='http://help.keyman.com.local/products/desktop/10.0/docs/basic_fonthelper.php'>Font Helper</a>.</p>
+    <p>This is a Unicode keyboard and works with any Unicode font which has support for the Nastaleeq Script such as NafeesPakistaniWebNaskh. To find other fonts on your computer which support this keyboard, use the Keyman <a href='https://help.keyman.com/products/desktop/10.0/docs/basic_fonthelper.php'>Font Helper</a>.</p>
     <p>The NafeesPakistaniWebNaskh font does not support all Khowar characters - currently these unicode characters are unsupported: U+0772, U+076F, U+0771, U+0658, U+0770, U+0602, U+0656, U+0613, U+0614, U+0601, U+0611, U+0657, U+0610, U+0612, U+060F, U+0603, U+FDFD, U+0600.</p>
     <aside>
         <p>Update - Windows 8 now has several fonts that support all Khowar characters: Arial, Microsoft Sans Serif, Tahoma and Times New Roman.</p>
@@ -738,5 +738,5 @@
             <kbd>Ctrl</kbd>
         </div>
     </article>
-  </section>    
+  </section>
 </body>

--- a/legacy/t/tamil/source/help/chart.php
+++ b/legacy/t/tamil/source/help/chart.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_tamil
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Inscript Keyboard Help';
   $pagetitle = 'Tamil Inscript Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -43,7 +43,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -79,7 +79,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -95,7 +95,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components, the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, and the Tamil numberals, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Vowels are arranged on the left side of the keyboard, and most consonants are on the right, to make typing faster.  Some consonants can be typed with more than one key.</p>
@@ -106,7 +106,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 </p>
 
 <h4>Vowels and Pulli Marks</h4>
-<p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered by typing typing the consonant and vowel components separately.  Vowel components that combine with consonants are always typed after the consonants, whether the vowel component appears to the left or right of the consonant component.  
+<p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered by typing typing the consonant and vowel components separately.  Vowel components that combine with consonants are always typed after the consonants, whether the vowel component appears to the left or right of the consonant component.
 </p>
 <p>
 Because the consonants contain the implicit vowel <span class='highlightExample'>அ</span>, to produce a pure consonant it is necessary to add the Pulli mark <span class='lang2'>்</span> by typing <span class='keys'>d</span> immediately after the consonant.  In every case, a consonant-Pulli mark combinant behaves the same way as a consonant-vowel combinant when you use the arrow, Backspace and Delete keys.  Any vowel component that is typed immediately after typing the Pulli mark will not be combined with the consonant.
@@ -116,7 +116,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>&gt;</span> (Shift+Dot or Shift+Period).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/t/tamil/source/help/srii/tamil_srii.php
+++ b/legacy/t/tamil/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/t/tamil/source/help/tamil.php
+++ b/legacy/t/tamil/source/help/tamil.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_tamil
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Inscript Keyboard Help';
   $pagetitle = 'Tamil Inscript Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -80,7 +80,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -96,7 +96,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components, the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, and the Tamil numberals, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Vowels are arranged on the left side of the keyboard, and most consonants are on the right, to make typing faster.  Some consonants can be typed with more than one key.</p>
@@ -107,7 +107,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 </p>
 
 <h4>Vowels and Pulli Marks</h4>
-<p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered by typing typing the consonant and vowel components separately.  Vowel components that combine with consonants are always typed after the consonants, whether the vowel component appears to the left or right of the consonant component.  
+<p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered by typing typing the consonant and vowel components separately.  Vowel components that combine with consonants are always typed after the consonants, whether the vowel component appears to the left or right of the consonant component.
 </p>
 <p>
 Because the consonants contain the implicit vowel <span class='highlightExample'>அ</span>, to produce a pure consonant it is necessary to add the Pulli mark <span class='lang2'>்</span> by typing <span class='keys'>d</span> immediately after the consonant.  In every case, a consonant-Pulli mark combinant behaves the same way as a consonant-vowel combinant when you use the arrow, Backspace and Delete keys.  Any vowel component that is typed immediately after typing the Pulli mark will not be combined with the consonant.
@@ -117,7 +117,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>&gt;</span> (Shift+Dot or Shift+Period).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/v/visual_media_tamil_modular/source/help/chart.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/chart.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_visual_media_tamil_modular
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Modular (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Modular (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -80,7 +80,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -96,7 +96,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -116,7 +116,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>|</span> (Shift+Vertical Bar or Shift+Backslash).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/v/visual_media_tamil_modular/source/help/srii/tamil_srii.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/v/visual_media_tamil_modular/source/help/visual_media_tamil_modular.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/visual_media_tamil_modular.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_visual_media_tamil_modular
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Modular (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Modular (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -46,7 +46,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -82,7 +82,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -98,7 +98,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -118,7 +118,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>|</span> (Shift+Vertical Bar or Shift+Backslash).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/v/visual_media_tamil_typewriter/source/help/chart.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/chart.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_visual_media_tamil_typewriter
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -80,7 +80,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -96,7 +96,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -115,7 +115,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>_</span> (Shift+Underscore or Shift+Hyphen).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/legacy/v/visual_media_tamil_typewriter/source/help/srii/tamil_srii.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>

--- a/legacy/v/visual_media_tamil_typewriter/source/help/visual_media_tamil_typewriter.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/visual_media_tamil_typewriter.php
@@ -1,25 +1,25 @@
 <?php /*
   Name:             keyboard_visual_media_tamil_typewriter
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
   require_once('servervars.php');
   $pagename = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
 ?>
 
@@ -45,7 +45,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -81,7 +81,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -97,7 +97,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the vowel component will be erased.  This is the case whether the vowel component appears to the left or right of, above or below the consonant.
@@ -116,7 +116,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='srii/tamil_srii.png' style='vertical-align:middle' /></h4>
 <p>
 This character is entered by typing <span class='keys'>_</span> (Shift+Underscore or Shift+Hyphen).  Currently, some browsers do not display this character correctly.  <a href="srii/tamil_srii.php">Click here</a> if you are having difficulty entering this character.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/release/e/ekwtamil99uni/source/help/chart.php
+++ b/release/e/ekwtamil99uni/source/help/chart.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             keyboard_ekwtamil99uni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Tamil99 Keyboard Help';
   $pagetitle = 'Tamil99 Keyboard Help';
   $style = 'lang2 {font-size:130%}';
-  
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 thamizha.com and Tavultesoft</p>
 
 <br/>
@@ -44,7 +44,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -74,7 +74,7 @@ Most computers will automatically download a special font if needed to display t
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>q</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>a</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>x</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>c</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>, type <span class='keys'>b</span> then <span class='keys'>q</span>, and the combinant character will automatically be displayed.  Pressing Backspace once will delete only the vowel component, so the character displayed on the screen will change back to <span class='highlightExample'>ங</span>, and change again if a different vowel is typed.</p>
@@ -92,7 +92,7 @@ Short and long vowels appear next to each other.  For example, <span class='high
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.</p>
@@ -266,8 +266,8 @@ This character is entered by typing <span class='keys'>T</span>.  <span class='k
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/release/e/ekwtamil99uni/source/help/ekwtamil99uni.php
+++ b/release/e/ekwtamil99uni/source/help/ekwtamil99uni.php
@@ -1,30 +1,30 @@
 <?php /*
   Name:             keyboard_ekwtamil99uni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
   require_once('servervars.php');
   $pagename = 'Tamil99 Keyboard Help';
   $pagetitle = 'Tamil99 Keyboard Help';
   $style = 'lang2 {font-size:130%}';
-  
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008, 2015, 2018-2020 thamizha.com and SIL International</p>
 
 <br/>
@@ -32,7 +32,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -62,7 +62,7 @@ Most computers will automatically download a special font if needed to display t
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>q</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>a</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>x</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>c</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>, type <span class='keys'>b</span> then <span class='keys'>q</span>, and the combinant character will automatically be displayed.  Pressing Backspace once will delete only the vowel component, so the character displayed on the screen will change back to <span class='highlightExample'>ங</span>, and change again if a different vowel is typed.</p>
@@ -80,7 +80,7 @@ Short and long vowels appear next to each other.  For example, <span class='high
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.</p>
@@ -254,8 +254,8 @@ This character is entered by typing <span class='keys'>T</span>.  <span class='k
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 
 <h4> Fonts</h4>

--- a/release/e/ekwtamil99uni/source/help/srii/tamil_srii.php
+++ b/release/e/ekwtamil99uni/source/help/srii/tamil_srii.php
@@ -1,29 +1,29 @@
 <?php /*
   Name:             sri
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
   require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';
-  $relatedSites = array("http://$site_tavultesoft/tamil" => "Tamil Keyboards Home");
+  $relatedSites = array("$keyman_com/tamil" => "Tamil Keyboards Home");
 
   require_once('header.php');
 ?>
-   	
+
 <div class='KeymanWeb'>
 
 <h2>The SRii Character <img src='tamil_srii.png' style='vertical-align:bottom' /></h2>


### PR DESCRIPTION
Depends on keymanapp/help.keyman.com#200

The primary objective of this PR was to remove references to the legacy `$site_tavultesoft` variable which was causing site errors. The global variable `$keyman_com` will be available for use to refer to https://keyman.com once PR 200 referenced above is merged.

Version numbers do not need to be updated because the php files are updated on help.keyman.com with every deployment.