### PR TITLE
[basic_kbdyba] Add NCAPS to some rules

### DIFF
--- a/release/basic/basic_kbdyba/HISTORY.md
+++ b/release/basic/basic_kbdyba/HISTORY.md
@@ -1,6 +1,10 @@
 Yoruba Basic Change History
 ====================
 
+1.1.1 (2022-05-12)
+------------------
+* Add NCAPS to some rules to avoid inconsistent matches
+
 1.1 (2020-03-02)
 ----------------
 * Updated keyboard to support grave and acute with m

--- a/release/basic/basic_kbdyba/LICENSE.md
+++ b/release/basic/basic_kbdyba/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-(c) 2018-2020 SIL International
+(c) 2018-2022 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/basic/basic_kbdyba/README.md
+++ b/release/basic/basic_kbdyba/README.md
@@ -1,9 +1,7 @@
 Yoruba Basic keyboard
 ==============
 
-(c) 2018-2020 SIL International
-
-Version 1.1
+(c) 2018-2022 SIL International
 
 Description
 -----------

--- a/release/basic/basic_kbdyba/source/basic_kbdyba.kmn
+++ b/release/basic/basic_kbdyba/source/basic_kbdyba.kmn
@@ -13,8 +13,8 @@ store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'basic_kbdyba.kvks'
 store(&BITMAP) 'basic_kbdyba.ico'
 store(&LAYOUTFILE) 'basic_kbdyba.keyman-touch-layout'
-store(&COPYRIGHT) '(c) 2018-2020 SIL International'
-store(&KEYBOARDVERSION) '1.1'
+store(&COPYRIGHT) '(c) 2018-2022 SIL International'
+store(&KEYBOARDVERSION) '1.1.1'
 
 begin Unicode > use(main)
 
@@ -136,11 +136,11 @@ group(main) using keys
 + [CAPS SHIFT K_M] > U+006d
 
 c 2020-Mar-02 added grave m
-dk(005b) + [K_M]       > U+006d U+0300 
-dk(005b) + [SHIFT K_M] > U+004D U+0300 
+dk(005b) + [NCAPS K_M]       > U+006d U+0300 
+dk(005b) + [NCAPS SHIFT K_M] > U+004D U+0300 
 c 2020-Mar-02 added acute m
-dk(0027) + [K_M]       > U+1e3f 
-dk(0027) + [SHIFT K_M] > U+1e3e 
+dk(0027) + [NCAPS K_M]       > U+1e3f 
+dk(0027) + [NCAPS SHIFT K_M] > U+1e3e 
 
 + [T_M_Grave] > U+006d U+0300
 + [SHIFT T_M_Grave] > U+004d U+0300

--- a/release/basic/basic_kbdyba/source/basic_kbdyba.kps
+++ b/release/basic/basic_kbdyba/source/basic_kbdyba.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Yoruba Basic</Name>
-    <Copyright URL="">(c) 2018-2020 SIL International</Copyright>
+    <Copyright URL="">(c) 2018-2022 SIL International</Copyright>
     <Author URL=""></Author>
   </Info>
   <Files>
@@ -80,7 +80,7 @@
     <Keyboard>
       <Name>Yoruba Basic</Name>
       <ID>basic_kbdyba</ID>
-      <Version>1.1</Version>
+      <Version>1.1.1</Version>
       <Languages>
         <Language ID="yo-Latn">Yoruba</Language>
       </Languages>

--- a/release/basic/basic_kbdyba/source/readme.htm
+++ b/release/basic/basic_kbdyba/source/readme.htm
@@ -17,7 +17,7 @@
     This keyboard is designed for the Yoruba language of Nigeria.
 </p>
 
-<p>(c) 2018-2020 SIL International</p>
+<p>(c) 2018-2022 SIL International</p>
 
 </body>
 </html>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (https://github.com/keymanapp/keyman/pull/6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```
