### PR TITLE
[hieroglyphic] Fix platforms in keyboard_info file

### DIFF
--- a/release/h/hieroglyphic/HISTORY.md
+++ b/release/h/hieroglyphic/HISTORY.md
@@ -1,6 +1,10 @@
 Hieroglyphic Keyboard Change History
 =======================
 
+1.3.2 (29 Apr 2021)
+-------------------
+* Remove JS file from keyboard package
+
 1.3.1 (23 Apr 2019)
 -------------------
 * Rebuild to resolve compatibility issue with Chrome

--- a/release/h/hieroglyphic/HISTORY.md
+++ b/release/h/hieroglyphic/HISTORY.md
@@ -3,7 +3,7 @@ Hieroglyphic Keyboard Change History
 
 1.3.2 (29 Apr 2021)
 -------------------
-* Remove JS file from keyboard package
+* Remove JS file from keyboard package as the keyboard does not currently support mobile devices
 
 1.3.1 (23 Apr 2019)
 -------------------

--- a/release/h/hieroglyphic/hieroglyphic.keyboard_info
+++ b/release/h/hieroglyphic/hieroglyphic.keyboard_info
@@ -1,6 +1,13 @@
 {
-    "license": "mit",
-    "languages": ["egy-Egyp"],
-    "legacyId": 651,
-    "description": "This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text."
+  "license": "mit",
+  "languages": ["egy-Egyp"],
+  "legacyId": 651,
+  "description": "This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text.",
+  "platformSupport": {
+    "windows": "full",
+    "macos": "full",
+    "linux": "full",
+    "desktopWeb": "full"
+  }
+
 }

--- a/release/h/hieroglyphic/hieroglyphic.keyboard_info
+++ b/release/h/hieroglyphic/hieroglyphic.keyboard_info
@@ -2,12 +2,5 @@
   "license": "mit",
   "languages": ["egy-Egyp"],
   "legacyId": 651,
-  "description": "This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text.",
-  "platformSupport": {
-    "windows": "full",
-    "macos": "full",
-    "linux": "full",
-    "desktopWeb": "full"
-  }
-
+  "description": "This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text."
 }

--- a/release/h/hieroglyphic/source/hieroglyphic.kmn
+++ b/release/h/hieroglyphic/source/hieroglyphic.kmn
@@ -3,7 +3,7 @@ store(&NAME) 'Hieroglyphic'
 store(&BITMAP) 'hieroglyphic.ico'
 store(&INCLUDECODES) 'codes.txt'
 
-store(&COPYRIGHT) '© 2010-2021 Christian Casey'
+store(&COPYRIGHT) '© 2010-2019 Christian Casey'
 store(&ETHNOLOGUECODE) 'egy'
 store(&VISUALKEYBOARD) 'hieroglyphic.kvks'
 store(&KEYBOARDVERSION) '1.3.2'

--- a/release/h/hieroglyphic/source/hieroglyphic.kmn
+++ b/release/h/hieroglyphic/source/hieroglyphic.kmn
@@ -3,10 +3,10 @@ store(&NAME) 'Hieroglyphic'
 store(&BITMAP) 'hieroglyphic.ico'
 store(&INCLUDECODES) 'codes.txt'
 
-store(&COPYRIGHT) '© 2010-2019 Christian Casey'
+store(&COPYRIGHT) '© 2010-2021 Christian Casey'
 store(&ETHNOLOGUECODE) 'egy'
 store(&VISUALKEYBOARD) 'hieroglyphic.kvks'
-store(&KEYBOARDVERSION) '1.3.1'
+store(&KEYBOARDVERSION) '1.3.2'
 store(&TARGETS) 'windows macosx linux web'
 
 begin Unicode > use(main)

--- a/release/h/hieroglyphic/source/hieroglyphic.kps
+++ b/release/h/hieroglyphic/source/hieroglyphic.kps
@@ -22,12 +22,6 @@
   </Info>
   <Files>
     <File>
-      <Name>..\build\hieroglyphic.js</Name>
-      <Description>File hieroglyphic.js</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.js</FileType>
-    </File>
-    <File>
       <Name>..\build\hieroglyphic.kvk</Name>
       <Description>File hieroglyphic.kvk</Description>
       <CopyLocation>0</CopyLocation>


### PR DESCRIPTION
While investigating keymanapp/keyman#4990 I was able to install hieroglyphic keyboard on Keyman for Android.
I wondered why:
1. The keyboard wasn't working (e.g Shift-H)
2. The bottom right key on the default layer had no output
![hieroglyphic default layer](https://user-images.githubusercontent.com/7358010/116341248-c26d1480-a80a-11eb-8ca6-b84b6c7ff1fe.png)

Turns out the hieroglyphic keyboard should not be available on mobile apps though
https://keyman.com/keyboards/hieroglyphic lists:

![hieroglyphic platforms](https://user-images.githubusercontent.com/7358010/116341042-65715e80-a80a-11eb-9ce1-0de29c518d09.PNG)

hieroglyphic.kmn only targets 
```
store(&TARGETS) 'windows macosx linux web'
```

I suspect kmcomp sees the .js file in the .kmp file and erroneously includes Android and iOS.

This PR fixes the platforms that get listed in the keyboard_info file.
