### PR TITLE
[balochi_latin] Add NCAPS modifier to avoid inconsistent matches

### DIFF
--- a/release/b/balochi_latin/HISTORY.md
+++ b/release/b/balochi_latin/HISTORY.md
@@ -1,5 +1,10 @@
 Balochi Latin Change History
 ====================
+
+1.0.2 (2022-05-12)
+------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 1.0.1 (2021-09-09)
 ------------------
 * Use bal-Latn instead of bcc-Latn

--- a/release/b/balochi_latin/LICENSE.md
+++ b/release/b/balochi_latin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2020-2021 SIL International
+© 2020-2022 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/b/balochi_latin/source/balochi_latin.kmn
+++ b/release/b/balochi_latin/source/balochi_latin.kmn
@@ -6,19 +6,19 @@ store(&VISUALKEYBOARD) 'balochi_latin.kvks'
 store(&BITMAP) 'balochi_latin.ico'
 store(&LAYOUTFILE) 'balochi_latin.keyman-touch-layout'
 store(&COPYRIGHT) '© 2020-2021 SIL International'
-store(&KEYBOARDVERSION) '1.0.1'
+store(&KEYBOARDVERSION) '1.0.2'
 store(&MESSAGE) 'The Balochi Latin keyboard is distributed under The MIT License (MIT).'
 store(&KMW_HELPTEXT) 'This is a modified US keyboard for typing Balochi in Latin script.'
 
 begin Unicode > use(main)
 
 group(main) using keys
-+ [SHIFT ALT K_X] > 'X'
-+ [SHIFT ALT K_F] > 'F'
-+ [SHIFT ALT K_V] > 'V'
-+ [ALT K_V] > 'v'
-+ [ALT K_F] > 'f'
-+ [ALT K_X] > 'x'
++ [NCAPS SHIFT ALT K_X] > 'X'
++ [NCAPS SHIFT ALT K_F] > 'F'
++ [NCAPS SHIFT ALT K_V] > 'V'
++ [NCAPS ALT K_V] > 'v'
++ [NCAPS ALT K_F] > 'f'
++ [NCAPS ALT K_X] > 'x'
 
 + [K_SPACE] > U+0020
 

--- a/release/b/balochi_latin/source/balochi_latin.kps
+++ b/release/b/balochi_latin/source/balochi_latin.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Balochi Latin</Name>
-    <Copyright URL="">© 2020-2021 SIL International</Copyright>
+    <Copyright URL="">© 2020-2022 SIL International</Copyright>
     <Author URL="">RL</Author>
     <Version URL=""></Version>
   </Info>
@@ -69,7 +69,7 @@
     <Keyboard>
       <Name>Balochi Latin</Name>
       <ID>balochi_latin</ID>
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
       <Languages>
         <Language ID="bal-Latn">Baluchi (Latin)</Language>
       </Languages>

--- a/release/b/balochi_latin/source/readme.htm
+++ b/release/b/balochi_latin/source/readme.htm
@@ -16,7 +16,7 @@
     Balochi Latin based on the US English keyboard.
 </p>
 
-<p>© 2020-2021 SIL International</p>
+<p>© 2020-2022 SIL International</p>
 
 </body>
 </html>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release 

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (keymanapp/keyman#6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```

Applies to ll 16-21
