### PR TITLE
[xinaliq] Fix help documentation for "c" key

### DIFF
--- a/release/x/xinaliq/HISTORY.md
+++ b/release/x/xinaliq/HISTORY.md
@@ -1,6 +1,9 @@
 Xinaliq Keyboard Change History
 =======================
 
+1.1.4 (7 Apr 2022)
+* Fix help documentation for c key
+
 1.1.3 (2 Feb 2022)
 * Added s with cedilla
 * Remove circumflex ss

--- a/release/x/xinaliq/LICENSE.md
+++ b/release/x/xinaliq/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Kenneth Keyes
+Copyright (c) 2019-2022 Kenneth Keyes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/x/xinaliq/README.md
+++ b/release/x/xinaliq/README.md
@@ -2,7 +2,7 @@ Xinaliq Keyboard
 =====================
 
 Copyright (C) 2019-2022 Kenneth Keyes
-Version 1.1.3
+Version 1.1.4
 
 __DESCRIPTION__
 Keyboard for Xinaliq (kjj) using the Latin Orthography approved by the Ministry of Education of the Republic of Azerbaijan.
@@ -21,10 +21,3 @@ Supported Platforms
  * iOS
  * Android
  * Linux
-
-
-  
-  
-
-
- 

--- a/release/x/xinaliq/source/help/xinaliq.php
+++ b/release/x/xinaliq/source/help/xinaliq.php
@@ -28,8 +28,8 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
-<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 5x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
@@ -58,8 +58,8 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
-<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 5x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
 <p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>

--- a/release/x/xinaliq/source/welcome/welcome.htm
+++ b/release/x/xinaliq/source/welcome/welcome.htm
@@ -27,8 +27,8 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
-<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 5x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = c</p>
 <h3>Xüsusi diakritik olan digər samitlər üçün biz bir az daha sadə şərtlər istifadə etmişik:</h3>
 <h3>Xüsusi dam t̂ui samitirduru yir sətkəm rəḣət işarədişilli istifadə kuijmə:</h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
@@ -56,8 +56,8 @@
 <p>“t” 1x = t ; “t” 2x = ṫ ; “t” 3x = t̂ ; “t” 4x = t̂t̂ ; “t” 5x = tt ; “t” 6x = t</p>
 <p>“p” 1x = p ; “p” 2x = ṗ ; “p” 3x = p̂ ; “p” 4x = p̂p̂ ; “p” 5x = p</p>
 <p>“k” 1x = k ; “k” 2x = k̇ ; “k” 3x = k̂ ; “k” 4x = k̂k̂ ; “k” 5x = k</p>
-<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 6x = s</p>
-<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = ç ; “c” 6x = c</p>
+<p>“s” 1x = s ; “s” 2x = ss ; “s” 3x = ŝ ; “s” 4x = ş ; “s” 5x = s</p>
+<p>“c” 1x = c ; “c” 2x = ċ ; “c” 3x = ĉ ; “c” 4x = ĉĉ ; “c” 5x = c</p>
 <h3>For other consonants which have special diacritics, we have used a little simpler convention: </h3>
 <p>“z” 1x = z ; “z” 2x = ż ; “z”  3x = ẑ ; “z” 4x = z</p>
 <p>“g” 1x = g ; “g” 2x = ğ ; “g”  3x = ğg ; “g” 4x = ĝ ; “g” 5x = g</p>

--- a/release/x/xinaliq/source/xinaliq.kmn
+++ b/release/x/xinaliq/source/xinaliq.kmn
@@ -1,6 +1,6 @@
 ﻿store(&VERSION) '9.0'
 store(&ETHNOLOGUECODE) 'kjj'
-store(&COPYRIGHT) '© 2019-2020 Kenneth Keyes'
+store(&COPYRIGHT) '© 2019-2022 Kenneth Keyes'
 store(&WINDOWSLANGUAGES) 'x042C'
 store(&BITMAP) 'xinaliq.ico'
 store(&LANGUAGE) 'x042C'
@@ -8,7 +8,7 @@ store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'xinaliq.keyman-touch-layout'
 store(&VISUALKEYBOARD) 'xinaliq.kvks'
 store(&NAME) 'Xinaliq'
-store(&KEYBOARDVERSION) '1.1.3'
+store(&KEYBOARDVERSION) '1.1.4'
 begin Unicode > use(main)
 
 group(main) using keys 


### PR DESCRIPTION
Follow-on to #1698

During testing of keymanapp/keyman#6477, @bharanidharanj noted that the rota for <kbd>c</kbd> didn't match the help documentation. (The rota reverts to "c" after 5x).

Per the keyboard source, there is no c-cedilla on the rota:
https://github.com/keymanapp/keyboards/blob/e60d8fa3fd599a7c34bcac3d327ff9006a086cd5/release/x/xinaliq/source/xinaliq.kmn#L168-L171

This bumps the keyboard version and fixes the help documentation.