### PR TITLE
Changed the Postmodern English US Natural Keyboard BCP 47 tag to en-QP

### DIFF
--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
@@ -1,7 +1,7 @@
 {
     "license": "mit",
     "languages": [
-        "en"
+        "en-QP"
     ],
 	"links": [
         {

--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.kpj
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.kpj
@@ -33,7 +33,7 @@
       <ID>id_72a5f7e6b21a6128edf0decc4fc4f30c</ID>
       <Filename>postmodern_english_us_natural.kmn</Filename>
       <Filepath>source\postmodern_english_us_natural.kmn</Filepath>
-      <FileVersion>1.1</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Postmodern English US Natural</Name>

--- a/release/p/postmodern_english_us_natural/source/postmodern_english_us_natural.kmn
+++ b/release/p/postmodern_english_us_natural/source/postmodern_english_us_natural.kmn
@@ -1,6 +1,6 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) 'Postmodern English US Natural'
-store(&KEYBOARDVERSION) '1.1'
+store(&KEYBOARDVERSION) '1.2'
 store(&TARGETS) 'any'
 store(&BITMAP) 'postmodern_english_us_natural.ico'
 store(&LAYOUTFILE) 'postmodern_english_us_natural.keyman-touch-layout'

--- a/release/p/postmodern_english_us_natural/source/postmodern_english_us_natural.kps
+++ b/release/p/postmodern_english_us_natural/source/postmodern_english_us_natural.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>14.0.286.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.288.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -70,9 +70,9 @@
     <Keyboard>
       <Name>Postmodern English US Natural</Name>
       <ID>postmodern_english_us_natural</ID>
-      <Version>1.1</Version>
+      <Version>1.2</Version>
       <Languages>
-        <Language ID="en">Postmodern English</Language>
+        <Language ID="en-QP">Postmodern English</Language>
       </Languages>
     </Keyboard>
   </Keyboards>


### PR DESCRIPTION
This change is to correlate this keyboard with the new Postmodern lexical model.