### PR TITLE
[sil_kmhmu] half space after the special two

### DIFF
--- a/release/sil/sil_kmhmu/HISTORY.md
+++ b/release/sil/sil_kmhmu/HISTORY.md
@@ -1,6 +1,10 @@
 SIL Kmhmu Keyboard Change History
 =======================
 
+1.6 (19 Nov 2020)
+-------------------
+* Fixed the space issue after ໞ or ໟ (half space instead of regular space after words end in these two)
+
 1.5 (21 May 2020)
 -----------------
 * Replaced shift+u and shift+y with appropriate Unicode Characters

--- a/release/sil/sil_kmhmu/README.md
+++ b/release/sil/sil_kmhmu/README.md
@@ -3,7 +3,7 @@ Kmhmu (SIL) Keyboard
 
 Copyright (C) 2008-2020 SIL International
 
-Version 1.5
+Version 1.6
 
 __DESCRIPTION__
 Lao-script Kmhmu language keyboard
@@ -16,3 +16,5 @@ Supported Platforms
  * iOS
  * macOS
  * Linux
+ * Web
+ * Mobile Web

--- a/release/sil/sil_kmhmu/sil_kmhmu.kpj
+++ b/release/sil/sil_kmhmu/sil_kmhmu.kpj
@@ -12,7 +12,7 @@
       <ID>id_596bdcd93dd413c0e2cfa05d72f22442</ID>
       <Filename>sil_kmhmu.kmn</Filename>
       <Filepath>source\sil_kmhmu.kmn</Filepath>
-      <FileVersion>1.5</FileVersion>
+      <FileVersion>1.6</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Kmhmu (SIL)</Name>

--- a/release/sil/sil_kmhmu/source/sil_kmhmu.kmn
+++ b/release/sil/sil_kmhmu/source/sil_kmhmu.kmn
@@ -7,7 +7,7 @@ c store(&ETHNOLOGUECODE) 'kjg'
 store(&capsalwaysoff) "1"
 c store(&WINDOWSLANGUAGES) 'x0454'
 store(&COPYRIGHT) '© 2008-2020 SIL International'
-store(&KEYBOARDVERSION) '1.5'
+store(&KEYBOARDVERSION) '1.6'
 store(&NAME) 'Kmhmu (SIL)'
 store(&BITMAP) 'sil_kmhmu.ico'
 store(&VISUALKEYBOARD) 'sil_kmhmu.kvks'
@@ -18,8 +18,8 @@ begin Unicode > use(Start)
 
 c Define sets of characters for matching and filtering: basic consonant sets
 c (Composites and extra characters will be handled by specific rules)
-store(Consonant)  "ກຂຄງຈສຊຍດຕຖທນບປຜຝພຟມຢຣລວຫອຮໝໜ" U+0EBC
-store(ConsonantKey) "d07'9l-pf84mo[xz/r2,1i];svI<O^"
+store(Consonant)  "ກຂຄງຈສຊຍດຕຖທນບປຜຝພຟມຢຣລວຫອຮໝໜໞໟ" U+0EBC
+store(ConsonantKey) "d07'9l-pf84mo[xz/r2,1i];svI<OYU^"
 
 c Basic vowel character sets
 store(Vowel) "ເແໂໄໃ" "ະຽາ" U+0ECD U+0EB3 U+0EB1 U+0EBB U+0EB4 \
@@ -92,12 +92,8 @@ c + "U" > U+0EB5 U+0EC9
 U+200B + '|' > '|'
 
 c Specials for Kmhmu - adapted May 08
-any(LaoCharacter) + [K_SPACE] > context U+2009 U+200B c Space inserts thin space plus ZWSP when pressed once (5/08)
-U+2009 U+200B + [K_SPACE] > U+0020          c Special handling of double space - remove preceding thin space (5/08)
-+ [SHIFT K_SPACE] > U+0020  c Force a normal space (5/08)
-+ [LCTRL K_SPACE] > U+2009
-+ [RCTRL K_SPACE] > U+2009
+
 c + "Y" > U+0E81 U+0ECC  c commented out as we have changed over to unicode
-+ "Y" > U+0EDE
+c + "Y" > U+0EDE
 c + "U" > U+0E8D U+0ECC  c commented out as we have changed over to unicode
-+ "U" > U+0EDF
+c + "U" > U+0EDF


### PR DESCRIPTION
This version updates to include the two special characters in the Lao consonant  store (`store(Consonant)`) so that the rules for Thin Space and Full Space are triggered and work as expected. 

The previous version would not add a half space after the two characters ໞ (on Shift + Y) and ໟ (on Shift + U) when the spacebar is pressed.

We would like to ensure as well whether the two fonts get installed when the .kmp is either installed via the Keyman Desktop configuration or via keyman.com.