### PR TITLE
fix(balochi_phonetic): typo in .kps masking .ttf

### DIFF
--- a/release/b/balochi_phonetic/HISTORY.md
+++ b/release/b/balochi_phonetic/HISTORY.md
@@ -1,9 +1,13 @@
 Balochi Phonetic Change History
 ===============================
+1.4.1 (19 July 2021)
+--------------------
+Fix issue in package blocking distribution of Lateef font.
+
 1.4 (28 May 2021)
 -----------------
-Zal and Hamza letters added. Left and right single and double quotation marks 
-added. En-dash added. Right-to-left mark and left-to-right mark added. 
+Zal and Hamza letters added. Left and right single and double quotation marks
+added. En-dash added. Right-to-left mark and left-to-right mark added.
 
 1.3.2 (27 October 2020)
 -----------------------
@@ -22,7 +26,7 @@ Other minor changes.
 
 1.2 (9 Aug 2019)
 ----------------
-Removed deadkeys for Indic numbers. Use ctrl combination instead. Added the 
+Removed deadkeys for Indic numbers. Use ctrl combination instead. Added the
 zero-width joiner and better visuals for the zero-width non-joiner. Added
 ', ", :, and - to desktop versions. Made unused tablet keys output nothing.
 Corrected key visuals for key pairs like () for tablet keyboard.

--- a/release/b/balochi_phonetic/balochi_phonetic.kpj
+++ b/release/b/balochi_phonetic/balochi_phonetic.kpj
@@ -80,6 +80,14 @@
       <ParentFileID>id_01e3812c58888136c59800dc1f434d32</ParentFileID>
     </File>
     <File>
+      <ID>id_19860173bf5147bf3ffec13384fe522a</ID>
+      <Filename>LateefRegOT.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\lateef\LateefRegOT.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
+      <ParentFileID>id_01e3812c58888136c59800dc1f434d32</ParentFileID>
+    </File>
+    <File>
       <ID>id_545d33cfb6b7f83915ad6d09dee30def</ID>
       <Filename>phoneticU_.png</Filename>
       <Filepath>source\welcome\phoneticU_.png</Filepath>

--- a/release/b/balochi_phonetic/balochi_phonetic.kpj
+++ b/release/b/balochi_phonetic/balochi_phonetic.kpj
@@ -12,7 +12,7 @@
       <ID>id_c7ff70eb71a333c08b46b9b831957b57</ID>
       <Filename>balochi_phonetic.kmn</Filename>
       <Filepath>source\balochi_phonetic.kmn</Filepath>
-      <FileVersion>1.4</FileVersion>
+      <FileVersion>1.4.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Balochi Phonetic</Name>
@@ -30,6 +30,34 @@
         <Name>Balochi Phonetic</Name>
         <Copyright>© 2017-2021 SIL International. This keyboard is distributed under The MIT License (MIT).</Copyright>
       </Details>
+    </File>
+    <File>
+      <ID>id_0730bb7c2e8f9ea2438b52e419dd86c9</ID>
+      <Filename>README.md</Filename>
+      <Filepath>README.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_53e892b8b41cc4caece1cfd5ef21d6e7</ID>
+      <Filename>LICENSE.md</Filename>
+      <Filepath>LICENSE.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_ede98e4633e239f933cbfd1f4e1b766c</ID>
+      <Filename>HISTORY.md</Filename>
+      <Filepath>HISTORY.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_4007dc5bff0be87baf7ad0e7d05fb3e8</ID>
+      <Filename>balochi_phonetic.keyboard_info</Filename>
+      <Filepath>balochi_phonetic.keyboard_info</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.keyboard_info</FileType>
     </File>
     <File>
       <ID>id_9e940e1ccefd64aed7c400f63dc28b5c</ID>

--- a/release/b/balochi_phonetic/source/balochi_phonetic.kmn
+++ b/release/b/balochi_phonetic/source/balochi_phonetic.kmn
@@ -3,13 +3,13 @@ store(&NAME) 'Balochi Phonetic'
 store(&TARGETS) 'any'
 store(&KMW_RTL) '1'
 store(&LAYOUTFILE) 'balochi_phonetic.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.4'
+store(&KEYBOARDVERSION) '1.4.1'
 store(&COPYRIGHT) '© 2017-2021 SIL International'
 store(&MESSAGE) 'The Balochi Phonetic keyboard is distributed under The MIT License (MIT).'
 store(&KMW_HELPTEXT) 'This is a phonetically organized Balochi keyboard.'
 store(&VISUALKEYBOARD) 'balochi_phonetic.kvks'
 store(&BITMAP) 'balochi_phonetic.ico'
-     
+
 begin Unicode > use(main)
 
 group(main) using keys

--- a/release/b/balochi_phonetic/source/balochi_phonetic.kps
+++ b/release/b/balochi_phonetic/source/balochi_phonetic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>14.0.274.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>15.0.68.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -58,12 +58,12 @@
       <FileType>.htm</FileType>
     </File>
     <File>
-    <File>
       <Name>..\..\..\shared\fonts\sil\lateef\LateefRegOT.ttf</Name>
       <Description>Font Lateef</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.ttf</FileType>
     </File>
+    <File>
       <Name>welcome\phoneticU_.png</Name>
       <Description>File phoneticU_.png</Description>
       <CopyLocation>0</CopyLocation>
@@ -94,6 +94,8 @@
       <ID>balochi_phonetic</ID>
       <Version>1.4</Version>
       <RTL>True</RTL>
+      <OSKFont>..\..\..\shared\fonts\sil\lateef\LateefRegOT.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\lateef\LateefRegOT.ttf</DisplayFont>
       <Languages>
         <Language ID="bal">Baluchi</Language>
       </Languages>

--- a/release/b/balochi_phonetic/source/balochi_phonetic.kps
+++ b/release/b/balochi_phonetic/source/balochi_phonetic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>15.0.68.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.274.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>


### PR DESCRIPTION
This was causing the .ttf to be excluded from the build, without warning or error.

I have opened a [corresponding issue](https://github.com/keymanapp/keyman/issues/5464) in Keyman Developer to improve validation of .kps files to avoid this in the future.

Picked up by chance in a conversation on Slack!