### PR TITLE
[indonesia] Add NCAPS modifier to some rules

### DIFF
--- a/release/i/indonesia/HISTORY.md
+++ b/release/i/indonesia/HISTORY.md
@@ -2,6 +2,10 @@ Indonesia Keyboard Layout Change History
 Riwayat Perubahan Tata Letak Papan Tombol Indonesia
 =======================================
 
+2.0.1 (13 May 2022)
+-------------------
+* Add NCAPS modifier to some rules to avoid inconsistent matches
+
 2.0 (6 April 2021)
 ---------------------------------
 * Update & harmonize with my other keyboard layouts (Jawa Latin, etc.)

--- a/release/i/indonesia/LICENSE.md
+++ b/release/i/indonesia/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2020-2021 Benny Lin
+© 2020-2022 Benny Lin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/i/indonesia/README.md
+++ b/release/i/indonesia/README.md
@@ -1,10 +1,8 @@
 Indonesia keyboard
 Papan ketik Indonesia
 =====================
-© 2020-2021 Benny Lin
+© 2020-2022 Benny Lin
 
-Version 2.0
-Versi 2.0
 
 Description
 Deskripsi

--- a/release/i/indonesia/source/help/indonesia.php
+++ b/release/i/indonesia/source/help/indonesia.php
@@ -35,7 +35,7 @@ Website homepage/Situs web: https://github.com/bennylin/keyboards
 </div>
 
 <h2>Mobile/Tablet Keyboard Layout</h2>
-<div id='osk-tablet' data-states='default shift capital shiftwithnumbers numeric symbols'>
+<div id='osk-tablet' data-states='default shift symbols numeric capital withnumbers shiftwithnumbers capitalwithnumbers'>
 </div>
 
 

--- a/release/i/indonesia/source/help/indonesia.php
+++ b/release/i/indonesia/source/help/indonesia.php
@@ -35,7 +35,7 @@ Website homepage/Situs web: https://github.com/bennylin/keyboards
 </div>
 
 <h2>Mobile/Tablet Keyboard Layout</h2>
-<div id='osk-tablet' data-states='default shift'>
+<div id='osk-tablet' data-states='default shift capital shiftwithnumbers numeric symbols'>
 </div>
 
 

--- a/release/i/indonesia/source/indonesia.kmn
+++ b/release/i/indonesia/source/indonesia.kmn
@@ -6,14 +6,14 @@ store(&VERSION) '10.0'
 store(&NAME) 'Indonesia'
 store(&VISUALKEYBOARD) 'indonesia.kvks'
 store(&BITMAP) 'indonesia.ico'
-store(&COPYRIGHT) '© 2020-2021 Benny Lin'
-store(&KEYBOARDVERSION) '2.0'
+store(&COPYRIGHT) '© 2020-2022 Benny Lin'
+store(&KEYBOARDVERSION) '2.0.1'
 store(&TARGETS) 'any'
 store(&MESSAGE) 'Indonesian basic keyboard'
 store(&LAYOUTFILE) 'indonesia.keyman-touch-layout'
 store(&KMW_HELPTEXT) 'readme.htm'
 
-store(controls) "ABCDEFGHIJKLMNOOPQRSTUVWXYZ\<>;_,/'"
+store(controls) "ABCDEFGHIJKLMNOOPQRSTUVWXY" [NCAPS K_Z] "\<>;_,/'"
 store(symbols) "`~!@#$%^&*()-_=+[{]}\|;:,<.>/?'" "'"
 store(numbers) "1234567890"
 
@@ -39,20 +39,20 @@ c new sentece markers
 
 c These button rotation works for physical device and touch device.
 c button rotation 1: "z", "x", "q"
-"z" + [K_Z] > "x"
-"x" + [K_Z] > "q"
-"q" + [K_Z] > "z"
-"Z" + [K_Z] > "x"
-"X" + [K_Z] > "q"
-"Q" + [K_Z] > "z"
+"z" + [NCAPS K_Z] > "x"
+"x" + [NCAPS K_Z] > "q"
+"q" + [NCAPS K_Z] > "z"
+"Z" + [NCAPS K_Z] > "x"
+"X" + [NCAPS K_Z] > "q"
+"Q" + [NCAPS K_Z] > "z"
 
 c this is for the physical keyboard rule
-"z" + [SHIFT K_Z] > "X"
-"x" + [SHIFT K_Z] > "Q"
-"q" + [SHIFT K_Z] > "Z"
-"Z" + [SHIFT K_Z] > "X"
-"X" + [SHIFT K_Z] > "Q"
-"Q" + [SHIFT K_Z] > "Z"
+"z" + [NCAPS SHIFT K_Z] > "X"
+"x" + [NCAPS SHIFT K_Z] > "Q"
+"q" + [NCAPS SHIFT K_Z] > "Z"
+"Z" + [NCAPS SHIFT K_Z] > "X"
+"X" + [NCAPS SHIFT K_Z] > "Q"
+"Q" + [NCAPS SHIFT K_Z] > "Z"
 
 "z" + [CAPS K_Z] > "X"
 "x" + [CAPS K_Z] > "Q"
@@ -96,25 +96,18 @@ c button rotation 4: "'", ":", '"'
 ":" + "'" > '"'
 '"' + "'" > "'"
 
-if(&layer = 'shift') "z" + "Z" > "X" set(&layer = "default")
-if(&layer = 'shift') "x" + "Z" > "Q" set(&layer = "default")
-if(&layer = 'shift') "q" + "Z" > "Z" set(&layer = "default")
-if(&layer = 'shift') "Z" + "Z" > "X" set(&layer = "default")
-if(&layer = 'shift') "X" + "Z" > "Q" set(&layer = "default")
-if(&layer = 'shift') "Q" + "Z" > "Z" set(&layer = "default")
-if(&layer = 'shiftwithnumbers') "z" + "Z" > "X" set(&layer = "withnumbers")
-if(&layer = 'shiftwithnumbers') "x" + "Z" > "Q" set(&layer = "withnumbers")
-if(&layer = 'shiftwithnumbers') "q" + "Z" > "Z" set(&layer = "withnumbers")
-if(&layer = 'shiftwithnumbers') "Z" + "Z" > "X" set(&layer = "withnumbers")
-if(&layer = 'shiftwithnumbers') "X" + "Z" > "Q" set(&layer = "withnumbers")
-if(&layer = 'shiftwithnumbers') "Q" + "Z" > "Z" set(&layer = "withnumbers")
-
-"z" + "Z" > "X"
-"x" + "Z" > "Q"
-"q" + "Z" > "Z"
-"Z" + "Z" > "X"
-"X" + "Z" > "Q"
-"Q" + "Z" > "Z"
+if(&layer = 'shift') "z" + [NCAPS SHIFT K_Z] > "X" set(&layer = "default")
+if(&layer = 'shift') "x" + [NCAPS SHIFT K_Z] > "Q" set(&layer = "default")
+if(&layer = 'shift') "q" + [NCAPS SHIFT K_Z] > "Z" set(&layer = "default")
+if(&layer = 'shift') "Z" + [NCAPS SHIFT K_Z] > "X" set(&layer = "default")
+if(&layer = 'shift') "X" + [NCAPS SHIFT K_Z] > "Q" set(&layer = "default")
+if(&layer = 'shift') "Q" + [NCAPS SHIFT K_Z] > "Z" set(&layer = "default")
+if(&layer = 'shiftwithnumbers') "z" + [NCAPS SHIFT K_Z] > "X" set(&layer = "withnumbers")
+if(&layer = 'shiftwithnumbers') "x" + [NCAPS SHIFT K_Z] > "Q" set(&layer = "withnumbers")
+if(&layer = 'shiftwithnumbers') "q" + [NCAPS SHIFT K_Z] > "Z" set(&layer = "withnumbers")
+if(&layer = 'shiftwithnumbers') "Z" + [NCAPS SHIFT K_Z] > "X" set(&layer = "withnumbers")
+if(&layer = 'shiftwithnumbers') "X" + [NCAPS SHIFT K_Z] > "Q" set(&layer = "withnumbers")
+if(&layer = 'shiftwithnumbers') "Q" + [NCAPS SHIFT K_Z] > "Z" set(&layer = "withnumbers")
 
 if(&layer = 'shift') + any(controls) > index(controls, 2) set(&layer = "default")
 if(&layer = 'shiftwithnumbers') + any(controls) > index(controls, 2) set(&layer = "withnumbers")

--- a/release/i/indonesia/source/indonesia.kps
+++ b/release/i/indonesia/source/indonesia.kps
@@ -33,7 +33,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Indonesia Keyboard</Name>
-    <Copyright URL="">© 2020 Benny Lin</Copyright>
+    <Copyright URL="">© 2020-2022 Benny Lin</Copyright>
     <Author URL="mailto:bennylin.idwiki@hotmail.com">Benny Lin</Author>
     <WebSite URL="github.com/bennylin">github.com/bennylin</WebSite>
   </Info>
@@ -79,7 +79,7 @@
     <Keyboard>
       <Name>Indonesia</Name>
       <ID>indonesia</ID>
-      <Version>1.0</Version>
+      <Version>2.0.1</Version>
       <Languages>
         <Language ID="id">Bahasa Indonesia</Language>
       </Languages>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings about inconsistent matches needing NCAPS (keymanapp/keyman#6347)

```
 Other rules which reference this key include CAPS or NCAPS modifiers, so this 
rule must include NCAPS modifier to avoid inconsistent matches
```
