### PR TITLE
[cabecar] Add NCAPS to some rules

### DIFF
--- a/release/c/cabecar/HISTORY.md
+++ b/release/c/cabecar/HISTORY.md
@@ -1,5 +1,10 @@
 Cabecar Change History
 ====================
+
+1.2.1 (2022-05-12)
+------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 1.2 (2021-01-07)
 ----------------
 * Prepared for release 

--- a/release/c/cabecar/LICENSE.md
+++ b/release/c/cabecar/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2020-2021 Victoria Quint
+© 2020-2022 Victoria Quint
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/c/cabecar/README.md
+++ b/release/c/cabecar/README.md
@@ -1,14 +1,8 @@
 Cabécar Keyboard / Teclado Cabécar
 ==============
 
-© 2020-2021 Victoria Quint
+© 2020-2022 Victoria Quint
 
-Version 1.2
-
-Prepared for release
---------------------
-
-Version 1.1
 
 Description
 -----------

--- a/release/c/cabecar/source/cabecar.kmn
+++ b/release/c/cabecar/source/cabecar.kmn
@@ -16,8 +16,8 @@ store(&NAME) 'Cabecar'
 store(&TARGETS) 'any'
 store(&BITMAP) 'cabecar.ico'
 store(&LAYOUTFILE) 'cabecar.keyman-touch-layout'
-store(&COPYRIGHT) '© 2020-2021 Victoria Quint'
-store(&KEYBOARDVERSION) '1.2'
+store(&COPYRIGHT) '© 2020-2022 Victoria Quint'
+store(&KEYBOARDVERSION) '1.2.1'
 store(&VISUALKEYBOARD) 'cabecar.kvks'
 
 begin Unicode > use(main)
@@ -184,7 +184,7 @@ group(main) using keys
 + [CAPS K_Q] > 'Q'
 + [NCAPS SHIFT K_Q] > 'Q'
 + [CAPS SHIFT K_Q] > 'q'
-+ [ALT K_Q] > '@'
++ [NCAPS ALT K_Q] > '@'
 
 + [NCAPS K_R] > 'r'
 + [CAPS K_R] > 'R'

--- a/release/c/cabecar/source/cabecar.kps
+++ b/release/c/cabecar/source/cabecar.kps
@@ -17,7 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Cabecar</Name>
-    <Copyright URL="">© 2020-2021 Victoria Quint</Copyright>
+    <Copyright URL="">© 2020-2022 Victoria Quint</Copyright>
     <Author URL="">Victoria Quint</Author>
     <Version URL=""></Version>
   </Info>
@@ -81,7 +81,7 @@
     <Keyboard>
       <Name>Cabecar</Name>
       <ID>cabecar</ID>
-      <Version>1.0</Version>
+      <Version>1.2.1</Version>
       <Languages>
         <Language ID="cjp-Latn">Cabécar</Language>
       </Languages>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (https://github.com/keymanapp/keyman/pull/6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```
