### PR TITLE
Update sil_euro_latin.keyman-touch-layout to add Anglo-Saxon support.

### DIFF
--- a/release/sil/sil_euro_latin/source/sil_euro_latin.keyman-touch-layout
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.keyman-touch-layout
@@ -452,7 +452,9 @@
                   },
                   {
                     "id": "U_00E6"
-                  }
+                  },
+                  {
+                    "id": "U_01E3" c Latin small ae with macron for Anglo-Saxon
                 ]
               },
               {
@@ -589,6 +591,10 @@
                   {
                     "text": "ɣ",
                     "id": "U_0263"
+                  },
+                  {
+                    "text": "ȝ",
+                    "id": "U_021D"
                   }
                 ]
               },
@@ -1399,6 +1405,8 @@
                   },
                   {
                     "id": "U_00C6"
+                  },
+                    "id": "U_01E2" c Latin capital AE with macron for Anglo-Saxon
                   }
                 ]
               },
@@ -1529,6 +1537,10 @@
                   {
                     "text": "Ɣ",
                     "id": "U_0194"
+                  },
+                  {
+                    "text": "Ȝ",
+                    "id": "U_021C"
                   }
                 ]
               },

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
@@ -153,6 +153,8 @@ if(&platform = 'touch') + [SHIFT T_0058_0331] > U+0058 U+0331     c Zapotec addi
 c Preferred for digraphs
 'A\' dk(1) + 'E' > 'Æ'
 'a\' dk(1) + 'e' > 'æ'
+'Æ' dk(1) + '-' > U+01E2 c Anglo-Saxon addition 8/20/2021
+'æ' dk(1) + '-' > U+01E3 c Anglo-Saxon addition 8/20/2021
 'c\' dk(1) + 'h' > U+0063 U+0332 U+0068 U+0332  c Zapotec addition 12/2/2020
 'C\' dk(1) + 'h' > U+0043 U+0332 U+0068 U+0332  c Zapotec addition 12/2/2020
 'C\' dk(1) + 'H' > U+0043 U+0332 U+0048 U+0332  c Zapotec addition 12/2/2020
@@ -188,6 +190,8 @@ if(&platform = 'touch') + [SHIFT T_CHmacron] > U+0043 U+0332 U+0048 U+0332  c Za
 't\' dk(1) + 'h' > 'þ'     c deprecated - see extended - no longer in help/osk
 'T\' dk(1) + 'M' > '™'
 't\' dk(1) + 'm' > '™'
+'G\' dk(1) + 'J' > U+021C c Anglo-Saxon addition 8/20/2021
+'g\' dk(1) + 'j' > U+021D c Anglo-Saxon addition 8/20/2021
 
 
 '1//' + '2' > '½'


### PR DESCRIPTION
Adding support for Anglo-Saxon letters. Added Æ, æ with macron. Added Ȝ, ȝ (yogh). Other letters used in Old English already supported by the layout, so not many updates needed.