### PR TITLE
[fv_all] Associate sil_euro_latin with English

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.4 (02 Feb 2022)
+* Associate sil_euro_latin keyboard with English
+
 ## 12.3 (16 Jul 2020)
 * Add Aboriginal Serif font to touch layout keyboards
 

--- a/release/packages/fv_all/README.md
+++ b/release/packages/fv_all/README.md
@@ -1,9 +1,9 @@
 FirstVoices Keyboard Package
 ==================================================
 
-(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
+(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
-Version 12.3
+Version 12.4
 
 __DESCRIPTION__
 

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -81,6 +81,12 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   oskFont=${kpsdata[4]}
   displayFont=${kpsdata[5]}
 
+  # Override sil_euro_latin keyboard to English language
+  if [[ $id = 'sil_euro_latin' ]]; then
+    bcp47="en"
+    langname="English"
+  fi
+
   # Build a file entry
   FILE_LINES_0=''
   FILE_LINES_1=''

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -15,10 +15,10 @@
     <Items/>
   </StartMenu>
   <Info>
-    <Copyright URL="">(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
+    <Copyright URL="">(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.3</Version>
+    <Version URL="">12.4</Version>
   </Info>
   <Files>
     <File>

--- a/release/packages/fv_all/source/readme.htm
+++ b/release/packages/fv_all/source/readme.htm
@@ -9,7 +9,7 @@
 
 <h1>FirstVoices Keyboard Package</h1>
 
-<p style='margin:0px'>(c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
+<p style='margin:0px'>(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
        
 <p>This package includes all the FirstVoices keyboards for Windows and mobile. It is distributed as part of the FirstVoices project.</p>
 


### PR DESCRIPTION
We were checking out the associated languages for the fv_all keyboard package, and noticed the build scripts are pulling the last associated language *Zapotec (Latin)* for the sil_euro_latin keyboard. This tweaks the fv_all build script to use *English*.

This is for integrating dictionary support in the First Voices apps in the upcoming month.

Note, the build script is also generating a lot of warnings about the current language tags being valid, but not canonical. 
Per @mcdurdin, we'll address those at another time.

Tagging @madebybridget 