### PR TITLE
chore: add blurb from keyman.com to sil_euro_latin keyboard

### DIFF
--- a/release/sil/sil_euro_latin/sil_euro_latin.keyboard_info
+++ b/release/sil/sil_euro_latin/sil_euro_latin.keyboard_info
@@ -3422,7 +3422,7 @@
       }
     }
   },
-  "description": "The EuroLatin keyboard enables you to type in all European languages which use Latin-script, and most Latin-script languages from the rest of the world.",
+  "description": "The EuroLatin keyboard enables you to type in all European languages which use Latin-script, and most Latin-script languages from the rest of the world. If you need a simple solution for typing multiple Latin-script languages from the same keyboard, this keyboard was designed for you.<br><br>The EuroLatin keyboard is ideal for:<ul><li>Home-users who occasionally type or web browse in several languages</li><li>Professional translators</li><li>Scholars and agencies working with multiple European languages</li><li>Libraries running multilingual databases</li><li>Anyone who frequently types in more than one Latin-script language</li></ul>",
   "related": {
     "european": {
       "deprecates": true


### PR DESCRIPTION
We want to merge the separate landing page for sil_euro_latin (https://keyman.com/eurolatin) as it is essentially the same content as the keyboard record. We thought we'd just add this blurb to the keyboard description :)