### PR TITLE
[fv_gwichin][fv_southern_tutchone]version bump

### DIFF
--- a/release/fv/fv_gwichin/HISTORY.md
+++ b/release/fv/fv_gwichin/HISTORY.md
@@ -1,6 +1,10 @@
 Gwich'in Change History
 ============================
 
+9.2.1 (23 Feb 2021)
+----------------
+* Increment version number to force recompile of touch layout.
+
 9.2 (27 Jun 2019)
 ----------------
 * Canonical ordering normalized (U+0323 and U+0328)

--- a/release/fv/fv_gwichin/LICENSE.md
+++ b/release/fv/fv_gwichin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_gwichin/README.md
+++ b/release/fv/fv_gwichin/README.md
@@ -1,9 +1,9 @@
 Gwich'in keyboard
 ======================
 
-Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.2
+Version 9.2.1
 
 Gwich'in keyboard layout for Unicode
 

--- a/release/fv/fv_gwichin/source/fv_gwichin.kmn
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kmn
@@ -1,8 +1,8 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) '9.2'
+store(&KEYBOARDVERSION) '9.2.1'
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "gwi"
-store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) "Gwich'in"
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_gwichin.ico'

--- a/release/fv/fv_gwichin/source/fv_gwichin.kps
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kps
@@ -12,7 +12,7 @@
   </Options>
   <Info>
     <Name URL="">Gwich'in</Name>
-    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>

--- a/release/fv/fv_southern_tutchone/HISTORY.md
+++ b/release/fv/fv_southern_tutchone/HISTORY.md
@@ -1,6 +1,10 @@
 Southern Tutchone Change History
 ============================
 
+9.2.1 (23 Feb 2021)
+----------------
+* Increment version number to force recompile of touch layout
+
 9.2 (1 Jul 2019)
 ----------------
 * Fix canonical ordering for U+0328

--- a/release/fv/fv_southern_tutchone/LICENSE.md
+++ b/release/fv/fv_southern_tutchone/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_southern_tutchone/README.md
+++ b/release/fv/fv_southern_tutchone/README.md
@@ -1,9 +1,9 @@
 Southern Tutchone keyboard
 ======================
 
-Copyright (c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.2
+Version 9.2.1
 
 Southern Tutchone keyboard layout for Unicode
 

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kmn
@@ -1,8 +1,8 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) '9.2'
+store(&KEYBOARDVERSION) '9.2.1'
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "tce"
-store(&COPYRIGHT) "(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
+store(&COPYRIGHT) "(c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey"
 store(&NAME) 'Southern Tutchone'
 store(&HOTKEY) '[CTRL SHIFT K_1]'
 store(&BITMAP) 'fv_southern_tutchone.ico'

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Southern Tutchone</Name>
-    <Copyright URL="">(c) 2008-2019 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
+    <Copyright URL="">(c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>


### PR DESCRIPTION
This PR addresses two of the five keyboards listed in issue #1375 
- The following keyboards have their version number incremented:
  - fv_gwichin
  - fv_southern_tutchone
- The following will be handled by whatever PR addresses issue 1237:
  - fv_taltan
  - fv_kwakwala_liqwala
- The following will be handled by whatever PR addresses issue 1384:
  - fv_hlgaagilda_xaayda_kil

