### PR TITLE
Change BCP 47 code to en-QP for Postmodern UK Dualstroke Keyboard

### DIFF
--- a/release/p/postmodern_english_uk_dualstroke/HISTORY.md
+++ b/release/p/postmodern_english_uk_dualstroke/HISTORY.md
@@ -4,3 +4,7 @@ Postmodern English UK DualStroke Change History
 1.0 (2022-02-19)
 ----------------
 - Added the base keyboard.
+
+1.1 (2022-03-25)
+----------------
+- Changed the BCP 47 code to en-QP.

--- a/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.keyboard_info
+++ b/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.keyboard_info
@@ -1,7 +1,7 @@
 {
     "license": "mit",
     "languages": [
-        "en"
+        "en-QP"
     ],
 	"links": [
         {

--- a/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.kpj
+++ b/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.kpj
@@ -33,7 +33,7 @@
       <ID>id_282ca6ead120c27593018f4b562f2ad7</ID>
       <Filename>postmodern_english_uk_dualstroke.kmn</Filename>
       <Filepath>source\postmodern_english_uk_dualstroke.kmn</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Postmodern English UK Dualstroke</Name>

--- a/release/p/postmodern_english_uk_dualstroke/source/postmodern_english_uk_dualstroke.kmn
+++ b/release/p/postmodern_english_uk_dualstroke/source/postmodern_english_uk_dualstroke.kmn
@@ -1,5 +1,5 @@
 ﻿store(&NAME) 'Postmodern English UK Dualstroke'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.1'
 store(&TARGETS) 'any'
 store(&COPYRIGHT) '© 2022, The Postmodern English Project'
 store(&VISUALKEYBOARD) 'postmodern_english_uk_dualstroke.kvks'

--- a/release/p/postmodern_english_uk_dualstroke/source/postmodern_english_uk_dualstroke.kps
+++ b/release/p/postmodern_english_uk_dualstroke/source/postmodern_english_uk_dualstroke.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>14.0.286.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.288.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -69,9 +69,9 @@
     <Keyboard>
       <Name>Postmodern English UK Dualstroke</Name>
       <ID>postmodern_english_uk_dualstroke</ID>
-      <Version>1.0</Version>
+      <Version>1.1</Version>
       <Languages>
-        <Language ID="en">Postmodern English</Language>
+        <Language ID="en-QP">Postmodern English</Language>
       </Languages>
     </Keyboard>
   </Keyboards>


### PR DESCRIPTION
This is to match up the BCP 47 code with the recent lexical model that was added.