### PR TITLE
chore: update code signing

### DIFF
--- a/resources/codesign.sh
+++ b/resources/codesign.sh
@@ -2,11 +2,6 @@
 
 # Code signing functionality
 
-SERVERLIST=(http://timestamp.comodoca.com/authenticode \
-http://timestamp.verisign.com/scripts/timstamp.dll \
-http://timestamp.globalsign.com/scripts/timestamp.dll \
-http://tsa.starfieldtech.com)
-
 RFC3161SERVERLIST=(http://sha256timestamp.ws.symantec.com/sha256/timestamp \
 http://timestamp.globalsign.com/scripts/timstamp.dll \
 http://timestamp.comodoca.com/rfc3161 \
@@ -37,16 +32,13 @@ function codesign {
   local SIGNFILE="$target"
 
   local file_extension=${target##*.}
-  if [[ "$file_extension" == "msi" ]] || [[ "$file_extension" == "msm" ]]; then
-    # msi can only be single-signed, not dual-signed
+
+  if [ -f /c/codesign/signtime.bat ]; then
+    # Keyman build agents use a signing script
+    cmd //c "c:\\codesign\\signtime.bat" "$SIGNTOOL" - - "$SC_URL" - //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign $SIGNFILE"
+  else
     "$SIGNTOOL" sign //f "$SC_PFX_SHA256" //fd sha256 //du "$SC_URL" //p "$SC_PWD" //v //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign with sha256 $SIGNFILE"
     codesign_timestamp "$SIGNFILE" sha256msi || die "Unable to timestamp $SIGNFILE"
-  else
-    # dual sign, first with sha1, then with sha256
-    "$SIGNTOOL" sign //f "$SC_PFX_SHA1" //fd sha1 //du "$SC_URL" //p "$SC_PWD" //v //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign with sha1 $SIGNFILE"
-    codesign_timestamp "$SIGNFILE" sha1 || die "Unable to timestamp $SIGNFILE"
-    "$SIGNTOOL" sign //as //f "$SC_PFX_SHA256" //fd sha256 //du "$SC_URL" //p "$SC_PWD" //v //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign with sha256 $SIGNFILE"
-    codesign_timestamp "$SIGNFILE" sha256 || die "Unable to timestamp $SIGNFILE"
   fi
 }
 
@@ -55,28 +47,23 @@ function codesign {
 ##
 function codesign_timestamp {
   local SIGNFILE=$1
-  local MODE=$2
-  local SERVER=$3
-  
+  local SERVER=$2
+
   if [[ -z $SERVER ]]; then
-    if [[ $MODE == sha1 ]]; then
-      local SERVERS=${SERVERLIST[*]}
-    else
-      local SERVERS=${RFC3161SERVERLIST[*]}
-    fi
+    local SERVERS=${RFC3161SERVERLIST[*]}
   else
     local SERVERS=($SERVER)
   fi
-  
+
   #
   # Randomize the server list so that we don't always try
   # the same order
   #
   SERVERS=$(echo ${SERVERS[*]} | tr " " "\n" | shuf | tr "\n" " ")
-  
+
   local a
   local s
-  
+
   #
   # Retry the code signing 3 times against the server list in case of
   # temporary network failure. After that we'll give up and fail the
@@ -86,18 +73,7 @@ function codesign_timestamp {
     for s in ${SERVERS[@]}; do
       echo Attempting to sign file with timestamp server $s
       # try to timestamp the file. This operation is unreliable and may need to be repeated...
-      case $MODE in
-        sha1)
-          "$SIGNTOOL" timestamp //t "$s" //v "$SIGNFILE" && return 0
-          ;;
-        sha256)
-          "$SIGNTOOL" timestamp //tr "$s" //tp 1 //td sha256 //v "$SIGNFILE" && return 0
-          ;;
-        sha256msi)
-          "$SIGNTOOL" timestamp //tr "$s" //td sha256 //v "$SIGNFILE" && return 0
-          ;;
-      esac
-      
+      "$SIGNTOOL" timestamp //tr "$s" //td sha256 //v "$SIGNFILE" && return 0
       echo "Signing failed. Probably cannot find the timestamp server at $s"
     done
 

--- a/resources/codesign.sh
+++ b/resources/codesign.sh
@@ -38,7 +38,7 @@ function codesign {
     cmd //c "c:\\codesign\\signtime.bat" "$SIGNTOOL" - - "$SC_URL" - //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign $SIGNFILE"
   else
     "$SIGNTOOL" sign //f "$SC_PFX_SHA256" //fd sha256 //du "$SC_URL" //p "$SC_PWD" //v //d "$SIGNNAME" "$SIGNFILE" || die "Unable to sign with sha256 $SIGNFILE"
-    codesign_timestamp "$SIGNFILE" sha256msi || die "Unable to timestamp $SIGNFILE"
+    codesign_timestamp "$SIGNFILE" || die "Unable to timestamp $SIGNFILE"
   fi
 }
 


### PR DESCRIPTION
Removes sha1 signing and hands signing over to agent on Keyman build agents for Windows bundled installers.