### PR TITLE
fix: use correct modification date

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,27 @@ SHLVL=0
 KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 KMCOMP="$KEYBOARDROOT/tools/kmcomp.exe"
 
+. "$KEYBOARDROOT/resources/util.sh"
+
 case "${OSTYPE}" in
   "cygwin") KMCOMP_LAUNCHER= ;;
   "msys") KMCOMP_LAUNCHER= ;;
+  "darwin"*) 
+    # For Catalina (10.15) onwards, must use wine64
+    base_macos_ver=10.15
+    macos_ver=$(sw_vers -productVersion)
+    if verlt "$macos_ver" "$base_macos_ver"; then
+      KMCOMP_LAUNCHER=wine
+    else
+      # On Catalina, and later versions:
+      # wine-4.12.1 works; wine-5.0, wine-5.7 do not.
+      # retrieve these from:
+      # `brew tap gcenx/wine && brew install --cask --no-quarantine wine-crossover`
+      # may also need to `sudo spctl --master-disable`
+      KMCOMP_LAUNCHER=wine64
+      KMCOMP="$KEYBOARDROOT/tools/kmcomp.x64.exe"
+    fi
+    ;;
   *) KMCOMP_LAUNCHER=wine ;;
 esac
 
@@ -39,7 +57,6 @@ esac
 KEYBOARDINFO_SCHEMA_JSON="$KEYBOARDROOT/tools/keyboard_info.source.json"
 KEYBOARDINFO_SCHEMA_DIST_JSON="$KEYBOARDROOT/tools/keyboard_info.distribution.json"
 
-. "$KEYBOARDROOT/resources/util.sh"
 . "$KEYBOARDROOT/resources/compile.sh"
 . "$KEYBOARDROOT/resources/validate.sh"
 . "$KEYBOARDROOT/resources/merge.sh"

--- a/resources/merge.sh
+++ b/resources/merge.sh
@@ -82,11 +82,12 @@ function merge_keyboard_info {
   # Note, we trim the +00:00 time zone component and replace it with Z
   local pDate=$(TZ=UTC git show --quiet --date=iso-strict-local --format="%cd" | cut -c 1-19 -)Z
 
-  # for macos sed is
-  case "${OSTYPE}" in
-    "darwin") sed -i '' 's/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
-    *) sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
-  esac
+  # for macos sed is not quite gnu-compatible
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
+  else
+    sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
+  fi
 
   return 0
 }

--- a/resources/merge.sh
+++ b/resources/merge.sh
@@ -81,7 +81,12 @@ function merge_keyboard_info {
   # Use the date of the last committed change in this folder and insert into the destination .keyboard_info
   # Note, we trim the +00:00 time zone component and replace it with Z
   local pDate=$(TZ=UTC git show --quiet --date=iso-strict-local --format="%cd" | cut -c 1-19 -)Z
-  sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
+
+  # for macos sed is
+  case "${OSTYPE}" in
+    "darwin") sed -i '' 's/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
+    *) sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
+  esac
 
   return 0
 }

--- a/resources/merge.sh
+++ b/resources/merge.sh
@@ -80,13 +80,13 @@ function merge_keyboard_info {
 
   # Use the date of the last committed change in this folder and insert into the destination .keyboard_info
   # Note, we trim the +00:00 time zone component and replace it with Z
-  local pDate=$(TZ=UTC git show --quiet --date=iso-strict-local --format="%cd" | cut -c 1-19 -)Z
+  local pDate=$(TZ=UTC git log --quiet --date=iso-strict-local --format="%cd" -n 1 -- . | cut -c 1-19 -)Z
 
   # for macos sed is not quite gnu-compatible
   if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i '' 's/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
   else
-    sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut" ;;
+    sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
   fi
 
   return 0

--- a/resources/merge.sh
+++ b/resources/merge.sh
@@ -84,9 +84,9 @@ function merge_keyboard_info {
 
   # for macos sed is not quite gnu-compatible
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' 's/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
+    sed -i '' -E 's/.+"lastModifiedDate".+/  "lastModifiedDate": "'$pDate'",/' "build/$keyboard_info"
   else
-    sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "$pOut"
+    sed -i '/"lastModifiedDate"/c\  "lastModifiedDate": "'$pDate'",' "build/$keyboard_info"
   fi
 
   return 0


### PR DESCRIPTION
Fixes keymanapp/api.keyman.com#136.

Instead of using the date of the build, we now use the last changed date for the folder according to the git log, which is significantly more useful!

For example, for gff_amharic.keyboard_info, this produces (snipped):

```json
{
  "id": "gff_amharic",
  "authorName": "The Ge'ez Frontier Foundation",
  "authorEmail": "keyboards@ethiopic.org",
  "lastModifiedDate": "2020-12-04T04:57:34Z",
  "sourcePath": "release/gff/gff_amharic",
  "version": "1.9.2",
  "packageFilename": "gff_amharic.kmp"
}
```

instead of:

```json
{
  "id": "gff_amharic",
  "authorName": "The Ge'ez Frontier Foundation",
  "authorEmail": "keyboards@ethiopic.org",
  "lastModifiedDate": "2021-01-14T23:08:09.024Z",
  "sourcePath": "release/gff/gff_amharic",
  "version": "2.0",
  "packageFilename": "gff_amharic.kmp"
}
```