### PR TITLE
[xinaliq] Add s-cedilla

### DIFF
--- a/release/x/xinaliq/HISTORY.md
+++ b/release/x/xinaliq/HISTORY.md
@@ -1,8 +1,9 @@
 Xinaliq Keyboard Change History
 =======================
 
-1.1.3 (6 Dec 2021)
+1.1.3 (2 Feb 2022)
 * Added s with cedilla
+* Remove circumflex ss
 * Remove stray longpress keys on shift key in default layer of touch layout
 * Use canonical tag "kjj" instead of "kjj-Latn"
 

--- a/release/x/xinaliq/HISTORY.md
+++ b/release/x/xinaliq/HISTORY.md
@@ -1,6 +1,11 @@
 Xinaliq Keyboard Change History
 =======================
 
+1.1.3 (6 Dec 2021)
+* Added s with cedilla
+* Remove stray longpress keys on shift key in default layer of touch layout
+* Use canonical tag "kjj" instead of "kjj-Latn"
+
 1.1.2 (27 Oct 2020)
 -----------------
 * Increment version number to force recompile of touch layout.

--- a/release/x/xinaliq/README.md
+++ b/release/x/xinaliq/README.md
@@ -1,7 +1,7 @@
 Xinaliq Keyboard
 =====================
 
-Copyright (C) 2019-2021 Kenneth Keyes
+Copyright (C) 2019-2022 Kenneth Keyes
 Version 1.1.3
 
 __DESCRIPTION__

--- a/release/x/xinaliq/README.md
+++ b/release/x/xinaliq/README.md
@@ -1,8 +1,8 @@
 Xinaliq Keyboard
 =====================
 
-Copyright (C) 2019-2020 Kenneth Keyes
-Version 1.1.2
+Copyright (C) 2019-2021 Kenneth Keyes
+Version 1.1.3
 
 __DESCRIPTION__
 Keyboard for Xinaliq (kjj) using the Latin Orthography approved by the Ministry of Education of the Republic of Azerbaijan.

--- a/release/x/xinaliq/source/help/xinaliq.php
+++ b/release/x/xinaliq/source/help/xinaliq.php
@@ -28,7 +28,7 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
 <p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
@@ -58,7 +58,7 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
 <p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
@@ -87,4 +87,4 @@
 </div>
 
 
-<p>(c) 2019-2021 Kenneth Keyes</p>
+<p>(c) 2019-2022 Kenneth Keyes</p>

--- a/release/x/xinaliq/source/help/xinaliq.php
+++ b/release/x/xinaliq/source/help/xinaliq.php
@@ -26,22 +26,23 @@
 <h2>Deməli, kirəş hasım izahat lək̇ink̂uijmə:</h2>
 <p>“q” 1x = q ; “q” 2x = q̇ ; “q” 3x = q̂ ; “q” 4x = q̂q̂ ; “q” 5x = q </p>
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
-<p>“p” 1x = p “p” 2x = ṗ “p” 3x = p̂ “p” 4x = p̂p̂ “p” 5x = p</p>
-<p>“k” 1x = k; “k” 2x = k̇; “k” 3x = k̂; “k” 4x = k̂k̂; 5x = k</p>
-<p>“s” 1x = s ; “s” ; 2x = ss ; “s”  3x = ŝ ; “s”  4x = ş ; “s”  5x = s</p>
-<p>“c” 1x = c 2x = ċ 3x = ĉ 4x = ĉĉ 5x = ç 6x = c</p>
+<p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
+<p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
-<p>“g” 1x = g 2x = ğ 3x = ğg 4x = ĝ 5x = g</p>
-<p>“h” 1x = h 2x = ḣ 3x = ĥ 4x = h</p>
-<p>“x” 1x = x 2x = x̂ 3x = x</p>
+<p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>
+<p>“h” 1x = h ; “h” 2x = ḣ ; “h”  3x = ĥ ; “h” 4x = h</p>
+<p>“x” 1x = x ; “x” 2x = x̂ ; “x”  3x = x</p>
 <h3>Saitlər üçün çox az fərq var, buna görə də daha asan üsul istifadə etmişik:</h3>
 <h3>Saitirdirir lap dənə fərq t̂uijmə, hine görə sətkəm rəḣət qaydaş istifadə kuijmə:</h3>
-<p>“e” 1x = e 2x = ə 3x = e</p>
-<p>“u” 1x = u 2x = ü 3x = u</p>
-<p>“o” 1x = o 2x = ö 3x = o</p>
-<p>“i” 1x =  2x = ı 3x = i</p>
+<p>“e” 1x = e ; “e” 2x = ə ; “e” 3x = e</p>
+<p>“u” 1x = u ; “u” 2x = ü ; “u” 3x = u</p>
+<p>“o” 1x = o ; “o” 2x = ö ; “o” 3x = o</p>
+<p>“i” 1x = i ; “i” 2x = ı ; “i” 3x = i</p>
+
 
 <h1>How to use this keyboard</h1>
 <p>This keyboard is based on the Standard Azeri keyboard, so it uses the keyboard assignments which are familiar to Azerbaijani speakers.</p>
@@ -55,20 +56,20 @@
 <h2>So, we can summarize as follows:</h2>
 <p>“q” 1x = q ; “q” 2x = q̇ ; “q” 3x = q̂ ; “q” 4x = q̂q̂ ; “q” 5x = q </p>
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
-<p>“p” 1x = p “p” 2x = ṗ “p” 3x = p̂ “p” 4x = p̂p̂ “p” 5x = p</p>
-<p>“k” 1x = k; “k” 2x = k̇; “k” 3x = k̂; “k” 4x = k̂k̂; 5x = k</p>
-<p>“s” 1x = s ; “s” ; 2x = ss ; “s”  3x = ŝ ; “s”  4x = ş ; “s”  5x = s</p>
-<p>“c” 1x = c 2x = ċ 3x = ĉ 4x = ĉĉ 5x = ç 6x = c</p>
+<p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
+<p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
-<p>“g” 1x = g 2x = ğ 3x = ğg 4x = ĝ 5x = g</p>
-<p>“h” 1x = h 2x = ḣ 3x = ĥ 4x = h</p>
-<p>“x” 1x = x 2x = x̂ 3x = x</p>
+<p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>
+<p>“h” 1x = h ; “h” 2x = ḣ ; “h”  3x = ĥ ; “h” 4x = h</p>
+<p>“x” 1x = x ; “x” 2x = x̂ ; “x”  3x = x</p>
 <h3>For vowels, there is very little variation, so this is even simpler: </h3>
-<p>“e” 1x = e 2x = ə 3x = e</p>
-<p>“u” 1x = u 2x = ü 3x = u</p>
-<p>“o” 1x = o 2x = ö 3x = o</p>
-<p>“i” 1x =  2x = ı 3x = i</p>
+<p>“e” 1x = e ; “e” 2x = ə ; “e” 3x = e</p>
+<p>“u” 1x = u ; “u” 2x = ü ; “u” 3x = u</p>
+<p>“o” 1x = o ; “o” 2x = ö ; “o” 3x = o</p>
+<p>“i” 1x = i ; “i” 2x = ı ; “i” 3x = i</p>
 
 
 
@@ -86,4 +87,4 @@
 </div>
 
 
-<p>(c) 2019-2020 Kenneth Keyes</p>
+<p>(c) 2019-2021 Kenneth Keyes</p>

--- a/release/x/xinaliq/source/welcome/welcome.htm
+++ b/release/x/xinaliq/source/welcome/welcome.htm
@@ -27,7 +27,7 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
 <p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
@@ -56,7 +56,7 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
 <p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
@@ -75,7 +75,7 @@
 	<h3>Shift</h3>
 	<p><a href="xinaliqU_S.png"><img class="keyboard" src="xinaliqU_S.png" alt="Shift state" /></a></p>
 
-<p>(c) 2019-2021 Kenneth Keyes</p>
+<p>(c) 2019-2022 Kenneth Keyes</p>
 
 </body>
 </html>

--- a/release/x/xinaliq/source/welcome/welcome.htm
+++ b/release/x/xinaliq/source/welcome/welcome.htm
@@ -25,22 +25,22 @@
 <h2>Deməli, kirəş hasım izahat lək̇ink̂uijmə:</h2>
 <p>“q” 1x = q ; “q” 2x = q̇ ; “q” 3x = q̂ ; “q” 4x = q̂q̂ ; “q” 5x = q </p>
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
-<p>“p” 1x = p “p” 2x = ṗ “p” 3x = p̂ “p” 4x = p̂p̂ “p” 5x = p</p>
-<p>“k” 1x = k; “k” 2x = k̇; “k” 3x = k̂; “k” 4x = k̂k̂; 5x = k</p>
-<p>“s” 1x = s ; “s” ; 2x = ss ; “s”  3x = ŝ ; “s”  4x = ş ; “s”  5x = s</p>
-<p>“c” 1x = c 2x = ċ 3x = ĉ 4x = ĉĉ 5x = ç 6x = c</p>
+<p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
+<p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
-<p>“g” 1x = g 2x = ğ 3x = ğg 4x = ĝ 5x = g</p>
-<p>“h” 1x = h 2x = ḣ 3x = ĥ 4x = h</p>
-<p>“x” 1x = x 2x = x̂ 3x = x</p>
+<p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>
+<p>“h” 1x = h ; “h” 2x = ḣ ; “h”  3x = ĥ ; “h” 4x = h</p>
+<p>“x” 1x = x ; “x” 2x = x̂ ; “x”  3x = x</p>
 <h3>Saitlər üçün çox az fərq var, buna görə də daha asan üsul istifadə etmişik:</h3>
 <h3>Saitirdirir lap dənə fərq t̂uijmə, hine görə sətkəm rəḣət qaydaş istifadə kuijmə:</h3>
-<p>“e” 1x = e 2x = ə 3x = e</p>
-<p>“u” 1x = u 2x = ü 3x = u</p>
-<p>“o” 1x = o 2x = ö 3x = o</p>
-<p>“i” 1x =  2x = ı 3x = i</p>
+<p>“e” 1x = e ; “e” 2x = ə ; “e” 3x = e</p>
+<p>“u” 1x = u ; “u” 2x = ü ; “u” 3x = u</p>
+<p>“o” 1x = o ; “o” 2x = ö ; “o” 3x = o</p>
+<p>“i” 1x = i ; “i” 2x = ı ; “i” 3x = i</p>
 
 <h1>How to use this keyboard</h1>
 <p>This keyboard is based on the Standard Azeri keyboard, so it uses the keyboard assignments which are familiar to Azerbaijani speakers.</p>
@@ -54,20 +54,20 @@
 <h2>So, we can summarize as follows:</h2>
 <p>“q” 1x = q ; “q” 2x = q̇ ; “q” 3x = q̂ ; “q” 4x = q̂q̂ ; “q” 5x = q </p>
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
-<p>“p” 1x = p “p” 2x = ṗ “p” 3x = p̂ “p” 4x = p̂p̂ “p” 5x = p</p>
-<p>“k” 1x = k; “k” 2x = k̇; “k” 3x = k̂; “k” 4x = k̂k̂; 5x = k</p>
-<p>“s” 1x = s ; “s” ; 2x = ss ; “s”  3x = ŝ ; “s”  4x = ş ; “s”  5x = s</p>
-<p>“c” 1x = c 2x = ċ 3x = ĉ 4x = ĉĉ 5x = ç 6x = c</p>
+<p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
+<p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ŝs ; “s” 5x = ş ; “s” 6x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
-<p>“g” 1x = g 2x = ğ 3x = ğg 4x = ĝ 5x = g</p>
-<p>“h” 1x = h 2x = ḣ 3x = ĥ 4x = h</p>
-<p>“x” 1x = x 2x = x̂ 3x = x</p>
+<p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>
+<p>“h” 1x = h ; “h” 2x = ḣ ; “h”  3x = ĥ ; “h” 4x = h</p>
+<p>“x” 1x = x ; “x” 2x = x̂ ; “x”  3x = x</p>
 <h3>For vowels, there is very little variation, so this is even simpler: </h3>
-<p>“e” 1x = e 2x = ə 3x = e</p>
-<p>“u” 1x = u 2x = ü 3x = u</p>
-<p>“o” 1x = o 2x = ö 3x = o</p>
-<p>“i” 1x =  2x = ı 3x = i</p>
+<p>“e” 1x = e ; “e” 2x = ə ; “e” 3x = e</p>
+<p>“u” 1x = u ; “u” 2x = ü ; “u” 3x = u</p>
+<p>“o” 1x = o ; “o” 2x = ö ; “o” 3x = o</p>
+<p>“i” 1x = i ; “i” 2x = ı ; “i” 3x = i</p>
 
   <h2>OnScreen Keyboard layout</h2>
 	<h3>Default (unshifted)</h3>
@@ -75,7 +75,7 @@
 	<h3>Shift</h3>
 	<p><a href="xinaliqU_S.png"><img class="keyboard" src="xinaliqU_S.png" alt="Shift state" /></a></p>
 
-<p>(c) 2019-2020 Kenneth Keyes</p>
+<p>(c) 2019-2021 Kenneth Keyes</p>
 
 </body>
 </html>

--- a/release/x/xinaliq/source/xinaliq.keyman-touch-layout
+++ b/release/x/xinaliq/source/xinaliq.keyman-touch-layout
@@ -203,17 +203,7 @@
                 "text": "*Shift*",
                 "width": "110",
                 "sp": "1",
-                "nextlayer": "shift",
-                "sk": [
-                  {
-                    "text": "Q̇",
-                    "id": "T_Q_dot"
-                  },
-                  {
-                    "text": "Q̂",
-                    "id": "T_Q_circumflex"
-                  }
-                ]
+                "nextlayer": "shift"
               },
               {
                 "id": "K_Z",

--- a/release/x/xinaliq/source/xinaliq.kmn
+++ b/release/x/xinaliq/source/xinaliq.kmn
@@ -158,8 +158,7 @@ c ***lowercase consonants****
 
 's' + 's' > 'ss'            c doubled 's'
 'ss' + 's' > 'ŝ'            c circumflex
-'ŝ' + 's' > '̂ss'            c circumflex 's' and 's'
-'̂ss' + 's' > 'ş'            c cedilla 's'
+'ŝ' + 's' > 'ş'             c circumflex 's' and 's'
 'ş' + 's' > 's'             c reverts to base character 's'
 
 'z' + 'z' > 'ż'             c dot above
@@ -200,15 +199,14 @@ c ***uppercase consonants****
 'P̂P̂' + 'P' > 'P'            C REVERTS TO BASE CHARACTER 'P'
 
 'T' + 'T' > 'Ṫ'            C DOT ABOVE
-'Ṫ' + 'T' > 'T̂'		     C CIRCUMFLEX
-'T̂' + 'T' > 'T̂T̂'		      C DOUBLED CIRCUMFLEX
-'T̂T̂' + 'T' > 'TT'		     C DOUBLED T
+'Ṫ' + 'T' > 'T̂'            C CIRCUMFLEX
+'T̂' + 'T' > 'T̂T̂'           C DOUBLED CIRCUMFLEX
+'T̂T̂' + 'T' > 'TT'          C DOUBLED T
 'TT' + 'T' > 'T'           C REVERTS TO BASE CHARACTER 'T'
 
 'S' + 'S' > 'SS'           C DOUBLED 'S'
 'SS' + 'S' > 'Ŝ'           C CIRCUMFLEX
-'Ŝ' + 'S' > '̂SS'           C CIRCUMFLEX 'S' AND 'S'
-'̂SS' + 'S' > 'Ş'           C CEDILLA 'S'
+'Ŝ' + 'S' > 'Ş'            C CIRCUMFLEX 'S' AND 'S'
 'Ş' + 'S' > 'S'            C REVERTS TO BASE CHARACTER  'S'
 
 'Z' + 'Z' > 'Ż'            C DOT ABOVE

--- a/release/x/xinaliq/source/xinaliq.kmn
+++ b/release/x/xinaliq/source/xinaliq.kmn
@@ -8,7 +8,7 @@ store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'xinaliq.keyman-touch-layout'
 store(&VISUALKEYBOARD) 'xinaliq.kvks'
 store(&NAME) 'Xinaliq'
-store(&KEYBOARDVERSION) '1.1.2'
+store(&KEYBOARDVERSION) '1.1.3'
 begin Unicode > use(main)
 
 group(main) using keys 
@@ -159,7 +159,8 @@ c ***lowercase consonants****
 's' + 's' > 'ss'            c doubled 's'
 'ss' + 's' > 'ŝ'            c circumflex
 'ŝ' + 's' > '̂ss'            c circumflex 's' and 's'
-'̂ss' + 's' > 's'            c reverts to base character 's'
+'̂ss' + 's' > 'ş'            c cedilla 's'
+'ş' + 's' > 's'             c reverts to base character 's'
 
 'z' + 'z' > 'ż'             c dot above
 'ż' + 'z' > 'ẑ'             c circumflex
@@ -207,7 +208,8 @@ c ***uppercase consonants****
 'S' + 'S' > 'SS'           C DOUBLED 'S'
 'SS' + 'S' > 'Ŝ'           C CIRCUMFLEX
 'Ŝ' + 'S' > '̂SS'           C CIRCUMFLEX 'S' AND 'S'
-'̂SS' + 'S' > 'S'           C REVERTS TO BASE CHARACTER  'S'
+'̂SS' + 'S' > 'Ş'           C CEDILLA 'S'
+'Ş' + 'S' > 'S'            C REVERTS TO BASE CHARACTER  'S'
 
 'Z' + 'Z' > 'Ż'            C DOT ABOVE
 'Ż' + 'Z' > 'Ẑ'            C CIRCUMFLEX

--- a/release/x/xinaliq/source/xinaliq.kps
+++ b/release/x/xinaliq/source/xinaliq.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.102.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>15.0.160.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -18,7 +18,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">Xinaliq</Name>
-    <Copyright URL="">© 2019-2020 Kenneth Keyes</Copyright>
+    <Copyright URL="">© 2019-2021 Kenneth Keyes</Copyright>
   </Info>
   <Files>
     <File>
@@ -68,9 +68,9 @@
     <Keyboard>
       <Name>Xinaliq</Name>
       <ID>xinaliq</ID>
-      <Version></Version>
+      <Version>1.1.3</Version>
       <Languages>
-        <Language ID="kjj-Latn">Khinalugh (Latin)</Language>
+        <Language ID="kjj">Khinalugh</Language>
       </Languages>
     </Keyboard>
   </Keyboards>

--- a/release/x/xinaliq/xinaliq.keyboard_info
+++ b/release/x/xinaliq/xinaliq.keyboard_info
@@ -1,5 +1,5 @@
 {
     "license": "mit",
-    "languages": ["kjj-Latn"],
+    "languages": ["kjj"],
     "description": "Keyboard for Xinaliq (kjj) using the Latin Orthography approved by the Ministry of Education of the Republic of Azerbaijan."
 }

--- a/release/x/xinaliq/xinaliq.kpj
+++ b/release/x/xinaliq/xinaliq.kpj
@@ -12,7 +12,7 @@
       <ID>id_d11e7609ceb5ea0d94e6b3580673e75e</ID>
       <Filename>xinaliq.kmn</Filename>
       <Filepath>source\xinaliq.kmn</Filepath>
-      <FileVersion>1.1.1</FileVersion>
+      <FileVersion>1.1.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Xinaliq</Name>
@@ -27,7 +27,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>Xinaliq</Name>
-        <Copyright>© 2019-2020 Kenneth Keyes</Copyright>
+        <Copyright>© 2019-2021 Kenneth Keyes</Copyright>
       </Details>
     </File>
     <File>


### PR DESCRIPTION
Fixes #1696

* Add s-cedilla to the <kbd>s</kbd> key rota
* (edited) Remove circumflex ss per review comment
* Remove stray `q` longpress keys on the <kbd>Shift</kbd> button in the default layer of the touch layout
* Use canonical tag `kjj` instead of `kjj-Latn`
* Fix formatting on welcome page

@KenK-3-21 - Can you clarify if "brother" is spelled with the composing circumflex before "ss"?