### PR TITLE
[ukwuani] Remove extraneous group(main)

### DIFF
--- a/release/u/ukwuani/HISTORY.md
+++ b/release/u/ukwuani/HISTORY.md
@@ -1,6 +1,10 @@
 Ukwuani Change History
 ====================
 
+1.0.1 (2022-05-13)
+------------------
+* Remove extraneous group(main)
+
 1.0 (2022-01-03)
 ----------------
 * Created by ULDECF

--- a/release/u/ukwuani/README.md
+++ b/release/u/ukwuani/README.md
@@ -3,7 +3,6 @@ Ukwuani keyboard
 
 © 2022 ULDECF
 
-Version 1.0
 
 Description
 -----------

--- a/release/u/ukwuani/source/ukwuani.kmn
+++ b/release/u/ukwuani/source/ukwuani.kmn
@@ -3,7 +3,7 @@ c with name "Ukwuani"
 store(&VERSION) '10.0'
 store(&NAME) 'Ukwuani'
 store(&COPYRIGHT) '© 2022 ULDECF'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'ukwuani.kvks'
 store(&LAYOUTFILE) 'ukwuani.keyman-touch-layout'
@@ -24,7 +24,6 @@ group(main) using keys
 + [RALT K_U] > 'ụ'
 + [RALT K_E] > 'ẹ'
 
-group(main) using keys
 + [SHIFT K_Z] > 'Z'
 + [SHIFT K_X] > 'X'
 + [SHIFT K_C] > 'C'

--- a/release/u/ukwuani/source/ukwuani.kps
+++ b/release/u/ukwuani/source/ukwuani.kps
@@ -106,7 +106,7 @@
     <Keyboard>
       <Name>Ukwuani</Name>
       <ID>ukwuani</ID>
-      <Version>1.0</Version>
+      <Version>1.0.1</Version>
       <Languages>
         <Language ID="ukw">Ukwuani-Aboh-Ndoni</Language>
       </Languages>


### PR DESCRIPTION
Prep for the upcoming Keyman 15 release

The upcoming kmcmp.exe release will generate warnings when store names are re-used. keymanapp/keyman#6463

* Remove extraneous group(main) since it's already on l.14