### PR TITLE
[sil_euro_latin] Assign font in keyboard package

### DIFF
--- a/release/sil/sil_euro_latin/HISTORY.md
+++ b/release/sil/sil_euro_latin/HISTORY.md
@@ -1,5 +1,7 @@
 # EuroLatin (SIL) Keyboard Change History
 
+## 1.9.2 (12 Aug 2020)
+* Assign DejaVu Sans font as display font
 ## 1.9.1 (4 Jun 2020)
 * Updated htm files for readability on Linux
 ## 1.9 (15 Apr 2020)

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
@@ -14,7 +14,7 @@ c KeymanWeb-specific header statements
 store(&KMW_HELPFILE) 'sil_euro_latin.html'
 store(&KMW_EMBEDJS) 'sil_euro_latin_js.txt'
 store(&LAYOUTFILE) 'sil_euro_latin.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.9.1'
+store(&KEYBOARDVERSION) '1.9.2'
 store(&TARGETS) 'any'
 
 begin Unicode > use(Main)

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.kps
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.106.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.110.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -147,6 +147,8 @@
       <Name>EuroLatin (SIL)</Name>
       <ID>sil_euro_latin</ID>
       <Version></Version>
+      <OSKFont>..\..\..\shared\fonts\dejavu\DejaVuSans.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\dejavu\DejaVuSans.ttf</DisplayFont>
       <Languages>
         <Language ID="aae-Latn">Arbëreshë Albanian</Language>
         <Language ID="acf-Latn">Saint Lucian Creole French</Language>


### PR DESCRIPTION
I missed this during the review

#1162 added DejaVu Sans font to the keyboard package.

The package source file needs to use it as OSKFont and DisplayFont.

The keyboard rendered fine in the emulator. But this is good for completeness.