### PR TITLE
Deprecating "ndailu keyman keyboard"

### DIFF
--- a/legacy/n/ndailu keyman keyboard/DEPRECATED.md
+++ b/legacy/n/ndailu keyman keyboard/DEPRECATED.md
@@ -1,0 +1,1 @@
+This keyboard has been deprecated and replaced by release/n/ntl_onekey

--- a/release/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/release/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -6,7 +6,7 @@
     "languages": [
         "khb-Talu"
     ],
-	related": {
+	"related": {
     "ndailu keyman keyboard": {
       "deprecates": true
     }

--- a/release/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/release/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -5,5 +5,9 @@
     "license": "mit",
     "languages": [
         "khb-Talu"
-    ]
-}
+    ],
+	related": {
+    "ndailu keyman keyboard": {
+      "deprecates": true
+    }
+ }

--- a/release/n/ntl_onekey/ntl_onekey.keyboard_info
+++ b/release/n/ntl_onekey/ntl_onekey.keyboard_info
@@ -11,3 +11,4 @@
       "deprecates": true
     }
  }
+}


### PR DESCRIPTION
@sdysart created `legacy/ndalu keyman keyboard`  4 years ago. A user recently reported a bug:

> ndailu keyman keyboard has an error where typing <kbd>g</kbd>+<kbd>g</kbd> should give you U+19B6 but gives two U+19B5.  `release/n/ntl_onekey` is a dailu keyboard that produces the proper U+19B6 character when typing <kbd>w</kbd>+<kbd>w</kbd>

Rather than updating a legacy (desktop only) keyboard, @sdysart wants to deprecate it in favor of ntl_onekey. ntl_onekey also has the added benefit of including a touch layout.

Question: ndali keyman keyboard uses a language tag `khb` and ntl_oneykey uses `khb-Talu`. Maybe we need to add `khb` to ntl_onekey?