### PR TITLE
[bj_naskapi_classic] Remove .js from package and bump version

### DIFF
--- a/release/bj/bj_naskapi_classic/HISTORY.md
+++ b/release/bj/bj_naskapi_classic/HISTORY.md
@@ -1,6 +1,10 @@
 Naskapi (Classic) Change History
 ====================
 
+2.1.1 (2020-12-11)
+----------------
+* Remove .js file from package as this indicates there is mobile support (there is not)
+
 2.1 (2020-11-13)
 ----------------
 *  split from Naskapi Common 

--- a/release/bj/bj_naskapi_classic/README.md
+++ b/release/bj/bj_naskapi_classic/README.md
@@ -3,7 +3,7 @@ Naskapi (Classic) keyboard
 
 © 2001-2020 Bill Jancewicz
 
-Version 2.1
+Version 2.1.1
 
 Description
 -----------

--- a/release/bj/bj_naskapi_classic/bj_naskapi_classic.kpj
+++ b/release/bj/bj_naskapi_classic/bj_naskapi_classic.kpj
@@ -12,7 +12,7 @@
       <ID>id_deaa5e7c2177ac221e0e910a15d87f1f</ID>
       <Filename>bj_naskapi_classic.kmn</Filename>
       <Filepath>source\bj_naskapi_classic.kmn</Filepath>
-      <FileVersion>2.1</FileVersion>
+      <FileVersion></FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Naskapi (Classic)</Name>
@@ -72,14 +72,6 @@
       <Filepath>source\..\build\bj_naskapi_classic.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
-      <ParentFileID>id_a2c1f22ab8affd016538abb8a7e942cb</ParentFileID>
-    </File>
-    <File>
-      <ID>id_21ffa4b0ac2d04a9920d5d83575093ea</ID>
-      <Filename>bj_naskapi_classic.js</Filename>
-      <Filepath>source\..\build\bj_naskapi_classic.js</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.js</FileType>
       <ParentFileID>id_a2c1f22ab8affd016538abb8a7e942cb</ParentFileID>
     </File>
     <File>

--- a/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kmn
+++ b/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kmn
@@ -3,7 +3,7 @@ c with name "Naskapi (Classic)"
 store(&VERSION) '10.0'
 store(&NAME) 'Naskapi (Classic)'
 store(&COPYRIGHT) '© 2001-2020 Bill Jancewicz'
-store(&KEYBOARDVERSION) '2.1'
+store(&KEYBOARDVERSION) '2.1.1'
 store(&VISUALKEYBOARD) 'bj_naskapi_classic.kvks'
 store(&BITMAP) 'bj_naskapi_classic.ico'
 store(&TARGETS) 'windows macosx linux web desktop'

--- a/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kps
+++ b/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kps
@@ -29,12 +29,6 @@
       <FileType>.kmx</FileType>
     </File>
     <File>
-      <Name>..\build\bj_naskapi_classic.js</Name>
-      <Description></Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.js</FileType>
-    </File>
-    <File>
       <Name>..\build\bj_naskapi_classic.kvk</Name>
       <Description></Description>
       <CopyLocation>0</CopyLocation>
@@ -69,7 +63,7 @@
     <Keyboard>
       <Name>Naskapi (Classic)</Name>
       <ID>bj_naskapi_classic</ID>
-      <Version>2.1</Version>
+      <Version></Version>
       <OSKFont>..\..\..\shared\fonts\cree\bjcrus.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\cree\bjcrus.ttf</DisplayFont>
       <Languages>


### PR DESCRIPTION
I suggested we not have a mobile layout for this keyboard, but I forgot we are not supposed to include .js when there is no mobile layout so I approved it.

This PR removes the .js file from the keyboard and bumps the version. No other changes.