### PR TITLE
[sil_eastern_congo] Fix bug introduced in previous version

### DIFF
--- a/release/sil/sil_eastern_congo/HISTORY.md
+++ b/release/sil/sil_eastern_congo/HISTORY.md
@@ -1,6 +1,13 @@
 Eastern Congo Keyboard Change History
 =====================================
 
+1.5.2 (23 April 2021)
+------------------
+* Fixed bug where ''e should produce 'e. Instead it produced 'é. This also occurred 
+  when typing ``e which produced `è instead of `e. This bug was introduced between
+  versions 1.5 and 1.5.1 when extra high and extra low tone were introduced and
+  subsequently removed.
+
 1.5.1 (20 April 2021)
 ------------------
 * Removed extra high and extra low tone

--- a/release/sil/sil_eastern_congo/README.md
+++ b/release/sil/sil_eastern_congo/README.md
@@ -3,7 +3,7 @@ Eastern Congo Keyboard
 
 Copyright (C) 2005-2021 SIL International
 
-Version 1.5.1
+Version 1.5.2
 
 __DESCRIPTION__
 Eastern Congo keyboard for languages of the Democratic Republic of the Congo.

--- a/release/sil/sil_eastern_congo/sil_eastern_congo.kpj
+++ b/release/sil/sil_eastern_congo/sil_eastern_congo.kpj
@@ -12,7 +12,7 @@
       <ID>id_f2515d025cb1353295e3dd4652287e76</ID>
       <Filename>sil_eastern_congo.kmn</Filename>
       <Filepath>source\sil_eastern_congo.kmn</Filepath>
-      <FileVersion>1.5.1</FileVersion>
+      <FileVersion>1.5.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Eastern Congo</Name>

--- a/release/sil/sil_eastern_congo/source/sil_eastern_congo.kmn
+++ b/release/sil/sil_eastern_congo/source/sil_eastern_congo.kmn
@@ -9,7 +9,7 @@ store(&copyright) "© 2005-2021 SIL - Eastern Congo Group"
 store(&MESSAGE) 'Eastern Congo keyboard for languages of the Democratic Republic of the Congo.'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'sil_eastern_congo.kvks'
-store(&KEYBOARDVERSION) '1.5.1'
+store(&KEYBOARDVERSION) '1.5.2'
 store(&LAYOUTFILE) 'sil_eastern_congo.keyman-touch-layout'
 
 begin Unicode > use(main)
@@ -23,13 +23,6 @@ store(basic_diacritics) U+0041 U+0044 U+0045 U+0049 U+004D \
                         U+0061 U+0064 U+0065 U+0069 U+006D \
                         U+006E U+006F U+0072 U+0073 \
                         U+0075 U+007A
-
-c Characters than can take extra high and extra low tone
-c store(spc_high_lowK)  "e"    "r"    "i"    "6"    "8"    "o"    "u"    "7"    "t"    "9"    "p"    "m"    "n"
-c store(spc_high_low)   U+025B U+0259 U+0268 U+026A U+0269 U+0254 U+0289 U+028A U+01DD U+0275 U+00F8 U+0272 U+014B 
-c store(basic_high_low) U+0061 U+0065 U+0069 U+006F U+0075 U+006D U+006E
-              
-
 
 c All characters on standard keyboard
 store(all_basic_chars) "A"    "B"    "C"    "D"    "E"    "F"    "G"    "H"    "I"    "J"    "K" "L" \
@@ -105,10 +98,8 @@ any(spc) + any(semi_chars_K)    > index(semi_chars_U,2)         c all special ch
 c standard characters on keyboard
 "^" + any(basic_diacritics) > index(basic_diacritics,2) U+0302 use(nfc)       c circumflex
 "!" + any(basic_diacritics) > index(basic_diacritics,2) U+030C use(nfc)        c caron
-c "``" + any(basic_high_low) > index(basic_high_low,3) U+030F use(nfc)        c double grave
 "`" + any(basic_diacritics) > index(basic_diacritics,2) U+0300 use(nfc)        c grave
 "'" + any(basic_diacritics) > index(basic_diacritics,2) U+0301 use(nfc)        c acute
-c "!!" + any(basic_high_low) > index(basic_high_low,3) U+030B use(nfc)        c double acute
 ":" + any(basic_diacritics) > index(basic_diacritics,2) U+0308 use(nfc)        c diaersis (This was " before.)
 "@" + any(basic_diacritics) > index(basic_diacritics,2) U+0304 use(nfc)        c macron
 "~" + any(basic_diacritics) > index(basic_diacritics,2) U+0303 use(nfc)        c tilde
@@ -116,9 +107,7 @@ c "!!" + any(basic_high_low) > index(basic_high_low,3) U+030B use(nfc)        c 
 "^" any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0302 use(nfc)
 "!" any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+030C use(nfc)
 "`" any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0300 use(nfc)
-c "``" any(spc) + any(spc_high_lowK) > index(spc_high_low,4) U+030F use(nfc)
 "'" any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0301 use(nfc)
-c "''" any(spc) + any(spc_high_lowK) > index(spc_high_low,4) U+030B use(nfc)
 ":" any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0308 use(nfc)
 '@' any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0304 use(nfc)
 '~' any(spc) + any(dia_chars_K) > index(dia_chars_U,3) U+0303 use(nfc)
@@ -180,14 +169,14 @@ any(spc) + "`" > U+02CB  c modifier letter grave accent
 "=" any(spc) + "@" > U+0304 use(nfc)  c combining macron
 
 c changed lines 117-125 to use dk(block_convert) to terminate processing on advice from MD. AC 26/04/18
-"''" + "'" > "'" dk(block_convert) c single apostrophe, stop context
-"``" + "`" > "`" dk(block_convert)
+"'" + "'" > "'" dk(block_convert) c single apostrophe, stop context
+any(spc) + any(spc) > outs(spc) dk(block_convert)
+"`" + "`" > "`" dk(block_convert)
 '"' + '"' > '"' dk(block_convert)
 "=" + "=" > "=" dk(block_convert)
 ":" + ":" > ":" dk(block_convert)
 "^" + "^" > "^" dk(block_convert)
 "@" + "@" > "@" dk(block_convert)
-any(spc) + any(spc) > outs(spc) dk(block_convert)
 c "'" + "'" > U+0027 dk(block_convert)   c apostrophe, stop context
 c any(accent) + any(vowel) > index(vowel,2) index(accent,1)
 c any(vowel) any(accent) + [K_BKSP] > nul
@@ -350,24 +339,5 @@ U+005A U+0302 > U+1E90
 c z caron
 U+007A U+030C > U+017E
 U+005A U+030C > U+017D
-
-c double grave aeiou - not supported by this keyboard
-U+0061 U+030F > U+0201
-U+0041 U+030F > U+0200
-
-U+0065 U+030F > U+0205
-U+0045 U+030F > U+0204
-
-U+0069 U+030F > U+0209
-U+0049 U+030F > U+0208
-
-U+006F U+030F > U+020D
-U+004F U+030F > U+020C
-
-U+0072 U+030F > U+0211
-U+0052 U+030F > U+0210
-
-U+0075 U+030F > U+0215
-U+0045 U+030F > U+0214
 
 c EOF


### PR DESCRIPTION
Well, this keyboard has been a true mess. Sorry about this! I think it's finally correct.
Typing `''` to get `'` and ` `` ` to get ` was messed up when we tried to implement extra high and extra low tone. Then I forgot to revert two rules in the previous version.
