### PR TITLE
feat: xmllint .kps files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 #
 # This script is built with commands available to Git Bash on Windows. (mingw32)
 #
-# This script and scripts in resources/ should be identical in the 
-# https://github.com/keymanapp/keyboards and 
+# This script and scripts in resources/ should be identical in the
+# https://github.com/keymanapp/keyboards and
 # https://github.com/keymanapp/keyboards_starter repos
 #
 
@@ -31,10 +31,24 @@ KMCOMP="$KEYBOARDROOT/tools/kmcomp.exe"
 
 . "$KEYBOARDROOT/resources/util.sh"
 
+# Look for xmllint on path or XMLLINT env var
+if [ -z ${XMLLINT+x} ]; then
+  if ! hash xmllint 2>/dev/null; then
+    XMLLINT=
+  else
+    XMLLINT=xmllint
+  fi
+fi
+
+
 case "${OSTYPE}" in
-  "cygwin") KMCOMP_LAUNCHER= ;;
-  "msys") KMCOMP_LAUNCHER= ;;
-  "darwin"*) 
+  "cygwin")
+    KMCOMP_LAUNCHER=
+    ;;
+  "msys")
+    KMCOMP_LAUNCHER=
+    ;;
+  "darwin"*)
     # For Catalina (10.15) onwards, must use wine64
     base_macos_ver=10.15
     macos_ver=$(sw_vers -productVersion)
@@ -50,7 +64,9 @@ case "${OSTYPE}" in
       KMCOMP="$KEYBOARDROOT/tools/kmcomp.x64.exe"
     fi
     ;;
-  *) KMCOMP_LAUNCHER=wine ;;
+  *)
+    KMCOMP_LAUNCHER=wine
+    ;;
 esac
 
 # Master json schema is from https://api.keyman.com/schemas/keyboard_info.json

--- a/release/sil/sil_nubian/source/sil_nubian.kps
+++ b/release/sil/sil_nubian/source/sil_nubian.kps
@@ -24,8 +24,8 @@
     </Items>
   </StartMenu>
   <Info>
-    <name URL="">Nubian (SIL) Keyman Keyboard</name>
-    <copyright URL="">© 2008-2020 SIL International</copyright>
+    <Name URL="">Nubian (SIL) Keyman Keyboard</Name>
+    <Copyright URL="">© 2008-2020 SIL International</Copyright>
     <Version URL=""></Version>
     <Author URL="">Lorna Priest Evans</Author>
     <WebSite URL="https://software.sil.org/SophiaNubian">https://software.sil.org/SophiaNubian</WebSite>

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -134,7 +134,7 @@ function build_keyboard {
   #
   # Check if .keyboard_info doesn't exist
   #
-  keyboard_infoFilename="$base_keyboard.keyboard_info"
+  local keyboard_infoFilename="$base_keyboard.keyboard_info"
   if [ ! -f "$keyboard_infoFilename" ]; then
     if [ "$WARNINGS_AS_ERRORS" = true ]; then
       die "$keyboard_infoFilename doesn't exist"
@@ -145,11 +145,13 @@ function build_keyboard {
   fi
 
   #
-  # Validate the .keyboard_info before build
+  # Validate the .keyboard_info and .kps before build
   #
 
+  local packageFilename="source/$base_keyboard.kps"
   validate_keyboard_info "$keyboard_infoFilename" || die "Failed to validate $keyboard_infoFilename in $keyboard"
   validate_keyboard_uniqueness "$group" "$keyboard" "$base_keyboard"
+  validate_package_file "$packageFilename" || die "Failed to validate $packageFilename"
 
   if [ "$DO_BUILD" = false ]; then
     popd

--- a/resources/validate.sh
+++ b/resources/validate.sh
@@ -9,8 +9,27 @@ function validate_keyboard_info {
     echo "Keyboard info file $1 is missing"
     return 99
   fi
-  
+
   $KMCOMP_LAUNCHER "$KMCOMP" -s -v "$1" || return 1
+  return 0
+}
+
+#
+# validate .kps file per XML schema
+#
+function validate_package_file {
+  if [ -z "$XMLLINT" ]; then
+    # if xmllint is not installed, then we'll just skip validation
+    echo "Note: not validating structure of package file $1"
+    return 0
+  fi
+
+  if [ ! -f "$1" ]; then
+    echo "Note: Package file $1 is missing (not failing build)"
+    return 0
+  fi
+
+  "$XMLLINT" --schema "$KEYBOARDROOT/tools/kps.xsd" --noout "$1" || return 1
   return 0
 }
 
@@ -27,11 +46,11 @@ function validate_keyboard_uniqueness {
   local folderlist=$(echo "$KEYBOARD_INFOS" | grep "/$base_keyboard/$base_keyboard.keyboard_info")
 #   ls -d "*/*/$base_keyboard") # | grep -v $group/$shortname/$base_keyboard)
   local duplicate_count=$(wc -l <<< "$folderlist")
-    
+
   if [[ $duplicate_count -gt 1 ]]; then
     die "Keyboard $base_keyboard exists in more than one location:
 $folderlist"
   fi
 
-  return 0  
+  return 0
 }

--- a/tools/kps.xsd
+++ b/tools/kps.xsd
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  .kps file schema, version 7.0
+
+  Copyright (C) SIL International
+
+  Supports KPS files for Keyman Developer 7+
+
+  Expects FileVersion 7.0
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="Package">
+  <xs:complexType>
+    <xs:all>
+
+
+      <xs:element minOccurs="1" maxOccurs="1" name="System">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="1" maxOccurs="1" name="KeymanDeveloperVersion" type="km-version" />
+            <xs:element minOccurs="1" maxOccurs="1" name="FileVersion" type="km-version" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Options">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="ExecuteProgram" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="ReadMeFile" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="GraphicFile" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="MSIFileName" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="MSIOptions" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="FollowKeyboardVersion" type="km-empty" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="StartMenu">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="Folder" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="AddUninstallEntry" type="km-empty" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Items">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" name="Item">
+                    <xs:complexType>
+                      <xs:all>
+                        <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="FileName" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Arguments" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Icon" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Location" type="km-start-menu-location" />
+                      </xs:all>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Info">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="Name" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Version" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Copyright" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Author" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="WebSite" type="km-info" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Files">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="File">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Description" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="CopyLocation" type="km-file-copy-location" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="FileType" type="xs:string" />
+                </xs:all>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Keyboards">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="Keyboard">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="OSKFont" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="DisplayFont" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
+                </xs:all>
+              </xs:complexType>
+              </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="LexicalModels">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="LexicalModel">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
+                </xs:all>
+              </xs:complexType>
+              </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Strings">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="String">
+              <xs:complexType>
+                <xs:attribute name="Name" type="xs:string" />
+                <xs:attribute name="Value" type="xs:string" />
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- Deprecated elements: we won't validate as processors ignore them -->
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Buttons" type="km-any" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Registry" type="km-any" />
+
+    </xs:all>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="km-empty">
+  <xs:sequence/>
+</xs:complexType>
+
+<xs:complexType name="km-any">
+  <xs:sequence>
+    <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType name="km-version">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="(\d+\.)+(\d+)"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="km-info">
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <xs:attribute name="URL" type="xs:anyURI" />
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<xs:simpleType name="km-file-copy-location">
+  <xs:restriction base="xs:integer">
+    <xs:minInclusive value="0" />
+    <xs:maxInclusive value="3"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="km-start-menu-location">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="psmelStartMenu|psmelDesktop"></xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="km-keyboard-languages">
+  <xs:sequence>
+    <xs:element minOccurs="0" maxOccurs="unbounded" name="Language">
+      <xs:complexType>
+        <xs:simpleContent>
+          <xs:extension base="xs:string">
+            <xs:attribute name="ID" type="xs:string" />
+          </xs:extension>
+        </xs:simpleContent>
+      </xs:complexType>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
This adds xmllint checks for .kps file to the build. If xmllint is not on the path, then the XMLLINT variable can be set to point to it; if no xmllint can be found then .kps file structure validation will be skipped (not a failure).

Found minor errors in one .kps file (apart from balochi_phonetic, which is already resolved in a separate branch).

Relates to keymanapp/keyman#5464 and uses .xsd from keymanapp/api.keyman.com#158. Do not merge until api.keyman.com PR is approved (as we may need to propagate changes for the .xsd to this branch).

Note: I will update the build agents to ensure xmllint is available on them too.