### PR TITLE
[haroi] Add rules for combining overline

### DIFF
--- a/release/h/haroi/HISTORY.md
+++ b/release/h/haroi/HISTORY.md
@@ -1,6 +1,9 @@
 Haroi Keyboard Change History
 =======================
 
+1.2 (08 Dec 2020)
+* Add additional rules for handling combining overline
+
 1.1 (10 Jan 2020)
 * Add additional rules to handle either NFC or NFD vowels
 

--- a/release/h/haroi/haroi.keyboard_info
+++ b/release/h/haroi/haroi.keyboard_info
@@ -1,7 +1,6 @@
 {
     "license": "mit",
     "languages": [
-        "hro-Latn-VN",
         "hro-Latn",
         "vi"
     ],	

--- a/release/h/haroi/haroi.kpj
+++ b/release/h/haroi/haroi.kpj
@@ -12,11 +12,11 @@
       <ID>id_11adc6ce83f2aa6ca1a1c25976fd9e21</ID>
       <Filename>haroi.kmn</Filename>
       <Filepath>source\haroi.kmn</Filepath>
-      <FileVersion>1.1</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Haroi</Name>
-        <Copyright>© 2019 SIL International</Copyright>
+        <Copyright>© 2019-2020 SIL International</Copyright>
         <Message>This keyboard is adapted from VNI.</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>Haroi</Name>
-        <Copyright>© 2019 SIL International</Copyright>
+        <Copyright>© 2019-2020 SIL International</Copyright>
       </Details>
     </File>
     <File>

--- a/release/h/haroi/source/haroi.kmn
+++ b/release/h/haroi/source/haroi.kmn
@@ -219,12 +219,18 @@ U+0115 + [K_5]   > context(1) U+0323     c for E85 > Ẹ̆
 
 any(gravevowels) + [K_5]    > context(1) U+0323     c for o25 > ọ̀
 
-c Cope with diacritic and composing overline
-U+0300 + [K_5] > context(1) U+0323
-U+0301 + [K_5] > context(1) U+0323
-U+0303 + [K_5] > context(1) U+0323
-U+0306 + [K_5] > context(1) U+0323
-U+0309 + [K_5] > context(1) U+0323
+
+store(diacritic)  U+0300 U+0301 U+0302 U+0303 U+0306 U+0309 U+031B U+0323
+
+c Add another diacritic in NFD
+any(diacritic) + [K_1] > context(1) U+0301 c acute
+any(diacritic) + [K_2] > context(1) U+0300 c grave
+any(diacritic) + [K_3] > context(1) U+0309 c hook above
+any(diacritic) + [K_4] > context(1) U+0303 c tilde
+any(diacritic) + [K_5] > context(1) U+0323 c dot below
+any(diacritic) + [K_6] > context(1) U+0302 c grave
+any(diacritic) + [K_7] > context(1) U+031b c horn
+any(diacritic) + [K_8] > context(1) U+0306 c breve
 
 c =======================================================================================================
 

--- a/release/h/haroi/source/haroi.kmn
+++ b/release/h/haroi/source/haroi.kmn
@@ -4,8 +4,8 @@ store(&TARGETS) 'any'
 store(&BITMAP) 'haroi.ico'
 store(&VISUALKEYBOARD) 'haroi.kvks'
 store(&LAYOUTFILE) 'haroi.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.1'
-store(&COPYRIGHT) '© 2019 SIL International'
+store(&KEYBOARDVERSION) '1.2'
+store(&COPYRIGHT) '© 2019-2020 SIL International'
 store(&MESSAGE) 'This keyboard is adapted from VNI.'
 
 begin Unicode > use(main)
@@ -218,6 +218,13 @@ U+0115 + [K_4]   > context(1) U+0303     c for E84 > Ĕ̃
 U+0115 + [K_5]   > context(1) U+0323     c for E85 > Ẹ̆
 
 any(gravevowels) + [K_5]    > context(1) U+0323     c for o25 > ọ̀
+
+c Cope with diacritic and composing overline
+U+0300 + [K_5] > context(1) U+0323
+U+0301 + [K_5] > context(1) U+0323
+U+0303 + [K_5] > context(1) U+0323
+U+0306 + [K_5] > context(1) U+0323
+U+0309 + [K_5] > context(1) U+0323
 
 c =======================================================================================================
 

--- a/release/h/haroi/source/haroi.kps
+++ b/release/h/haroi/source/haroi.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>12.0.64.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.176.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -18,7 +18,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">Haroi</Name>
-    <Copyright URL="">© 2019 SIL International</Copyright>
+    <Copyright URL="">© 2019-2020 SIL International</Copyright>
   </Info>
   <Files>
     <File>
@@ -134,11 +134,10 @@
     <Keyboard>
       <Name>Haroi</Name>
       <ID>haroi</ID>
-      <Version>1.0</Version>
+      <Version>1.2</Version>
       <OSKFont>..\..\..\shared\fonts\sil\charis_sil\CharisSIL-R.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\charis_sil\CharisSIL-R.ttf</DisplayFont>
       <Languages>
-        <Language ID="hro-Latn-VN">Haroi (Latin, Viet Nam)</Language>
         <Language ID="hro-Latn">Haroi (Latin)</Language>
         <Language ID="vi">Vietnamese</Language>
       </Languages>

--- a/release/h/haroi/source/help/haroi.php
+++ b/release/h/haroi/source/help/haroi.php
@@ -9,7 +9,7 @@
 
 
 <p style='margin: 16px 0 0 0'>
-Haroi Keyboard 1.1 is adapted from VNI.
+Haroi Keyboard 1.2 is adapted from VNI.
 </p>
 <p>If square boxes are displayed instead of characters when using this keyboard (and in the keyboard layouts below), please read our <a href="/troubleshooting/#boxes">troubleshooting guide</a>.
 </p>

--- a/release/h/haroi/source/welcome/welcome.htm
+++ b/release/h/haroi/source/welcome/welcome.htm
@@ -15,7 +15,7 @@
 <h1>Start Using Haroi Keyboard</h1>
 
 <p>
-    Haroi Keyboard 1.1 is adapted from VNI.
+    Haroi Keyboard 1.2 is adapted from VNI.
 </p>
 
 <h1>Keyboard Layout</h1>


### PR DESCRIPTION
Fixes keymanapp/keyboards#1392

* Add additional rules for handling combining overline
* Also removes language tag `hro-Latn-VN` (Keyman Developer 14.0 flags it as not being canonical)

Keyboard still undergoing tests