### PR TITLE
chore: cleanup build scripts 🚦

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,17 +8,21 @@ packages/*/build/
 .cache
 servervars.sh
 /.project
-release/j/jawa/jawa.kpj.user
-release/j/jawa/source/jawa-help.htm
-release/j/jawa/source/jawa.keyman-touch-layout
 .vscode/
-release/l/latin_jawa/latin_jawa.kpj
 
-# Program files downloaded
-tools/keyboard_info.distribution.json
-tools/keyboard_info.source.json
-tools/kmcmpdll.dll
-tools/kmcmpdll.x64.dll
-tools/kmcomp.exe
-tools/kmcomp.x64.exe
-tools/kmconvert.exe
+# compiler is downloaded into tools/kmcomp/
+/tools/kmcomp/
+
+# regression tests will be built into /output
+/output/
+
+# Program files downloaded -- legacy, these are no longer required
+# but we'll keep them in .gitignore so they don't accidentally get
+# added into commits
+/tools/keyboard_info.distribution.json
+/tools/keyboard_info.source.json
+/tools/kmcmpdll.dll
+/tools/kmcmpdll.x64.dll
+/tools/kmcomp.exe
+/tools/kmcomp.x64.exe
+/tools/kmconvert.exe

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+
 #
 # This script is built with commands available to Git Bash on Windows. (mingw32)
 #
@@ -9,7 +12,7 @@
 #
 
 function display_usage {
-  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [-no-update-compiler|-force-update-compiler] [target]"
+  echo "Usage: $0 [-validate] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [-no-update-compiler|-force-update-compiler] [target]"
   echo "  target should be a folder, for example: release, or release/k, or release/k/keyboard"
   echo "  (on keyboards_starter repo, target is not necessary)"
   echo
@@ -52,13 +55,7 @@ locate_keyboardinfo_schema
 #
 
 function parse_args {
-  DO_VALIDATE=true
   DO_BUILD=true
-  DO_CODESIGN=false
-  DO_UPLOAD_ONLY=false
-  DO_ZIP_ONLY=false
-  DO_DATA=true
-  DO_EXE=true
   WARNINGS_AS_ERRORS=false
   TARGET=
   PROJECT_TARGET_TYPE=
@@ -68,30 +65,22 @@ function parse_args {
   FLAG_CLEAN=
   FLAG_TARGET=
   FLAG_COLOR=
+  FLAG_COMPILER_VERSION=
   START=
   START_BASE=
   START_KEYBOARD=
   DO_UPDATE_COMPILER=true
   FORCE_UPDATE_COMPILER=false
 
-  local lastkey
+  local lastkey=
   local key
 
   # Parse args
   for key in "$@"; do
     if [[ -z "$lastkey" ]]; then
       case "$key" in
-        -upload-only)
-          DO_UPLOAD_ONLY=true
-          ;;
         -validate)
           DO_BUILD=false
-          ;;
-        -codesign)
-          DO_CODESIGN=true
-          ;;
-        -zip-only)
-          DO_ZIP_ONLY=true
           ;;
         -no-update-compiler)
           DO_UPDATE_COMPILER=false
@@ -99,17 +88,15 @@ function parse_args {
         -force-update-compiler)
           FORCE_UPDATE_COMPILER=true
           ;;
-        -prepare-and-upload-only)
-          DO_DATA=false
-          ;;
-        -no-exe)
-          DO_EXE=false
-          ;;
         -no-color)
           FLAG_COLOR=-no-color
           ;;
         -color)
           FLAG_COLOR=-color
+          ;;
+        -no-compiler-version)
+          # This flag is used only for regression tests.
+          FLAG_COMPILER_VERSION=-no-compiler-version
           ;;
         -start)
           lastkey=$key
@@ -170,6 +157,7 @@ util_set_log_color_mode "$FLAG_COLOR"
 # Are we in the keyboards_starter repo?
 #
 
+KEYBOARDS_STARTER=0
 if [[ -d "$KEYBOARDROOT/template" ]]; then
   if [[ -d "$KEYBOARDROOT/release" ]]; then
     die "This repo should not have both a /release/ folder and a /template/ folder. The /template/ folder should be present only in the keyboards_starter repo."

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -20,6 +20,7 @@ FLAG_CLEAN=
 FLAG_COLOR=
 FLAG_DEBUG=
 FLAG_TARGET=
+FLAG_COMPILER_VERSION=
 PROJECT_TARGET=
 lastkey=
 
@@ -45,7 +46,10 @@ for key in "$@"; do
       -color)
         FLAG_COLOR=-color
         ;;
-
+      -no-compiler-version)
+        # This flag is used only for regression tests.
+        FLAG_COMPILER_VERSION=-no-compiler-version
+        ;;
     esac
   else
     case "$lastkey" in
@@ -63,6 +67,12 @@ for key in "$@"; do
 done
 
 util_set_log_color_mode "$FLAG_COLOR"
+
+if [ ! -z "$FLAG_CLEAN" ]; then
+  rm -f ./source/fv_all.kps
+  rm -rf ./build/
+  exit 0
+fi
 
 # For each keyboard in the following release folders:
 # fv/*, inuktitut_*, sil_euro_latin, and basic_kbdcan
@@ -163,6 +173,6 @@ echo "${kps//@KEYBOARDS/$KEYBOARD_LINES}" > source/fv_all.kps
 
 mkdir -p build || die "Failed to create build folder for fv_all"
 
-$KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG "fv_all.kpj" $FLAG_TARGET "$PROJECT_TARGET"
+$KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_COMPILER_VERSION $FLAG_DEBUG "fv_all.kpj" $FLAG_TARGET "$PROJECT_TARGET"
 
 rm source/fv_all.kps

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -223,7 +223,8 @@ function build_keyboard {
       PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
       FLAG_TARGET=-t
     fi
-    ./build.sh $FLAG_SILENT $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Custom build script failed with an error"
+
+    ./build.sh $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG $FLAG_COMPILER_VERSION $FLAG_TARGET "$PROJECT_TARGET" || die "Custom build script failed with an error"
   else
     # We will use the standard build based on the group
     # Externally sourced keyboards (see above) may have the .source_is_binary flag,
@@ -354,7 +355,7 @@ function build_release_keyboard {
     PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
   fi
 
-  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
+  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG $FLAG_COMPILER_VERSION "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
 
   return 0
 }

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -171,10 +171,13 @@ function build_keyboard {
   # Validate the .keyboard_info and .kps before build
   #
 
-  local packageFilename="source/$base_keyboard.kps"
-  validate_keyboard_info "$keyboard_infoFilename" || die "Failed to validate $keyboard_infoFilename in $keyboard"
-  validate_keyboard_uniqueness "$group" "$keyboard" "$base_keyboard"
-  validate_package_file "$packageFilename" || die "Failed to validate $packageFilename"
+  if [[ -z "$FLAG_CLEAN" ]]; then
+    local packageFilename="source/$base_keyboard.kps"
+    validate_keyboard_info "$keyboard_infoFilename" || die "Failed to validate $keyboard_infoFilename in $keyboard"
+    validate_keyboard_uniqueness "$group" "$keyboard" "$base_keyboard"
+    validate_package_file "$packageFilename" || die "Failed to validate $packageFilename"
+
+  fi
 
   if [ "$DO_BUILD" = false ]; then
     popd
@@ -201,10 +204,12 @@ function build_keyboard {
   local keyboard_info_jsFilename=
   local keyboard_info_documentationFilename=
 
-  lines=$($KMCOMP_LAUNCHER "$KMCOMP" -nologo -extract-keyboard-info packageFilename,license,jsFilename,documentationFilename "$base_keyboard.keyboard_info" | grep -v "^$" | tr -d "\r") || die "Failed to extract keyboard_info properties: at least license must be specified"
-  lines="$(sed "s/^/keyboard_info_/g" <<< "$lines")"
+  if [[ -z "$FLAG_CLEAN" ]]; then
+    lines=$($KMCOMP_LAUNCHER "$KMCOMP" -nologo -extract-keyboard-info packageFilename,license,jsFilename,documentationFilename "$base_keyboard.keyboard_info" | grep -v "^$" | tr -d "\r") || die "Failed to extract keyboard_info properties: at least license must be specified"
+    lines="$(sed "s/^/keyboard_info_/g" <<< "$lines")"
 
-  eval $lines
+    eval $lines
+  fi
 
   #
   # Determine how we will build the keyboard. If a build.sh file exists, then that does
@@ -349,7 +354,7 @@ function build_release_keyboard {
     PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
   fi
 
-  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
+  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
 
   return 0
 }

--- a/resources/download-compiler.sh
+++ b/resources/download-compiler.sh
@@ -1,14 +1,36 @@
 #!/usr/bin/env bash
 
+# Assumes parent script has already set $KEYBOARDROOT and located kmcomp
+
 function download_and_unzip_kmcomp() {
   local VERSION=$1
   local TIER=$2
+
   local URL="https://keyman.com/go/download/kmcomp?version=$VERSION&tier=$TIER"
+  local KMCOMP_ZIP_PATH="$KEYBOARDROOT/tools/kmcomp/"
+  local KMCOMP_ZIP_FILE="$KEYBOARDROOT/tools/kmcomp.zip"
+
   echo "Downloading required version of kmcomp.exe and libraries from $URL"
-  curl --progress-bar -qL -o "$KEYBOARDROOT/tools/kmcomp.zip" "$URL" || die "Unable to download kmcomp.zip"
-  # We'll only unzip files in the root of kmcomp.zip
-  unzip -o "$KEYBOARDROOT/tools/kmcomp.zip" -x '**/*' -d "$KEYBOARDROOT/tools/" || die "Unable to unzip kmcomp.zip"
-  rm -f "$KEYBOARDROOT/tools/kmcomp.zip"
+  curl --progress-bar -qL -o "$KMCOMP_ZIP_FILE" "$URL" || die "Unable to download kmcomp.zip"
+
+  cleanup_legacy_kmcomp
+  rm -rf "$KMCOMP_ZIP_PATH"
+  mkdir -p "$KMCOMP_ZIP_PATH"
+  unzip -o "$KMCOMP_ZIP_FILE" -d "$KMCOMP_ZIP_PATH" || die "Unable to unzip kmcomp.zip"
+
+  rm -f "$KMCOMP_ZIP_FILE"
+}
+
+function cleanup_legacy_kmcomp() {
+  # Older versions of the repo put kmcomp files into tools/, which we've now moved
+  # into a separate folder to keep things tidier. If these files are present, we'll
+  # remove them
+  local f
+  for f in keyboard_info.distribution.json keyboard_info.source.json kmcmpdll.dll kmcmpdll.x64.dll kmcomp.exe kmcomp.x64.exe kmconvert.exe; do
+    if [ -f "$KEYBOARDROOT/tools/$f" ]; then
+      rm -f "$KEYBOARDROOT/tools/$f"
+    fi
+  done
 }
 
 function get_kmcomp_version() {
@@ -18,6 +40,7 @@ function get_kmcomp_version() {
 
 function download_and_check_kmcomp() {
   local force=$1
+
   local REQUIRED_VERSION=$(cat "$KEYBOARDROOT/tools/kmcomp-version.txt") KMCOMP_VERSION REQUIRED_TIER
   if [ -f "$KEYBOARDROOT/tools/kmcomp-tier.txt" ]; then
     REQUIRED_TIER=$(cat "$KEYBOARDROOT/tools/kmcomp-tier.txt")
@@ -42,7 +65,7 @@ function download_and_check_kmcomp() {
 }
 
 function kmcomp_exists() {
-  [ -f "$KEYBOARDROOT/tools/kmcomp.exe" ]
+  [ -f "$KMCOMP" ]
 }
 
 # Test code below:

--- a/resources/download-compiler.sh
+++ b/resources/download-compiler.sh
@@ -16,7 +16,7 @@ function download_and_unzip_kmcomp() {
   cleanup_legacy_kmcomp
   rm -rf "$KMCOMP_ZIP_PATH"
   mkdir -p "$KMCOMP_ZIP_PATH"
-  unzip -o "$KMCOMP_ZIP_FILE" -d "$KMCOMP_ZIP_PATH" || die "Unable to unzip kmcomp.zip"
+  unzip -q -o "$KMCOMP_ZIP_FILE" -d "$KMCOMP_ZIP_PATH" || die "Unable to unzip kmcomp.zip"
 
   rm -f "$KMCOMP_ZIP_FILE"
 }

--- a/resources/environment.sh
+++ b/resources/environment.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+function locate_xmllint() {
+  # Look for xmllint on path or XMLLINT env var
+  if [ -z ${XMLLINT+x} ]; then
+    if ! hash xmllint 2>/dev/null; then
+      XMLLINT=
+    else
+      XMLLINT=xmllint
+    fi
+  fi
+}
+
+function locate_kmcomp() {
+  KMCOMP="$KEYBOARDROOT/tools/kmcomp/kmcomp.exe"
+
+  case "${OSTYPE}" in
+    "cygwin")
+      KMCOMP_LAUNCHER=
+      ;;
+    "msys")
+      KMCOMP_LAUNCHER=
+      ;;
+    "darwin"*)
+      # For Catalina (10.15) onwards, must use wine64
+      base_macos_ver=10.15
+      macos_ver=$(sw_vers -productVersion)
+      if verlt "$macos_ver" "$base_macos_ver"; then
+        KMCOMP_LAUNCHER=wine
+      else
+        # On Catalina, and later versions:
+        # wine-4.12.1 works; wine-5.0, wine-5.7 do not.
+        # retrieve these from:
+        # `brew tap gcenx/wine && brew install --cask --no-quarantine wine-crossover`
+        # may also need to `sudo spctl --master-disable`
+        KMCOMP_LAUNCHER=wine64
+        KMCOMP="$KEYBOARDROOT/tools/kmcomp/kmcomp.x64.exe"
+      fi
+      ;;
+    *)
+      KMCOMP_LAUNCHER=wine
+      ;;
+  esac
+}
+
+function locate_keyboardinfo_schema() {
+  # Master json schema is from https://api.keyman.com/schemas/keyboard_info.json
+  KEYBOARDINFO_SCHEMA_JSON="$KEYBOARDROOT/tools/kmcomp/keyboard_info.source.json"
+  KEYBOARDINFO_SCHEMA_DIST_JSON="$KEYBOARDROOT/tools/kmcomp/keyboard_info.distribution.json"
+}

--- a/resources/regression-build.sh
+++ b/resources/regression-build.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+. "$KEYBOARDROOT/resources/zip.inc.sh"
+
+function get_kmcomp_full_version() {
+  local VERSION=$($KMCOMP_LAUNCHER "$KMCOMP" | grep -a Version | cut -d" " -f 2 - | cut -d"," -f 1 -)
+  echo $VERSION
+}
+
+function regression_build {
+  local SHOULD_BUILD_PACKAGES="$1"
+  local SHOULD_DECOMP="$2"
+  local SHOULD_ZIP="$3"
+  local BUILDPATH=
+  local BUILDTARGET="-T kmn"
+  local DEBUGBUILD=
+
+  #------------------------------------
+  # Configuration
+  #------------------------------------
+  # We don't want to build .kmp files
+  # BUILDTARGET=
+  if $SHOULD_BUILD_PACKAGES; then
+    BUILDTARGET=
+  fi
+
+  # TESTING: build just a specific path
+  # For testing purposes, probably should ./build.sh -c first
+  #BUILDPATH=release/a
+
+  # We'll do a debug build because it makes comparison MUCH easier for .js in particular
+  DEBUGBUILD=-d
+  #------------------------------------
+
+  #
+  # Get the kmcomp version for determining our output folder
+  #
+
+  local KMCOMP_VERSION=$(get_kmcomp_full_version)
+
+  #
+  # Prepare the output folder
+  #
+
+  local OUTPUT="$KEYBOARDROOT/output/$KMCOMP_VERSION"
+  rm -rf "$OUTPUT"
+  mkdir -p "$OUTPUT"
+
+  #
+  # Clean and build; we'll force -no-color because we are writing to a log file with tee
+  #
+
+  # Only add flag if this version of kmcomp supports it
+  local NO_COMPILER_VERSION=
+  $KMCOMP_LAUNCHER "$KMCOMP" | grep -- '-no-compiler-version' && NO_COMPILER_VERSION=-no-compiler-version
+
+  if [ ! -z "$BUILDPATH" ]; then
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log" || die "Unable to build keyboards"
+  else
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c release 2>&1 | tee "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c experimental 2>&1 | tee -a "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET release 2>&1 | tee "$OUTPUT/build.log" || die "Unable to build keyboards"
+    "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET experimental 2>&1 | tee -a "$OUTPUT/build.log" || die "Unable to build keyboards"
+  fi
+
+  #
+  # Copy results into target folder
+  #
+
+  echo "Copying final build files into $OUTPUT/"
+  cp -u "$KEYBOARDROOT"/release/*/*/build/* "$OUTPUT/"
+  cp -u "$KEYBOARDROOT"/experimental/*/*/build/* "$OUTPUT/"
+
+  #
+  # Decompile all .kmx in output/ into .kmn; this helps us with text comparisons and round-tripping
+  #
+
+  if $SHOULD_DECOMP && [ -f "$KEYBOARDROOT/tools/kmcomp/kmdecomp.exe" ]; then
+    echo "Decompiling all .kmx"
+    local i
+    for i in "$OUTPUT/"*.kmx; do
+      echo "Decompiling $i"
+      $KMCOMP_LAUNCHER "$KEYBOARDROOT/tools/kmcomp/kmdecomp.exe" "$i" || die "Failed to decompile $i"
+    done
+  fi
+
+  #
+  # Zip the resulting files
+  #
+
+  if $SHOULD_ZIP; then
+    echo "Zipping results into $OUTPUT.zip"
+    create_zip_file_strip_paths "$OUTPUT.zip" "$OUTPUT/*"
+  fi
+}

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -1,18 +1,48 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
-# Define terminal colours
+# Define terminal colours; we default to -no-color
 #
 
-if [ -t 2 ]; then
-  t_red=$'\e[1;31m'
-  t_grn=$'\e[1;32m'
-  t_yel=$'\e[1;33m'
-  t_blu=$'\e[1;34m'
-  t_mag=$'\e[1;35m'
-  t_cyn=$'\e[1;36m'
-  t_end=$'\e[0m'
-fi
+t_red=
+t_grn=
+t_yel=
+t_blu=
+t_mag=
+t_cyn=
+t_end=
+
+#
+# util_set_log_color_mode mode
+#
+#    mode: -no-color -- disable all color
+#          -color    -- force color mode on regardless of term settings
+#          (empty)   -- use term color mode
+#
+function util_set_log_color_mode {
+  local FLAG_COLOR="$1"
+  local COLOR
+
+  if [ "$FLAG_COLOR" == -no-color ]; then
+    COLOR=false
+  elif [ "$FLAG_COLOR" == -color ]; then
+    COLOR=true
+  elif [ -t 2 ]; then
+    COLOR=true
+  else
+    COLOR=false
+  fi
+
+  if $COLOR; then
+    t_red=$'\e[1;31m'
+    t_grn=$'\e[1;32m'
+    t_yel=$'\e[1;33m'
+    t_blu=$'\e[1;34m'
+    t_mag=$'\e[1;35m'
+    t_cyn=$'\e[1;36m'
+    t_end=$'\e[0m'
+  fi
+}
 
 #
 # We want to avoid globbing * when nothing exists
@@ -38,7 +68,7 @@ popd () {
 
 function die {
   local rc=$?
-  local msg=$1
+  local msg="$*"
 
   # We are dying, so if previous command didn't actually give
   # an error code, we still want to give an error. We'll give
@@ -50,110 +80,6 @@ function die {
   (>&2 echo "${t_red}$msg${t_end}")
   (>&2 echo "${t_red}Aborting with error $rc${t_end}")
   exit $rc
-}
-
-function parse_args {
-  DO_VALIDATE=true
-  DO_BUILD=true
-  DO_CODESIGN=false
-  DO_UPLOAD_ONLY=false
-  DO_ZIP_ONLY=false
-  DO_DATA=true
-  DO_EXE=true
-  WARNINGS_AS_ERRORS=false
-  TARGET=
-  PROJECT_TARGET_TYPE=
-  PROJECT_TARGET=
-  FLAG_SILENT=
-  FLAG_DEBUG=
-  FLAG_CLEAN=
-  FLAG_TARGET=
-  START=
-  START_BASE=
-  START_KEYBOARD=
-  DO_UPDATE_COMPILER=true
-  FORCE_UPDATE_COMPILER=false
-
-  local lastkey
-  local key
-
-  # Parse args
-  for key in "$@"; do
-    if [[ -z "$lastkey" ]]; then
-      case "$key" in
-        -upload-only)
-          DO_UPLOAD_ONLY=true
-          ;;
-        -validate)
-          DO_BUILD=false
-          ;;
-        -codesign)
-          DO_CODESIGN=true
-          ;;
-        -zip-only)
-          DO_ZIP_ONLY=true
-          ;;
-        -no-update-compiler)
-          DO_UPDATE_COMPILER=false
-          ;;
-        -force-update-compiler)
-          FORCE_UPDATE_COMPILER=true
-          ;;
-        -prepare-and-upload-only)
-          DO_DATA=false
-          ;;
-        -no-exe)
-          DO_EXE=false
-          ;;
-        -start)
-          lastkey=$key
-          ;;
-        -s)
-          FLAG_SILENT=-s
-          ;;
-        -d)
-          FLAG_DEBUG=-d
-          ;;
-        -c)
-          FLAG_CLEAN=-c
-          ;;
-        -w)
-          WARNINGS_AS_ERRORS=true
-          ;;
-        -h|-\?)
-          display_usage
-          ;;
-        -T)
-          lastkey="$key"
-          ;;
-        -t)
-          lastkey="$key"
-          ;;
-        *)
-          TARGET="$key"
-      esac
-    else
-      case "$lastkey" in
-        -start)
-          START="$key"
-          START_BASE=`dirname "$START"`
-          START_KEYBOARD=`basename "$START"`
-          if [[ "START_BASE" == "." ]]; then
-            START_BASE="$START"
-          fi
-          ;;
-        -t)
-          FLAG_TARGET=-t
-          PROJECT_TARGET="$key"
-          ;;
-        -T)
-          FLAG_TARGET=-t
-          PROJECT_TARGET_TYPE="$key"
-          ;;
-      esac
-      lastkey=
-    fi
-  done
 }
 
 #

--- a/resources/zip.inc.sh
+++ b/resources/zip.inc.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+#
+# Creates a zip file. This version strips paths from files added to the zip
+# file. Uses perl which is available in git bash and cross-platform; git bash
+# does not include 'zip'.
+#
+# $1: zip filename to create
+# $2: glob to add to zip file (paths will be stripped in resultant file)
+#
+# Example:
+#   create_zip_file_strip_paths \
+#     "output/16.0.30-alpha-local.zip" \
+#     "output/16.0.30-alpha-local/*"
+#
+function create_zip_file_strip_paths() {
+  local ZIP="$1"
+  local FILES="$2"
+
+  perl -e "
+    use strict;
+    use warnings;
+    use autodie;
+    use IO::Compress::Zip qw(:all);
+    zip [
+      <\$ARGV[1]>
+    ] => \$ARGV[0],
+        FilterName => sub { s/^.+?([^\\/]+)$/\$1/ },
+        Zip64 => 0,
+    or die \"Zip failed: \$ZipError\n\";
+  " -- "$ZIP" "$FILES"
+}

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+function display_usage {
+  echo "Builds regression-oriented version of all release and experimental keyboards"
+  echo "and puts all built files into output/<version>/. By default, this script"
+  echo "builds only .kmx and .js"
+  echo
+  echo "Note: all build modes overwrite existing tools/kmcomp/ except Default build mode."
+
+  echo "Build modes:"
+  echo "  regression.sh"
+  echo "     Default build mode."
+  echo "     Builds with current version of kmcomp already in tools/kmcomp/"
+  echo
+  echo "  regression.sh --local-search path"
+  echo "     Searches for the first kmcomp-<version>.zip in path and uses that"
+  echo "     (Used by Developer test build in CI)"
+  echo
+  echo "  regression.sh --local, -l kmcomp.zip"
+  echo "     Extracts the compiler from specified kmcomp.zip and uses that"
+  echo
+  echo "  regression.sh --download-for-tier TIER.md"
+  echo "     Uses --download semantics, reading tier from TIER.md"
+  echo "     (Used by Developer test build in CI)"
+  echo
+  echo "  regression.sh --download, -d [version][-tier]"
+  echo "     Downloads the specified version of kmcomp from keyman.com; "
+  echo "     <version>, if specified, should be a version number such as 14.0.294."
+  echo "     <tier>, if specified, should be 'alpha', 'beta', or 'stable'. Defaults to 'stable'."
+  echo "     If <version> is omitted, downloads the latest version of kmcomp in <tier>."
+  echo
+  echo "General flags:"
+  echo "  --packages, -p    Build .kmp packages as well as .kmx / .js"
+  echo "  --decomp, -D      Decompile .kmx into .kmn in output after build"
+  echo "  --zip, -z         Also compress the output files into a <version>.zip file"
+  echo "  --help, -h        Show this help"
+  exit 0
+}
+
+KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+. "$KEYBOARDROOT/resources/util.sh"
+. "$KEYBOARDROOT/resources/environment.sh"
+. "$KEYBOARDROOT/resources/download-compiler.sh"
+. "$KEYBOARDROOT/resources/regression-build.sh"
+
+util_set_log_color_mode -no-color
+
+locate_kmcomp
+
+function parse_args {
+  SHOULD_BUILD_PACKAGES=false
+  SHOULD_EXTRACT_LOCAL=false
+  SHOULD_SEARCH_LOCAL=false
+  SHOULD_DOWNLOAD=false
+  SHOULD_READ_TIER=false
+  SHOULD_DECOMP=false
+  SHOULD_ZIP=false
+  LOCAL_PATH=
+  REQUIRED_VERSION=
+  REQUIRED_TIER=stable
+
+  local lastkey=
+  local key
+
+  # Parse args
+  for key in "$@"; do
+    if [[ -z "$lastkey" ]]; then
+      case "$key" in
+        --packages|-p)
+          SHOULD_BUILD_PACKAGES=true
+          ;;
+        --decomp|-D)
+          SHOULD_DECOMP=true
+          ;;
+        --download|-d)
+          SHOULD_DOWNLOAD=true
+          lastkey="$key"
+          ;;
+        --download-for-tier)
+          SHOULD_DOWNLOAD=true
+          SHOULD_READ_TIER=true
+          lastkey="$key"
+          ;;
+        --local|-l)
+          SHOULD_EXTRACT_LOCAL=true
+          lastkey="$key"
+          ;;
+        --local-search)
+          SHOULD_EXTRACT_LOCAL=true
+          SHOULD_SEARCH_LOCAL=true
+          lastkey="$key"
+          ;;
+        --zip|-z)
+          SHOULD_ZIP=true
+          ;;
+        --help|-h)
+          display_usage
+          exit 0
+          ;;
+        *)
+          echo "Invalid parameter"
+          echo
+          display_usage
+          exit 1
+      esac
+    else
+      case "$lastkey" in
+        --local)
+          LOCAL_PATH="$key"
+          ;;
+        --local-search)
+          LOCAL_PATH="$key"
+          ;;
+        --download-for-tier)
+          TIER_MD="$key"
+          ;;
+        --download)
+          REQUIRED_VERSION=$(echo "$key" | cut -d- -f 1 -)
+          if [[ "$2" == *"-"* ]]; then
+            REQUIRED_TIER=$(echo "$key" | cut -d- -f 2 -)
+          fi
+          ;;
+      esac
+      lastkey=
+    fi
+  done
+}
+
+
+#
+# Validate args
+#
+
+parse_args "$@"
+
+if $SHOULD_EXTRACT_LOCAL; then
+  if [ -z "$LOCAL_PATH" ]; then
+    die "--local: path must be specified"
+  fi
+fi
+
+if $SHOULD_READ_TIER; then
+  if [ -z "$TIER_MD" ]; then
+    die "--download-for-tier: TIER.md path must be specified"
+  fi
+fi
+
+echo "Parameters:
+  SHOULD_BUILD_PACKAGES: $SHOULD_BUILD_PACKAGES
+  SHOULD_SEARCH_LOCAL:   $SHOULD_SEARCH_LOCAL
+  SHOULD_EXTRACT_LOCAL:  $SHOULD_EXTRACT_LOCAL
+  SHOULD_DOWNLOAD:       $SHOULD_DOWNLOAD
+  SHOULD_READ_TIER:      $SHOULD_READ_TIER
+  SHOULD_DECOMP:         $SHOULD_DECOMP
+  LOCAL_PATH:            $LOCAL_PATH
+  REQUIRED_VERSION:      $REQUIRED_VERSION
+  REQUIRED_TIER:         $REQUIRED_TIER
+"
+
+#
+# Get the most recent build for $TIER from downloads.keyman.com
+#
+function get_developer_remote_version {
+  local TIER="$1"
+  local JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+
+  local DOWNLOADS_VERSION_API=https://downloads.keyman.com/api/version/developer
+  local REMOTE_DEVELOPER_VERSIONS=`curl -s $DOWNLOADS_VERSION_API`
+  REQUIRED_VERSION=`echo $REMOTE_DEVELOPER_VERSIONS | $JQ -r ".developer.$TIER"`
+  echo "Latest downloadable version of kmcomp.zip for $TIER is $REQUIRED_VERSION"
+}
+
+#
+# We'll now get kmcomp.exe and friends from the built kmcomp-$version.zip.
+#
+function extract_local_compiler {
+  local SOURCE="$1"
+  if [ ! -f "$SOURCE" ]; then
+    die "Source zip $SOURCE not found"
+  fi
+
+  local TARGET="$KEYBOARDROOT/tools/kmcomp"
+  rm -rf "$TARGET"
+  mkdir -p "$TARGET"
+  unzip -q -o "$SOURCE" -d "$TARGET/" || die "Unable to unzip $SOURCE"
+}
+
+#
+# Locate the first kmcomp-<version>.zip in $LOCAL_PATH and update the variable
+#
+function find_local_compiler {
+  local COMPILERS=("$LOCAL_PATH"/*/kmcomp-*.zip)
+  if [ ${#COMPILERS[@]} -eq 0 ]; then
+    die "No kmcomp-<version>.zip found in immediate subdirectories of $LOCAL_PATH"
+  fi
+  LOCAL_PATH="${COMPILERS[0]}"
+  echo "Found local compiler at $LOCAL_PATH"
+}
+
+#
+# Extract tier from TIER.md
+#
+function read_tier_from_tier_md {
+  REQUIRED_TIER=`cat "$TIER_MD"` || die "Could not read $TIER_MD"
+}
+
+#------------------------------------------------------------------------------
+# main
+#------------------------------------------------------------------------------
+if $SHOULD_EXTRACT_LOCAL; then
+  if $SHOULD_SEARCH_LOCAL; then
+    find_local_compiler
+  fi
+  extract_local_compiler "$LOCAL_PATH"
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP" "$SHOULD_ZIP"
+else
+  if $SHOULD_READ_TIER; then
+    read_tier_from_tier_md "$TIER_MD"
+  fi
+
+  if $SHOULD_DOWNLOAD; then
+    if [ -z "$REQUIRED_VERSION" ]; then
+      echo "Finding latest version of Keyman Developer for $REQUIRED_TIER"
+      get_developer_remote_version "$REQUIRED_TIER"
+    fi
+    download_and_unzip_kmcomp "$REQUIRED_VERSION" "$REQUIRED_TIER"
+  fi
+
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP" "$SHOULD_ZIP"
+fi


### PR DESCRIPTION
This is part of a larger set of PRs coming which will automate the build of keyboards during the Keyman Developer build.

Refactors and rearranges various parts of build scripts:

* Moves functions to search for kmcomp, etc to environment.sh -- this way we can use the search functions from any script

* Moves parse_args from util.sh back to build.sh -- parse_args is specific to build.sh so should not be in a shared util script

* Moves kmcomp downloaded files to tools/kmcomp/ and cleans up older compiler files in tools/ -- this makes it much easier to cut and shut new versions of kmcomp

* Adds color flags to build.sh and related scripts for controlling color output in logs

* Cleans up some mess from .gitignore and ensures that kmcomp and future regression outputs will be ignored.

Note: additional cleanup of build scripts is in follow-up PR #1914.