### PR TITLE
[sil_myanmar_mywinext] Remove extraneous VISUALKEYBOARD store

### DIFF
--- a/release/sil/sil_myanmar_mywinext/HISTORY.md
+++ b/release/sil/sil_myanmar_mywinext/HISTORY.md
@@ -1,5 +1,8 @@
 # myWin Extended (SIL) Keyboard Change History
 
+# 1.4.1 (12 MAY 2022)
+* Remove extraneous KEYBOARDVERSION store 
+
 # 1.4 (6 JUL 2018)
 * Ported to GitHub
 

--- a/release/sil/sil_myanmar_mywinext/LICENSE.md
+++ b/release/sil/sil_myanmar_mywinext/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2004-2018 SIL International and Keith Stribley
+Copyright (c) 2004-2022 SIL International and Keith Stribley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil_myanmar_mywinext/README.md
+++ b/release/sil/sil_myanmar_mywinext/README.md
@@ -1,8 +1,7 @@
 # myWin Extended (SIL) Keyboard
 
-Copyright (C) 2004-2018 SIL International and Keith Stribley
+Copyright (C) 2004-2022 SIL International and Keith Stribley
 
-Version 1.4
 
 __DESCRIPTION__
 Burmese Keyboard for Unicode Encoding. This Layout has been designed to resemble that used by WinMyanmar Systems, however, it is much simplified because of the advantages of Unicode technology. Some keys have changed as a result.

--- a/release/sil/sil_myanmar_mywinext/sil_myanmar_mywinext.kpj
+++ b/release/sil/sil_myanmar_mywinext/sil_myanmar_mywinext.kpj
@@ -4,29 +4,30 @@
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
       <ID>id_476b0d82d6b68c5a214262c2770be6ce</ID>
       <Filename>sil_myanmar_mywinext.kmn</Filename>
       <Filepath>source\sil_myanmar_mywinext.kmn</Filepath>
-      <FileVersion>1.4</FileVersion>
+      <FileVersion>1.4.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>myWin Extended (SIL)</Name>
-        <Copyright>(c) 2004-2018 SIl International</Copyright>
+        <Copyright>(c) 2004-2022 SIl International</Copyright>
       </Details>
     </File>
     <File>
       <ID>id_d90ee0151f82b1a1f629f827b3d36c83</ID>
       <Filename>sil_myanmar_mywinext.kps</Filename>
       <Filepath>source\sil_myanmar_mywinext.kps</Filepath>
-      <FileVersion>1.4</FileVersion>
+      <FileVersion></FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>myWin Extended (SIL)</Name>
-        <Copyright>(c) 2004-2018 SIL International</Copyright>
-        <Version>1.4</Version>
+        <Copyright>(c) 2004-2022 SIL International</Copyright>
       </Details>
     </File>
     <File>

--- a/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kmn
+++ b/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kmn
@@ -27,14 +27,13 @@ c                               Add U+1035 on :, U+105A kinzi on Q
 store(&version) "10.0"  
 store(&NAME) 'myWin Extended (SIL)'
 c Comment out the line below to compile for SCIM
-store(&Copyright) "(c) 2004-2018 SIl International"
+store(&Copyright) "(c) 2004-2022 SIl International"
 store(sil_myanmar_mywinext.ico)
 store(&VISUALKEYBOARD) 'sil_myanmar_mywinext.kvks'
 c HOTKEY  "^+W"
 store(&TARGETS) 'windows macosx linux web'
-store(&KEYBOARDVERSION) '1.4'
+store(&KEYBOARDVERSION) '1.4.1'
 store(&BITMAP) 'sil_myanmar_mywinext.bmp'
-store(&VISUALKEYBOARD) 'sil_myanmar_mywinext.kvks'
 
 begin Unicode > use(Main)
 c qwertyuiop[ is same as Win

--- a/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kps
+++ b/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>10.0.1113.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>15.0.227.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -9,15 +9,16 @@
     <ReadMeFile>readme.htm</ReadMeFile>
     <MSIFileName></MSIFileName>
     <MSIOptions></MSIOptions>
+    <FollowKeyboardVersion/>
   </Options>
   <StartMenu>
     <Folder></Folder>
     <Items/>
   </StartMenu>
   <Info>
-    <Version URL="">1.4</Version>
+    <Version URL=""></Version>
     <Name URL="">myWin Extended (SIL)</Name>
-    <Copyright URL="">(c) 2004-2018 SIL International</Copyright>
+    <Copyright URL="">(c) 2004-2022 SIL International</Copyright>
   </Info>
   <Files>
     <File>
@@ -97,7 +98,7 @@
     <Keyboard>
       <Name>myWin Extended (SIL)</Name>
       <ID>sil_myanmar_mywinext</ID>
-      <Version>1.4</Version>
+      <Version>1.4.1</Version>
       <OSKFont>..\..\..\shared\fonts\sil\padauk\Padauk-Regular.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\padauk\Padauk-Regular.ttf</DisplayFont>
       <Languages>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate errors if a store() name is reused (https://github.com/keymanapp/keyman/pull/6463)