### PR TITLE
[basic_kbdrum] Russian - Mnemonic Basic Improve dead-key pair processing

### DIFF
--- a/release/basic/basic_kbdrum/source/basic_kbdrum.kmn
+++ b/release/basic/basic_kbdrum/source/basic_kbdrum.kmn
@@ -69,28 +69,28 @@ group(main) using keys
 + [CAPS SHIFT K_C] > dk(0446)   c ц (small)
 
 c цц (cc)
-dk(0446) + [NCAPS K_C] > U+0446 U+0446
-dk(0426) + [CAPS K_C] > U+0426 U+0426
-dk(0446) + [CAPS SHIFT K_C] > U+0446 U+0446
-dk(0426) + [NCAPS SHIFT K_C] > U+0426 U+0426
+dk(0446) + [NCAPS K_C] > U+0446 dk(0446)
+dk(0426) + [CAPS K_C] > U+0426 dk(0426)
+dk(0446) + [CAPS SHIFT K_C] > U+0446 dk(0446)
+dk(0426) + [NCAPS SHIFT K_C] > U+0426 dk(0426)
 
 c цс (cs)
-dk(0446) + [NCAPS K_S] > U+0446 U+0441
-dk(0426) + [CAPS K_S] > U+0426 U+0421
-dk(0446) + [CAPS SHIFT K_S] > U+0446 U+0441
-dk(0426) + [NCAPS SHIFT K_S] > U+0426 U+0421
+dk(0446) + [NCAPS K_S] > U+0446 dk(0441)
+dk(0426) + [CAPS K_S] > U+0426 dk(0421)
+dk(0446) + [CAPS SHIFT K_S] > U+0446 dk(0441)
+dk(0426) + [NCAPS SHIFT K_S] > U+0426 dk(0421)
 
 c цй (cj)
-dk(0446) + [NCAPS K_J] > U+0446 U+0439
-dk(0426) + [CAPS K_J] > U+0426 U+0419
-dk(0446) + [CAPS SHIFT K_J] > U+0446 U+0439
-dk(0426) + [NCAPS SHIFT K_J] > U+0426 U+0419
+dk(0446) + [NCAPS K_J] > U+0446 dk(0439)
+dk(0426) + [CAPS K_J] > U+0426 dk(0419)
+dk(0446) + [CAPS SHIFT K_J] > U+0446 dk(0439)
+dk(0426) + [NCAPS SHIFT K_J] > U+0426 dk(0419)
 
 c цы (cy)
-dk(0446) + [NCAPS K_Y] > U+0446 U+044B
-dk(0426) + [CAPS K_Y] > U+0426 U+042B
-dk(0446) + [CAPS SHIFT K_Y] > U+0446 U+044B
-dk(0426) + [NCAPS SHIFT K_Y] > U+0426 U+042B
+dk(0446) + [NCAPS K_Y] > U+0446 dk(044B)
+dk(0426) + [CAPS K_Y] > U+0426 dk(042B)
+dk(0446) + [CAPS SHIFT K_Y] > U+0446 dk(044B)
+dk(0426) + [NCAPS SHIFT K_Y] > U+0426 dk(042B)
 
 + [NCAPS K_D] > U+0434
 + [CAPS K_D] > U+0414
@@ -128,28 +128,28 @@ dk(0426) + [NCAPS SHIFT K_Y] > U+0426 U+042B
 + [CAPS SHIFT K_J] > dk(0439)   c й (small)
 
 c йц (jc)
-dk(0439) + [NCAPS K_C] > U+0439 U+0446
-dk(0419) + [CAPS K_C] > U+0419 U+0426
-dk(0439) + [CAPS SHIFT K_C] > U+0439 U+0446
-dk(0419) + [NCAPS SHIFT K_C] > U+0419 U+0426
+dk(0439) + [NCAPS K_C] > U+0439 dk(0446)
+dk(0419) + [CAPS K_C] > U+0419 dk(0426)
+dk(0439) + [CAPS SHIFT K_C] > U+0439 dk(0446)
+dk(0419) + [NCAPS SHIFT K_C] > U+0419 dk(0426)
 
 c йс (js)
-dk(0439) + [NCAPS K_S] > U+0439 U+0441
-dk(0419) + [CAPS K_S] > U+0419 U+0421
-dk(0439) + [CAPS SHIFT K_S] > U+0439 U+0441
-dk(0419) + [NCAPS SHIFT K_S] > U+0419 U+0421
+dk(0439) + [NCAPS K_S] > U+0439 dk(0441)
+dk(0419) + [CAPS K_S] > U+0419 dk(0421)
+dk(0439) + [CAPS SHIFT K_S] > U+0439 dk(0441)
+dk(0419) + [NCAPS SHIFT K_S] > U+0419 dk(0421)
 
 c йй (jj)
-dk(0439) + [NCAPS K_J] > U+0439 U+0439
-dk(0419) + [CAPS K_J] > U+0419 U+0419
-dk(0439) + [CAPS SHIFT K_J] > U+0439 U+0439
-dk(0419) + [NCAPS SHIFT K_J] > U+0419 U+0419
+dk(0439) + [NCAPS K_J] > U+0439 dk(0439)
+dk(0419) + [CAPS K_J] > U+0419 dk(0419)
+dk(0439) + [CAPS SHIFT K_J] > U+0439 dk(0439)
+dk(0419) + [NCAPS SHIFT K_J] > U+0419 dk(0419)
 
 c йы (jy)
-dk(0439) + [NCAPS K_Y] > U+0439 U+044B
-dk(0419) + [CAPS K_Y] > U+0419 U+042B
-dk(0439) + [CAPS SHIFT K_Y] > U+0439 U+044B
-dk(0419) + [NCAPS SHIFT K_Y] > U+0419 U+042B
+dk(0439) + [NCAPS K_Y] > U+0439 dk(044B)
+dk(0419) + [CAPS K_Y] > U+0419 dk(042B)
+dk(0439) + [CAPS SHIFT K_Y] > U+0439 dk(044B)
+dk(0419) + [NCAPS SHIFT K_Y] > U+0419 dk(042B)
 
 + [NCAPS K_K] > U+043a
 + [CAPS K_K] > U+041a
@@ -197,20 +197,20 @@ dk(0419) + [NCAPS SHIFT K_Y] > U+0419 U+042B
 + [CAPS SHIFT K_S] > dk(0441)   c с (small)
 
 c сс (ss)
-dk(0441) + [NCAPS K_S] > U+0441 U+0441
-dk(0421) + [CAPS K_S] > U+0421 U+0421
-dk(0441) + [CAPS SHIFT K_S] > U+0441 U+0441
-dk(0421) + [NCAPS SHIFT K_S] > U+0421 U+0421
+dk(0441) + [NCAPS K_S] > U+0441 dk(0441)
+dk(0421) + [CAPS K_S] > U+0421 dk(0421)
+dk(0441) + [CAPS SHIFT K_S] > U+0441 dk(0441)
+dk(0421) + [NCAPS SHIFT K_S] > U+0421 dk(0421)
 c сы (sy)
-dk(0441) + [NCAPS K_Y] > U+0441 U+044B
-dk(0421) + [CAPS K_Y] > U+0421 U+042B
-dk(0441) + [CAPS SHIFT K_Y] > U+0441 U+044B
-dk(0421) + [NCAPS SHIFT K_Y] > U+0421 U+042B
+dk(0441) + [NCAPS K_Y] > U+0441 dk(044B)
+dk(0421) + [CAPS K_Y] > U+0421 dk(042B)
+dk(0441) + [CAPS SHIFT K_Y] > U+0441 dk(044B)
+dk(0421) + [NCAPS SHIFT K_Y] > U+0421 dk(042B)
 c сй (sj)
-dk(0441) + [NCAPS K_J] > U+0441 U+0439
-dk(0421) + [CAPS K_J] > U+0421 U+0419
-dk(0441) + [CAPS SHIFT K_J] > U+0441 U+0439
-dk(0421) + [NCAPS SHIFT K_J] > U+0421 U+0419
+dk(0441) + [NCAPS K_J] > U+0441 dk(0439)
+dk(0421) + [CAPS K_J] > U+0421 dk(0419)
+dk(0441) + [CAPS SHIFT K_J] > U+0441 dk(0439)
+dk(0421) + [NCAPS SHIFT K_J] > U+0421 dk(0419)
 c щ (sc)
 dk(0441) + [NCAPS K_C] > U+0449
 dk(0421) + [CAPS K_C] > U+0429
@@ -248,28 +248,28 @@ dk(0421) + [NCAPS SHIFT K_C] > U+0429
 + [CAPS SHIFT K_Y] > dk(044b)   c ы (small)
 
 c ыц (yc)
-dk(044B) + [NCAPS K_C] > U+044B U+0446
-dk(042B) + [CAPS K_C] > U+042B U+0426
-dk(044B) + [CAPS SHIFT K_C] > U+044B U+0446
-dk(042B) + [NCAPS SHIFT K_C] > U+042B U+0426
+dk(044B) + [NCAPS K_C] > U+044B dk(0446)
+dk(042B) + [CAPS K_C] > U+042B dk(0426)
+dk(044B) + [CAPS SHIFT K_C] > U+044B dk(0446)
+dk(042B) + [NCAPS SHIFT K_C] > U+042B dk(0426)
 
 c ыс (ys)
-dk(044B) + [NCAPS K_S] > U+044B U+0441
-dk(042B) + [CAPS K_S] > U+042B U+0421
-dk(044B) + [CAPS SHIFT K_S] > U+044B U+0441
-dk(042B) + [NCAPS SHIFT K_S] > U+042B U+0421
+dk(044B) + [NCAPS K_S] > U+044B dk(0441)
+dk(042B) + [CAPS K_S] > U+042B dk(0421)
+dk(044B) + [CAPS SHIFT K_S] > U+044B dk(0441)
+dk(042B) + [NCAPS SHIFT K_S] > U+042B dk(0421)
 
 c ый (yj)
-dk(044B) + [NCAPS K_J] > U+044B U+0439
-dk(042B) + [CAPS K_J] > U+042B U+0419
-dk(044B) + [CAPS SHIFT K_J] > U+044B U+0439
-dk(042B) + [NCAPS SHIFT K_J] > U+042B U+0419
+dk(044B) + [NCAPS K_J] > U+044B dk(0439)
+dk(042B) + [CAPS K_J] > U+042B dk(0419)
+dk(044B) + [CAPS SHIFT K_J] > U+044B dk(0439)
+dk(042B) + [NCAPS SHIFT K_J] > U+042B dk(0419)
 
 c ыы (yy)
-dk(044B) + [NCAPS K_Y] > U+044B U+044B
-dk(042B) + [CAPS K_Y] > U+042B U+042B
-dk(044B) + [CAPS SHIFT K_Y] > U+044B U+044B
-dk(042B) + [NCAPS SHIFT K_Y] > U+042B U+042B
+dk(044B) + [NCAPS K_Y] > U+044B dk(044B)
+dk(042B) + [CAPS K_Y] > U+042B dk(042B)
+dk(044B) + [CAPS SHIFT K_Y] > U+044B dk(044B)
+dk(042B) + [NCAPS SHIFT K_Y] > U+042B dk(042B)
 
 + [NCAPS K_Z] > U+0437
 + [CAPS K_Z] > U+0417


### PR DESCRIPTION
This change makes it possible to input some words without a space between dead keys. For example, the Russian word *сюжет* can be typed without a space between the dead keys `S` and `Y`.

In the following repo, I have rewritten the Russian Mnemonic keyboard layout with improved dead-keys processing, complementary special and math symbols accessed by the keys `AltGr`, `/` and `\`.

[https://github.com/dotland/mnemonic-kb-ru](https://github.com/dotland/mnemonic-kb-ru)