### PR TITLE
Taigi POJ v1.4: ⁿ only after vowels

### DIFF
--- a/experimental/t/taigi_poj/HISTORY.md
+++ b/experimental/t/taigi_poj/HISTORY.md
@@ -1,6 +1,11 @@
 PhahTaigi POJ Change History
 ====================
 
+1.4 (2021-09-06)
+----------------
+* Updated by Guy Emerson
+* Only allow ⁿ after a vowel, so that "nng" can be typed
+
 1.3 (2021-07-14)
 ----------------
 * Updated by Guy Emerson

--- a/experimental/t/taigi_poj/README.md
+++ b/experimental/t/taigi_poj/README.md
@@ -3,7 +3,7 @@ PhahTaigi POJ
 
 © 2020 Ngô͘ Ka-bêng
 
-Version 1.3
+Version 1.4
 
 Description
 -----------

--- a/experimental/t/taigi_poj/README.md
+++ b/experimental/t/taigi_poj/README.md
@@ -1,7 +1,7 @@
 PhahTaigi POJ
 ==============
 
-© 2020 Ngô͘ Ka-bêng
+© Ngô͘ Ka-bêng
 
 Version 1.4
 

--- a/experimental/t/taigi_poj/source/taigi_poj.kmn
+++ b/experimental/t/taigi_poj/source/taigi_poj.kmn
@@ -10,7 +10,7 @@ store(&VISUALKEYBOARD) 'taigi_poj.kvks'
 store(&BITMAP) 'taigi_poj.ico'
 store(&LAYOUTFILE) 'taigi_poj.keyman-touch-layout'
 store(&COPYRIGHT) '© 2020-2021 Ngô͘ Ka-bêng'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
 
 begin Unicode > use(main)
 
@@ -307,12 +307,21 @@ c
 + [ALT K_oE2] > U+005c
 + [ALT SHIFT K_oE2] > U+007c
 
+c
+c Store vowels
+c
+store(vowels) 'aiueoAIUEO'
+store(vowels_tone2) 'áíúéóÁÍÚÉÓ'
+store(vowels_tone3) 'àìùèòÀÌÙÈÒ'
+store(vowels_tone5) 'âîûêôÂÎÛÊÔ'
+store(vowels_tone7) 'āīūēōĀĪŪĒŌ'
+store(vowels_tone9) 'ăĭŭĕŏĂĬŬĔŎ'
 
 c
 c Special input rules
 c
-"n" + "n" > "ⁿ"
-"N" + "N" > "ⁿ"
+any(vowels) "n" + "n" > context(1) "ⁿ"
+any(vowels) "N" + "N" > context(1) "ⁿ"
 "o" + "o" > "o͘"
 "O" + "o" > "O͘"
 "O" + "O" > "O͘"
@@ -976,13 +985,6 @@ c
 c Vowels with tone numbers
 c
 c Vowels with tone number 2
-store(vowels) 'aiueoAIUEO'
-store(vowels_tone2) 'áíúéóÁÍÚÉÓ'
-store(vowels_tone3) 'àìùèòÀÌÙÈÒ'
-store(vowels_tone5) 'âîûêôÂÎÛÊÔ'
-store(vowels_tone7) 'āīūēōĀĪŪĒŌ'
-store(vowels_tone9) 'ăĭŭĕŏĂĬŬĔŎ'
-
 any(vowels) + "2" > index(vowels_tone2, 1)
 any(vowels) "ⁿ" + "2" > index(vowels_tone2, 1) "ⁿ"
 "o͘" + "2" > "ó͘"

--- a/experimental/t/taigi_poj/source/taigi_poj.kps
+++ b/experimental/t/taigi_poj/source/taigi_poj.kps
@@ -81,7 +81,7 @@
     <Keyboard>
       <Name>PhahTaigi POJ</Name>
       <ID>taigi_poj</ID>
-      <Version>1.3</Version>
+      <Version>1.4</Version>
       <Languages>
         <Language ID="nan-Latn-TW">Tâi-gí</Language>
       </Languages>

--- a/experimental/t/taigi_poj/taigi_poj.kpj
+++ b/experimental/t/taigi_poj/taigi_poj.kpj
@@ -12,11 +12,11 @@
       <ID>id_f009a3beb5a55eb4e94bff9f1f0c1b5b</ID>
       <Filename>taigi_poj.kmn</Filename>
       <Filepath>source\taigi_poj.kmn</Filepath>
-      <FileVersion>1.3</FileVersion>
+      <FileVersion>1.4</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>PhahTaigi POJ</Name>
-        <Copyright>© 2020 Ngô͘ Ka-bêng</Copyright>
+        <Copyright>© 2020-2021 Ngô͘ Ka-bêng</Copyright>
       </Details>
     </File>
     <File>


### PR DESCRIPTION
With the previous versions, it is impossible to type the syllable "nng", because "nn" is converted to "ⁿ".  This update only allows "ⁿ" to be typed after a vowel.  For example:

"nng5" -> "nn̂g"
"inn7" -> "īⁿ"