### PR TITLE
Changed the keyboard info description for PME US Natural to be more informative

### DIFF
--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
@@ -3,5 +3,5 @@
     "languages": [
         "en"
     ],
-	  "description": "Postmodern English US Natural"
+	  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit http://www.PostmodernEnglish.org ."
 }

--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
@@ -3,5 +3,11 @@
     "languages": [
         "en"
     ],
-	  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit http://www.PostmodernEnglish.org ."
+	"links": [
+        {
+            "name": "Postmodern English Website",
+            "url": "http://www.postmodernenglish.org"
+        }
+    ],
+	  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
 }

--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
@@ -9,5 +9,5 @@
             "url": "http://www.postmodernenglish.org"
         }
     ],
-	  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
+	"description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
 }


### PR DESCRIPTION
The PME US Natural keyboard's keyboard info was previously just "Postmodern English US Natural" on the Keyman download page. We've updated it to be more informative.