### PR TITLE
GFF Gurage v0.8.1

### DIFF
--- a/release/gff/gff_gurage/HISTORY.md
+++ b/release/gff/gff_gurage/HISTORY.md
@@ -1,5 +1,8 @@
 # ጉራጊና (Gurage) Change History
 
+## 2021-06-22 0.8.1
+* Change of language version from '14.0' (non-existent) to '10.0'.
+
 ## 2021-06-09 0.8
 * Update for Ethiopic Extended-B block from Unicode 14.
 * The Gurage Wookianos font added from the "Gurage Font Collection".

--- a/release/gff/gff_gurage/HISTORY.md
+++ b/release/gff/gff_gurage/HISTORY.md
@@ -1,7 +1,7 @@
 # ጉራጊና (Gurage) Change History
 
 ## 2021-06-22 0.8.1
-* Change of language version from '14.0' (non-existent) to '10.0'.
+* Change of Keyman version from '14.0' (non-existent) to '10.0'.
 
 ## 2021-06-09 0.8
 * Update for Ethiopic Extended-B block from Unicode 14.

--- a/release/gff/gff_gurage/README.md
+++ b/release/gff/gff_gurage/README.md
@@ -3,7 +3,7 @@
 
 Copyright (C) 2019-2021 Ge'ez Frontier Foundation
 
-Version 0.8
+Version 0.8.1
 
 This is a Gurage (ጉራጊና , ISO-639-2 swg) language mnemonic input method for the 
 Gurage orthography devised by Dr. Fekede Menuta and adopted in Unicode 14.  It requires a font

--- a/release/gff/gff_gurage/gff_gurage.keyboard_info
+++ b/release/gff/gff_gurage/gff_gurage.keyboard_info
@@ -1,4 +1,4 @@
-{
+{ 
   "name": "Gurage",
   "license": "mit",
   "languages": {

--- a/release/gff/gff_gurage/gff_gurage.keyboard_info
+++ b/release/gff/gff_gurage/gff_gurage.keyboard_info
@@ -5,8 +5,8 @@
     "sgw-Ethi": {
     }
   },
-  "description": "This is a Gurage (ጉራጊና , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard. A collection of six fonts with names beginning with \"Gurage\" are included with this package.",
-  "minKeymanVersion": "14.0",
+  "description": "This is a Gurage (ጉራጊና , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard. A collection of five fonts with names beginning with \"Gurage\" are included with this package.",
+  "minKeymanVersion": "10.0",
   "related": {
     "gff_sgw_7": {
       "deprecates": true

--- a/release/gff/gff_gurage/gff_gurage.keyboard_info
+++ b/release/gff/gff_gurage/gff_gurage.keyboard_info
@@ -1,4 +1,4 @@
-{ 
+{
   "name": "Gurage",
   "license": "mit",
   "languages": {

--- a/release/gff/gff_gurage/gff_gurage.kpj
+++ b/release/gff/gff_gurage/gff_gurage.kpj
@@ -17,7 +17,7 @@
       <Details>
         <Name>ጉራጌ (Gurage)</Name>
         <Copyright>© 2019-2021 Ge’ez Frontier Foundation</Copyright>
-        <Message>This is a Gurage language mnemonic input method.  It requires the "Gurage Zebidar" Ethiopic which contains experimental characters.</Message>
+        <Message>This is a Gurage (ጉራጊና) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard.</Message>
       </Details>
     </File>
     <File>

--- a/release/gff/gff_gurage/gff_gurage.kpj
+++ b/release/gff/gff_gurage/gff_gurage.kpj
@@ -12,7 +12,7 @@
       <ID>id_6205fca46d8f3b2897cd1b3004453157</ID>
       <Filename>gff_gurage.kmn</Filename>
       <Filepath>source\gff_gurage.kmn</Filepath>
-      <FileVersion>0.8</FileVersion>
+      <FileVersion>0.8.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ጉራጌ (Gurage)</Name>

--- a/release/gff/gff_gurage/source/gff_gurage.kmn
+++ b/release/gff/gff_gurage/source/gff_gurage.kmn
@@ -1,8 +1,7 @@
 ﻿c =====================Begin Identity Section===================================================
 c 
 c The Ge'ez Frontier Foundation's mnemonic input method for the experimental Gurage orthography
-c devised by Dr. Fekede Menuta.  The keyboard is intended for use with the "Zebidar" font which
-c in turn is deived from Abyssinica SIL with glyph modifications and private use additions.
+c devised by Dr. Fekede Menuta and adopted in the Unicode 14 Ethiopic Extended-B block.
 c 
 c Keyman        :  http://www.keyman.com/
 c Documentation :  https://help.keyman.com/keyboard/gff_gurage/0.6/gff_gurage.php
@@ -18,7 +17,7 @@ store(&KEYBOARDVERSION) '0.8.1'
 store(&NAME) 'ጉራጌ (Gurage)'
 c store(&ETHNOLOGUECODE) 'sgw'
 store(&COPYRIGHT) '© 2019-2021 Ge’ez Frontier Foundation'
-store(&MESSAGE) 'This is a Gurage language mnemonic input method.  It requires the "Gurage Zebidar" Ethiopic which contains experimental characters.'
+store(&MESSAGE) 'This is a Gurage (ጉራጊና) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard.'
   store(&CapsAlwaysOff) '1'
   store(&HotKey) '[CTRL ALT K_G]'
 store(&BITMAP) 'gff_gurage.ico'

--- a/release/gff/gff_gurage/source/gff_gurage.kmn
+++ b/release/gff/gff_gurage/source/gff_gurage.kmn
@@ -13,8 +13,8 @@ c
 c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
-  store(&Version) '14.0'
-store(&KEYBOARDVERSION) '0.8'
+  store(&Version) '10.0'
+store(&KEYBOARDVERSION) '0.8.1'
 store(&NAME) 'ጉራጌ (Gurage)'
 c store(&ETHNOLOGUECODE) 'sgw'
 store(&COPYRIGHT) '© 2019-2021 Ge’ez Frontier Foundation'

--- a/release/gff/gff_gurage/source/gff_gurage.kps
+++ b/release/gff/gff_gurage/source/gff_gurage.kps
@@ -12,7 +12,7 @@
     <FollowKeyboardVersion/>
   </Options>
   <StartMenu>
-    <Folder>Zebidar Gurage Keyboard</Folder>
+    <Folder>GFF Gurage Keyboard</Folder>
     <AddUninstallEntry/>
     <Items>
       <Item>

--- a/release/packages/gff_gurage_and_amharic/HISTORY.md
+++ b/release/packages/gff_gurage_and_amharic/HISTORY.md
@@ -1,5 +1,7 @@
 # Amharic (አማርኛ) & Gurage (ጉራጌ) Keyboards
 
+## 0.8.1 (22 June 2021)
+* Resync with Gurage package to fix macOS installation issue.
 
 ## 0.8 (06 Jun 2021)
 * Resync with Gurage package for Unicode 14 updates.

--- a/release/packages/gff_gurage_and_amharic/README.md
+++ b/release/packages/gff_gurage_and_amharic/README.md
@@ -3,7 +3,7 @@ Amharic (አማርኛ) & Gurage (ጉራጌ) Keyboards
 
 Copyright (C) 2019-2021 Ge'ez Frontier Foundation
 
-Version 0.8.0
+Version 0.8.1
 =======
 
 This package aggregates the GFF Amharic and Gurage keyboards.  Complete documentation on the keyboards

--- a/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.keyboard_info
+++ b/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.keyboard_info
@@ -25,7 +25,6 @@
     }
   },
   "description": "This package provides both the GFF Gurage and Amharic keyboards.",
-  "minKeymanVersion": "14.0",
   "platformSupport": {
     "windows": "full",
     "macos": "full",

--- a/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.kpj
+++ b/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.kpj
@@ -24,7 +24,7 @@
       <ID>id_41f7a10af6dd1e2560a4a7fdf787c5ad</ID>
       <Filename>gff_gurage.kmn</Filename>
       <Filepath>..\..\gff\gff_gurage\source\gff_gurage.kmn</Filepath>
-      <FileVersion>0.8</FileVersion>
+      <FileVersion>0.8.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ጉራጌ (Gurage)</Name>
@@ -36,12 +36,12 @@
       <ID>id_9fc3e3d4a484b7e55d32b73995631eed</ID>
       <Filename>gff_gurage_and_amharic.kps</Filename>
       <Filepath>source\gff_gurage_and_amharic.kps</Filepath>
-      <FileVersion>0.8</FileVersion>
+      <FileVersion>0.8.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Gurage and Amharic Keyboard Package</Name>
         <Copyright>© 2019-2021 Ge’ez Frontier Foundation</Copyright>
-        <Version>0.8</Version>
+        <Version>0.8.1</Version>
       </Details>
     </File>
     <File>

--- a/release/packages/gff_gurage_and_amharic/source/gff_gurage_and_amharic.kps
+++ b/release/packages/gff_gurage_and_amharic/source/gff_gurage_and_amharic.kps
@@ -60,7 +60,7 @@
     </Items>
   </StartMenu>
   <Info>
-    <Version URL="">0.8</Version>
+    <Version URL="">0.8.1</Version>
     <Name URL="">Gurage and Amharic Keyboard Package</Name>
     <Copyright URL="">© 2019-2021 Ge’ez Frontier Foundation</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Ge’ez Frontier Foundation</Author>


### PR DESCRIPTION
The only change to the keyboard file is the VERSION string is set to '10.0' from '14.0', which is erroneous and caused an issue on macOs (discussed in: https://github.com/keymanapp/keyboards/pull/1513#issuecomment-818269381).  The fix corresponds to the reported issue: https://github.com/keymanapp/keyman/issues/5316

I had made this error earlier with gff_amharic , I had actually updated gff_gurage evern earlier but did not submit it, then forgot about the VERSION string.