### PR TITLE
[dagbani] Add NCAPS  modifier to some rules

### DIFF
--- a/release/d/dagbani/HISTORY.md
+++ b/release/d/dagbani/HISTORY.md
@@ -1,6 +1,10 @@
 Dagbani Change History
 ====================
 
+1.0.1 (2022-05-12)
+------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 1.0 (2021-07-28)
 ----------------
 * Created by kent schroeder

--- a/release/d/dagbani/LICENSE.md
+++ b/release/d/dagbani/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2021 SIL International
+© 2021-2022 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/d/dagbani/README.md
+++ b/release/d/dagbani/README.md
@@ -1,9 +1,8 @@
 Dagbani keyboard based on US
 ==============
 
-©2021 SIL International
+©2021-2022 SIL International
 
-Version 1.0
 
 Description
 -----------

--- a/release/d/dagbani/source/dagbani.kmn
+++ b/release/d/dagbani/source/dagbani.kmn
@@ -14,11 +14,13 @@ store(&VISUALKEYBOARD) 'dagbani.kvks'
 store(&BITMAP) 'dagbani.ico'
 store(&LAYOUTFILE) 'dagbani.keyman-touch-layout'
 store(&COPYRIGHT) '©2021 SIL International'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 
 begin Unicode > use(main)
 
-store(basekey) "eongzEONGZ"
+c store(basekey) "eongzEONGZ"
+store(basekey) [NCAPS K_E] [NCAPS K_O] [NCAPS K_N] [NCAPS K_G] [NCAPS K_Z] \
+               [NCAPS SHIFT K_E] [NCAPS SHIFT K_O] [NCAPS SHIFT K_N] [NCAPS SHIFT K_G] [NCAPS SHIFT K_Z]
 store(output_char) "ɛɔŋɣʒƐƆŊƔƷ"
 
 group(main) using keys

--- a/release/d/dagbani/source/dagbani.kps
+++ b/release/d/dagbani/source/dagbani.kps
@@ -18,7 +18,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">Dagbani</Name>
-    <Copyright URL="">©2021 SIL International</Copyright>
+    <Copyright URL="">©2021-2022 SIL International</Copyright>
   </Info>
   <Files>
     <File>
@@ -74,7 +74,7 @@
     <Keyboard>
       <Name>Dagbani</Name>
       <ID>dagbani</ID>
-      <Version>1.0</Version>
+      <Version>1.0.1</Version>
       <Languages>
         <Language ID="dag">Dagbani</Language>
       </Languages>

--- a/release/d/dagbani/source/readme.htm
+++ b/release/d/dagbani/source/readme.htm
@@ -15,10 +15,10 @@
 <h1>Dagbani</h1>
 
 <p>
-    This is the keyboard for the Dagbani language of Ghana.  Dagbani 1.0 Keyboard based on US.
+    This is the keyboard for the Dagbani language of Ghana.  Dagbani Keyboard based on US.
 </p>
 
-<p>©2021 SIL International</p>
+<p>©2021-2022 SIL International</p>
 
 </body>
 </html>

--- a/release/d/dagbani/source/welcome.htm
+++ b/release/d/dagbani/source/welcome.htm
@@ -15,7 +15,7 @@
 <h1>Start Using Dagbani</h1>
 
 <p>
-   Dagbani 1.0 keyboard based on US
+   Dagbani keyboard based on US
 </p>
 
 <h1>Keyboard Layout</h1>
@@ -28,7 +28,7 @@
 
 <p>See <a href="file:dagbani.pdf">this document</a> for all the key combinations.</p>
 
-<p>©2021 SIL International</p>
+<p>©2021-2022 SIL International</p>
 
 </body>
 </html>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (https://github.com/keymanapp/keyman/pull/6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```
