### PR TITLE
[fv_tsilhqotin] Add NCAPS modifier to some rules

### DIFF
--- a/release/fv/fv_tsilhqotin/HISTORY.md
+++ b/release/fv/fv_tsilhqotin/HISTORY.md
@@ -1,6 +1,10 @@
 Tŝilhqot'in Change History
 ============================
 
+9.1.2 (13 May 2022)
+-------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 9.1.1 (24 Feb 2021)
 -------------------
 * Updated htm files for readability on Linux

--- a/release/fv/fv_tsilhqotin/LICENSE.md
+++ b/release/fv/fv_tsilhqotin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2022 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/fv/fv_tsilhqotin/README.md
+++ b/release/fv/fv_tsilhqotin/README.md
@@ -1,9 +1,8 @@
 Tŝilhqot'in keyboard
 ======================
 
-Copyright (c) 2008-2021 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
+Copyright (c) 2008-2022 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey
 
-Version 9.1.1
 
 Tŝilhqot'in keyboard layout for Unicode
 

--- a/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kmn
+++ b/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kmn
@@ -1,8 +1,8 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) "9.1.1"
+store(&KEYBOARDVERSION) "9.1.2"
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "clc"
-store(&COPYRIGHT) "© 2008-2021 FirstVoices, SIL International. Portions © 2006 Chris Harvey"
+store(&COPYRIGHT) "© 2008-2022 FirstVoices, SIL International. Portions © 2006 Chris Harvey"
 store(&NAME) "Tŝilhqot'in"
 store(&BITMAP) 'fv_tsilhqotin.ico'
 store(&VISUALKEYBOARD) 'fv_tsilhqotin.kvks'
@@ -156,8 +156,8 @@ c original punctuation
 + [RALT K_COMMA] > '<'
 + [SHIFT RALT K_BKQUOTE] > '~'
 + [RALT K_BKQUOTE] > '`'
-+ [SHIFT RALT K_COLON] > ':'
-+ [RALT K_COLON] > ';'
++ [NCAPS SHIFT RALT K_COLON] > ':'
++ [NCAPS RALT K_COLON] > ';'
 + [RALT K_SLASH] > '/'
 + [RALT K_QUOTE] > U+0027
 + [RALT K_BKSLASH] > '\'
@@ -185,19 +185,10 @@ c Quotes
 + [ncaps shift k_colon] > "Ɨ"
 + [caps k_colon] > "Ɨ"
 + [ncaps k_colon] > "ɨ"
-                                             
-+ "`" > "́"
-+ "[" > "̂"
-+ "]" > "ʔ"
-+ "<" > ";"
-+ ">" > ":"
-+ "/" > "́"     
 
                               
 nomatch > use(x)                            
 
 group(x) using keys
 
-store(allkeys) 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-=[]\;,./`~!@#$%^&*()_+{}|:"<>?' "'"
-+ any(allkeys) > index(allkeys, 1)
 

--- a/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kps
+++ b/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kps
@@ -16,7 +16,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Tŝilhqot’in</Name>
-    <Copyright URL="">© 2008-2021 FirstVoices, SIL International. Portions © 2006 Chris Harvey</Copyright>
+    <Copyright URL="">© 2008-2022 FirstVoices, SIL International. Portions © 2006 Chris Harvey</Copyright>
     <Version URL=""></Version>
     <Author URL=""></Author>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
@@ -123,7 +123,7 @@
     <Keyboard>
       <Name>Tŝilhqot'in</Name>
       <ID>fv_tsilhqotin</ID>
-      <Version></Version>
+      <Version>9.1.2</Version>
       <Languages>
         <Language ID="clc-Latn">Chilcotin (Latin)</Language>
       </Languages>


### PR DESCRIPTION
Part of keymanapp/keyboards#1827

* Add NCAPS to some rules to avoid inconsistent matches
* Also remove extraneous allkeys store
* Remove duplicate punctuation block