### PR TITLE
[sil_cameroon_azerty] Add NCAPS to some rules

### DIFF
--- a/release/sil/sil_cameroon_azerty/HISTORY.md
+++ b/release/sil/sil_cameroon_azerty/HISTORY.md
@@ -1,6 +1,10 @@
 Change History
 =======================
 
+6.0.5 (2022-May 12)
+-------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 6.0.4 (2022-Feb-17)
 -----------------
 * Updated to use font from shared folders

--- a/release/sil/sil_cameroon_azerty/source/help/sil_cameroon_azerty.php
+++ b/release/sil/sil_cameroon_azerty/source/help/sil_cameroon_azerty.php
@@ -14204,7 +14204,7 @@ sélectionnez le nom de la touche de raccourci et modifiez la touche de raccourc
 </ul> 
 <p xml:lang="fr">Le Clavier Camerounais est un produit de SIL Cameroun. Pour plus  d´infos sur le Claver Camerounais ou la technologie linguistique au Cameroun,  veuillez visiter <a href="https://langtechcameroon.info">https://langtechcameroon.info</a>
 </p>
-<p xml:lang="fr" style="text-align: center;  font-style: italic;">Copyright 2018-2020  SIL Cameroun</p>
+<p xml:lang="fr" style="text-align: center;  font-style: italic;">Copyright 2018-2022  SIL Cameroun</p>
 </div>
 </div>
 </div>
@@ -28425,7 +28425,7 @@ select the hotkey name, and either change the hotkey or turn it off.
 </ul>
 <p xml:lang="en">The Cameroon Keyboard is developed by SIL Cameroon. For more  information about the Cameroon Keyboard or Language Technology in Cameroon, see  <a href="https://langtechcameroon.info">https://langtechcameroon.info</a>
 </p>
-<p xml:lang="en" style="text-align: center; font-style: italic;">Copyright 2018-2020 SIL  Cameroon</p>
+<p xml:lang="en" style="text-align: center; font-style: italic;">Copyright 2018-2022 SIL  Cameroon</p>
 </div>
 </div>
 </div>

--- a/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kmn
+++ b/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kmn
@@ -1,9 +1,9 @@
 ﻿store(&NAME) 'Cameroon AZERTY'
-store(&COPYRIGHT) '(c) 2018-2020 SIL Cameroon'
+store(&COPYRIGHT) '(c) 2018-2022 SIL Cameroon'
 store(&BITMAP) 'Cameroon.ico'
 store(&MESSAGE) 'Use ! or AltGr to access special characters.'
 store(&LAYOUTFILE) 'sil_cameroon_azerty.keyman-touch-layout'
-store(&KEYBOARDVERSION) '6.0.4'
+store(&KEYBOARDVERSION) '6.0.5'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'sil_cameroon_azerty.kvks'
 store(&KMW_EMBEDCSS) 'sil_cameroon_azerty.css'
@@ -23,15 +23,15 @@ store(num) "0123456789"
 store(diablock) " 0123456789?!;:'-_=<©®>.,[]{}\\/@°#$%^&*()«»‹›‘“’”€¥£èéçàùµ…†" U+0022 U+007C
 store(dia) U+0300 U+0304 U+0301 U+030C U+0302 U+0303 U+0308 U+0327 U+03B1 U+030D U+0330
 
-platform('touch') any(word) any(final) + [K_SPACE] > index(word,2) index(final,3) " " layer('shift')
-platform('touch') any(word) U+0020 + [K_SPACE] > index(word,2) U+002E " " layer('shift')
+platform('touch') any(word) any(final) + [NCAPS K_SPACE] > index(word,2) index(final,3) " " layer('shift')
+platform('touch') any(word) U+0020 + [NCAPS K_SPACE] > index(word,2) U+002E " " layer('shift')
 
 + [CAPS K_SPACE] > U+0020
 + [CAPS SHIFT K_SPACE] > U+0020
-+ [LCTRL K_SPACE] > U+00A0
++ [NCAPS LCTRL K_SPACE] > U+00A0
 + [NCAPS K_SPACE] > U+0020
 + [NCAPS SHIFT K_SPACE] > U+0020
-+ [RCTRL K_SPACE] > U+00A0
++ [NCAPS RCTRL K_SPACE] > U+00A0
 
 + [CAPS K_0] > U+0030    
 + [CAPS RALT K_0] > BEEP  
@@ -423,7 +423,6 @@ any(diablock) + [NCAPS RALT K_C] > context
 any(diablock) + [CAPS RALT K_PERIOD] > context
 any(diablock) + [NCAPS RALT K_PERIOD] > context
 
-+ [K_SLASH] > dk(0021)
 + [NCAPS K_SLASH] > dk(0021)
 + [CAPS K_SLASH] > dk(0021)
 + [CAPS SHIFT K_SLASH] > U+00A7

--- a/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kps
+++ b/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kps
@@ -154,7 +154,7 @@
     <Keyboard>
       <Name>Cameroon AZERTY</Name>
       <ID>sil_cameroon_azerty</ID>
-      <Version>6.0.4</Version>
+      <Version>6.0.5</Version>
       <OSKFont>..\..\..\shared\fonts\sil\andika_subsets\AndikaAfr-R.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\andika_subsets\AndikaAfr-R.ttf</DisplayFont>
       <Languages>

--- a/release/sil/sil_cameroon_azerty/source/welcome/welcome.htm
+++ b/release/sil/sil_cameroon_azerty/source/welcome/welcome.htm
@@ -14203,7 +14203,7 @@ sélectionnez le nom de la touche de raccourci et modifiez la touche de raccourc
 </ul> 
 <p xml:lang="fr">Le Clavier Camerounais est un produit de SIL Cameroun. Pour plus  d´infos sur le Claver Camerounais ou la technologie linguistique au Cameroun,  veuillez visiter <a href="https://langtechcameroon.info">https://langtechcameroon.info</a>
 </p>
-<p xml:lang="fr" style="text-align: center;  font-style: italic;">Copyright 2018-2020  SIL Cameroun</p>
+<p xml:lang="fr" style="text-align: center;  font-style: italic;">Copyright 2018-2022  SIL Cameroun</p>
 </div>
 </div>
 </div>
@@ -28424,7 +28424,7 @@ select the hotkey name, and either change the hotkey or turn it off.
 </ul>
 <p xml:lang="en">The Cameroon Keyboard is developed by SIL Cameroon. For more  information about the Cameroon Keyboard or Language Technology in Cameroon, see  <a href="https://langtechcameroon.info">https://langtechcameroon.info</a>
 </p>
-<p xml:lang="en" style="text-align: center; font-style: italic;">Copyright 2018-2020 SIL  Cameroon</p>
+<p xml:lang="en" style="text-align: center; font-style: italic;">Copyright 2018-2022 SIL  Cameroon</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (https://github.com/keymanapp/keyman/pull/6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```
