### PR TITLE
feat: regression builds 🚦

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+
 #
 # This script is built with commands available to Git Bash on Windows. (mingw32)
 #
@@ -9,7 +12,7 @@
 #
 
 function display_usage {
-  echo "Usage: $0 [-validate] [-codesign] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [-no-update-compiler|-force-update-compiler] [target]"
+  echo "Usage: $0 [-validate] [-start] [-s] [-d] [-c] [-w] [-T [kmn|kps]] [-t project_target] [-no-update-compiler|-force-update-compiler] [target]"
   echo "  target should be a folder, for example: release, or release/k, or release/k/keyboard"
   echo "  (on keyboards_starter repo, target is not necessary)"
   echo
@@ -52,13 +55,7 @@ locate_keyboardinfo_schema
 #
 
 function parse_args {
-  DO_VALIDATE=true
   DO_BUILD=true
-  DO_CODESIGN=false
-  DO_UPLOAD_ONLY=false
-  DO_ZIP_ONLY=false
-  DO_DATA=true
-  DO_EXE=true
   WARNINGS_AS_ERRORS=false
   TARGET=
   PROJECT_TARGET_TYPE=
@@ -75,36 +72,21 @@ function parse_args {
   DO_UPDATE_COMPILER=true
   FORCE_UPDATE_COMPILER=false
 
-  local lastkey
+  local lastkey=
   local key
 
   # Parse args
   for key in "$@"; do
     if [[ -z "$lastkey" ]]; then
       case "$key" in
-        -upload-only)
-          DO_UPLOAD_ONLY=true
-          ;;
         -validate)
           DO_BUILD=false
-          ;;
-        -codesign)
-          DO_CODESIGN=true
-          ;;
-        -zip-only)
-          DO_ZIP_ONLY=true
           ;;
         -no-update-compiler)
           DO_UPDATE_COMPILER=false
           ;;
         -force-update-compiler)
           FORCE_UPDATE_COMPILER=true
-          ;;
-        -prepare-and-upload-only)
-          DO_DATA=false
-          ;;
-        -no-exe)
-          DO_EXE=false
           ;;
         -no-color)
           FLAG_COLOR=-no-color
@@ -175,6 +157,7 @@ util_set_log_color_mode "$FLAG_COLOR"
 # Are we in the keyboards_starter repo?
 #
 
+KEYBOARDS_STARTER=0
 if [[ -d "$KEYBOARDROOT/template" ]]; then
   if [[ -d "$KEYBOARDROOT/release" ]]; then
     die "This repo should not have both a /release/ folder and a /template/ folder. The /template/ folder should be present only in the keyboards_starter repo."

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,7 @@ function parse_args {
   FLAG_CLEAN=
   FLAG_TARGET=
   FLAG_COLOR=
+  FLAG_COMPILER_VERSION=
   START=
   START_BASE=
   START_KEYBOARD=
@@ -110,6 +111,10 @@ function parse_args {
           ;;
         -color)
           FLAG_COLOR=-color
+          ;;
+        -no-compiler-version)
+          # This flag is used only for regression tests.
+          FLAG_COMPILER_VERSION=-no-compiler-version
           ;;
         -start)
           lastkey=$key

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -20,6 +20,7 @@ FLAG_CLEAN=
 FLAG_COLOR=
 FLAG_DEBUG=
 FLAG_TARGET=
+FLAG_COMPILER_VERSION=
 PROJECT_TARGET=
 lastkey=
 
@@ -45,7 +46,10 @@ for key in "$@"; do
       -color)
         FLAG_COLOR=-color
         ;;
-
+      -no-compiler-version)
+        # This flag is used only for regression tests.
+        FLAG_COMPILER_VERSION=-no-compiler-version
+        ;;
     esac
   else
     case "$lastkey" in
@@ -63,6 +67,12 @@ for key in "$@"; do
 done
 
 util_set_log_color_mode "$FLAG_COLOR"
+
+if [ ! -z "$FLAG_CLEAN" ]; then
+  rm -f ./source/fv_all.kps
+  rm -rf ./build/
+  exit 0
+fi
 
 # For each keyboard in the following release folders:
 # fv/*, inuktitut_*, sil_euro_latin, and basic_kbdcan
@@ -163,6 +173,6 @@ echo "${kps//@KEYBOARDS/$KEYBOARD_LINES}" > source/fv_all.kps
 
 mkdir -p build || die "Failed to create build folder for fv_all"
 
-$KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG "fv_all.kpj" $FLAG_TARGET "$PROJECT_TARGET"
+$KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_COMPILER_VERSION $FLAG_DEBUG "fv_all.kpj" $FLAG_TARGET "$PROJECT_TARGET"
 
 rm source/fv_all.kps

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -223,7 +223,8 @@ function build_keyboard {
       PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
       FLAG_TARGET=-t
     fi
-    ./build.sh $FLAG_SILENT $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Custom build script failed with an error"
+
+    ./build.sh $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG $FLAG_COMPILER_VERSION $FLAG_TARGET "$PROJECT_TARGET" || die "Custom build script failed with an error"
   else
     # We will use the standard build based on the group
     # Externally sourced keyboards (see above) may have the .source_is_binary flag,

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -354,7 +354,7 @@ function build_release_keyboard {
     PROJECT_TARGET="$base_keyboard.$PROJECT_TARGET_TYPE"
   fi
 
-  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
+  $KMCOMP_LAUNCHER "$KMCOMP" -nologo $FLAG_SILENT $FLAG_COLOR $FLAG_CLEAN $FLAG_DEBUG $FLAG_COMPILER_VERSION "$kpj" $FLAG_TARGET "$PROJECT_TARGET" || die "Could not compile keyboard"
 
   return 0
 }

--- a/resources/download-compiler.sh
+++ b/resources/download-compiler.sh
@@ -16,7 +16,7 @@ function download_and_unzip_kmcomp() {
   cleanup_legacy_kmcomp
   rm -rf "$KMCOMP_ZIP_PATH"
   mkdir -p "$KMCOMP_ZIP_PATH"
-  unzip -o "$KMCOMP_ZIP_FILE" -d "$KMCOMP_ZIP_PATH" || die "Unable to unzip kmcomp.zip"
+  unzip -q -o "$KMCOMP_ZIP_FILE" -d "$KMCOMP_ZIP_PATH" || die "Unable to unzip kmcomp.zip"
 
   rm -f "$KMCOMP_ZIP_FILE"
 }

--- a/resources/regression-build.sh
+++ b/resources/regression-build.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+function get_kmcomp_full_version() {
+  local VERSION=$($KMCOMP_LAUNCHER "$KMCOMP" | grep -a Version | cut -d" " -f 2 - | cut -d"," -f 1 -)
+  echo $VERSION
+}
+
 function regression_build {
   local SHOULD_BUILD_PACKAGES="$1"
   local SHOULD_DECOMP="$2"
@@ -27,7 +32,7 @@ function regression_build {
   # Get the kmcomp version for determining our output folder
   #
 
-  local KMCOMP_VERSION=$(get_kmcomp_version)
+  local KMCOMP_VERSION=$(get_kmcomp_full_version)
 
   #
   # Prepare the output folder
@@ -41,8 +46,8 @@ function regression_build {
   # Clean and build; we'll force -no-color because we are writing to a log file with tee
   #
 
-  "$KEYBOARDROOT/build.sh" -no-color -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log"
-  "$KEYBOARDROOT/build.sh" -no-color -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log"
+  "$KEYBOARDROOT/build.sh" -no-color -no-compiler-version -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log"
+  "$KEYBOARDROOT/build.sh" -no-color -no-compiler-version -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log"
 
   #
   # Copy results into target folder

--- a/resources/regression-build.sh
+++ b/resources/regression-build.sh
@@ -9,7 +9,7 @@ function regression_build {
   local SHOULD_BUILD_PACKAGES="$1"
   local SHOULD_DECOMP="$2"
   local BUILDPATH=
-  local BUILDTARGET=
+  local BUILDTARGET="-T kmn"
   local DEBUGBUILD=
 
   #------------------------------------
@@ -18,7 +18,7 @@ function regression_build {
   # We don't want to build .kmp files
   # BUILDTARGET=
   if $SHOULD_BUILD_PACKAGES; then
-    BUILDTARGET="-T kmn"
+    BUILDTARGET=
   fi
 
   # TESTING: build just a specific path
@@ -50,8 +50,10 @@ function regression_build {
   local NO_COMPILER_VERSION=
   $KMCOMP_LAUNCHER "$KMCOMP" | grep -- '-no-compiler-version' && NO_COMPILER_VERSION=-no-compiler-version
 
-  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log" || die "Unable to clean keyboards"
-  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log" || die "Unable to build keyboards"
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c $BUILDPATH release 2>&1 | tee "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c $BUILDPATH experimental 2>&1 | tee -a "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH release 2>&1 | tee "$OUTPUT/build.log" || die "Unable to build keyboards"
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH experimental 2>&1 | tee -a "$OUTPUT/build.log" || die "Unable to build keyboards"
 
   #
   # Copy results into target folder

--- a/resources/regression-build.sh
+++ b/resources/regression-build.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+function regression_build {
+  local SHOULD_BUILD_PACKAGES="$1"
+  local SHOULD_DECOMP="$2"
+  local BUILDPATH=
+  local BUILDTARGET=
+  local DEBUGBUILD=
+
+  #------------------------------------
+  # Configuration
+  #------------------------------------
+  # We don't want to build .kmp files
+  # BUILDTARGET=
+  if $SHOULD_BUILD_PACKAGES; then
+    BUILDTARGET="-T kmn"
+  fi
+
+  # TESTING: build just a specific path
+  #BUILDPATH=release/a
+
+  # We'll do a debug build because it makes comparison MUCH easier for .js in particular
+  DEBUGBUILD=-d
+  #------------------------------------
+
+  #
+  # Get the kmcomp version for determining our output folder
+  #
+
+  local KMCOMP_VERSION=$(get_kmcomp_version)
+
+  #
+  # Prepare the output folder
+  #
+
+  local OUTPUT="$KEYBOARDROOT/output/$KMCOMP_VERSION"
+  rm -rf "$OUTPUT"
+  mkdir -p "$OUTPUT"
+
+  #
+  # Clean and build; we'll force -no-color because we are writing to a log file with tee
+  #
+
+  "$KEYBOARDROOT/build.sh" -no-color -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log"
+  "$KEYBOARDROOT/build.sh" -no-color -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log"
+
+  #
+  # Copy results into target folder
+  #
+
+  echo "Copying final build files into $OUTPUT/"
+  cp -u "$KEYBOARDROOT"/release/*/*/build/* "$OUTPUT/"
+
+  #
+  # Decompile all .kmx in output/ into .kmn; this helps us with text comparisons and round-tripping
+  #
+
+  if $SHOULD_DECOMP && [ -f "$KEYBOARDROOT/tools/kmcomp/kmdecomp.exe" ]; then
+    echo "Decompiling all .kmx"
+    local i
+    for i in "$OUTPUT/"*.kmx; do
+      echo "Decompiling $i"
+      $KMCOMP_LAUNCHER "$KEYBOARDROOT/tools/kmcomp/kmdecomp.exe" "$i" || die "Failed to decompile $i"
+    done
+  fi
+}

--- a/resources/regression-build.sh
+++ b/resources/regression-build.sh
@@ -46,8 +46,12 @@ function regression_build {
   # Clean and build; we'll force -no-color because we are writing to a log file with tee
   #
 
-  "$KEYBOARDROOT/build.sh" -no-color -no-compiler-version -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log"
-  "$KEYBOARDROOT/build.sh" -no-color -no-compiler-version -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log"
+  # Only add flag if this version of kmcomp supports it
+  local NO_COMPILER_VERSION=
+  $KMCOMP_LAUNCHER "$KMCOMP" | grep -- '-no-compiler-version' && NO_COMPILER_VERSION=-no-compiler-version
+
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler -c $BUILDPATH 2>&1 | tee "$OUTPUT/clean.log" || die "Unable to clean keyboards"
+  "$KEYBOARDROOT/build.sh" -no-color $NO_COMPILER_VERSION -no-update-compiler $DEBUGBUILD $BUILDTARGET $BUILDPATH 2>&1 | tee "$OUTPUT/build.log" || die "Unable to build keyboards"
 
   #
   # Copy results into target folder

--- a/resources/zip.inc.sh
+++ b/resources/zip.inc.sh
@@ -30,7 +30,3 @@ function create_zip_file_strip_paths() {
     or die \"Zip failed: \$ZipError\n\";
   " -- "$ZIP" "$FILES"
 }
-
-  create_zip_file_strip_paths \
-    "output/16.0.30-alpha-local.zip" \
-    "output/16.0.30-alpha-local/*"

--- a/resources/zip.inc.sh
+++ b/resources/zip.inc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# Creates a zip file. This version strips paths from files added to the zip
+# file. Uses perl which is available in git bash and cross-platform; git bash
+# does not include 'zip'.
+#
+# $1: zip filename to create
+# $2: glob to add to zip file (paths will be stripped in resultant file)
+#
+# Example:
+#   create_zip_file_strip_paths \
+#     "output/16.0.30-alpha-local.zip" \
+#     "output/16.0.30-alpha-local/*"
+#
+function create_zip_file_strip_paths() {
+  local ZIP="$1"
+  local FILES="$2"
+
+  perl -e "
+    use strict;
+    use warnings;
+    use autodie;
+    use IO::Compress::Zip qw(:all);
+    zip [
+      <\$ARGV[1]>
+    ] => \$ARGV[0],
+        FilterName => sub { s/^.+?([^\\/]+)$/\$1/ },
+        Zip64 => 0,
+    or die \"Zip failed: \$ZipError\n\";
+  " -- "$ZIP" "$FILES"
+}
+
+  create_zip_file_strip_paths \
+    "output/16.0.30-alpha-local.zip" \
+    "output/16.0.30-alpha-local/*"

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -35,6 +35,7 @@ function display_usage {
   echo "General flags:"
   echo "  --packages, -p    Build .kmp packages as well as .kmx / .js"
   echo "  --decomp, -D      Decompile .kmx into .kmn in output after build"
+  echo "  --zip, -z         Also compress the output files into a <version>.zip file"
   echo "  --help, -h        Show this help"
   exit 0
 }
@@ -57,6 +58,7 @@ function parse_args {
   SHOULD_DOWNLOAD=false
   SHOULD_READ_TIER=false
   SHOULD_DECOMP=false
+  SHOULD_ZIP=false
   LOCAL_PATH=
   REQUIRED_VERSION=
   REQUIRED_TIER=stable
@@ -91,6 +93,9 @@ function parse_args {
           SHOULD_EXTRACT_LOCAL=true
           SHOULD_SEARCH_LOCAL=true
           lastkey="$key"
+          ;;
+        --zip|-z)
+          SHOULD_ZIP=true
           ;;
         --help|-h)
           display_usage
@@ -211,7 +216,7 @@ if $SHOULD_EXTRACT_LOCAL; then
     find_local_compiler
   fi
   extract_local_compiler "$LOCAL_PATH"
-  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP"
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP" "$SHOULD_ZIP"
 else
   if $SHOULD_READ_TIER; then
     read_tier_from_tier_md "$TIER_MD"
@@ -225,5 +230,5 @@ else
     download_and_unzip_kmcomp "$REQUIRED_VERSION" "$REQUIRED_TIER"
   fi
 
-  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP"
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP" "$SHOULD_ZIP"
 fi

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+function display_usage {
+  echo "Builds regression-oriented version of all release and experimental keyboards"
+  echo "and puts all built files into output/<version>/. By default, this script"
+  echo "builds only .kmx and .js"
+  echo
+  echo "Note: all build modes overwrite existing tools/kmcomp/ except Default build mode."
+
+  echo "Build modes:"
+  echo "  regression.sh"
+  echo "     Default build mode."
+  echo "     Builds with current version of kmcomp already in tools/kmcomp/"
+  echo
+  echo "  regression.sh --local-search path"
+  echo "     Searches for the first kmcomp-<version>.zip in path and uses that"
+  echo "     (Used by Developer test build in CI)"
+  echo
+  echo "  regression.sh --local, -l kmcomp.zip"
+  echo "     Extracts the compiler from specified kmcomp.zip and uses that"
+  echo
+  echo "  regression.sh --download-for-tier TIER.md"
+  echo "     Uses --download semantics, reading tier from TIER.md"
+  echo "     (Used by Developer test build in CI)"
+  echo
+  echo "  regression.sh --download, -d [version][-tier]"
+  echo "     Downloads the specified version of kmcomp from keyman.com; "
+  echo "     <version>, if specified, should be a version number such as 14.0.294."
+  echo "     <tier>, if specified, should be 'alpha', 'beta', or 'stable'. Defaults to 'stable'."
+  echo "     If <version> is omitted, downloads the latest version of kmcomp in <tier>."
+  echo
+  echo "General flags:"
+  echo "  --packages, -p    Build .kmp packages as well as .kmx / .js"
+  echo "  --decomp, -D      Decompile .kmx into .kmn in output after build"
+  echo "  --help, -h        Show this help"
+  exit 0
+}
+
+KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+. "$KEYBOARDROOT/resources/util.sh"
+. "$KEYBOARDROOT/resources/environment.sh"
+. "$KEYBOARDROOT/resources/download-compiler.sh"
+. "$KEYBOARDROOT/resources/regression-build.sh"
+
+util_set_log_color_mode -no-color
+
+locate_kmcomp
+
+function parse_args {
+  SHOULD_BUILD_PACKAGES=false
+  SHOULD_EXTRACT_LOCAL=false
+  SHOULD_SEARCH_LOCAL=false
+  SHOULD_DOWNLOAD=false
+  SHOULD_READ_TIER=false
+  SHOULD_DECOMP=false
+  LOCAL_PATH=
+  REQUIRED_VERSION=
+  REQUIRED_TIER=stable
+
+  local lastkey=
+  local key
+
+  # Parse args
+  for key in "$@"; do
+    if [[ -z "$lastkey" ]]; then
+      case "$key" in
+        --packages|-p)
+          SHOULD_BUILD_PACKAGES=true
+          ;;
+        --decomp|-D)
+          SHOULD_DECOMP=true
+          ;;
+        --download|-d)
+          SHOULD_DOWNLOAD=true
+          lastkey="$key"
+          ;;
+        --download-for-tier)
+          SHOULD_DOWNLOAD=true
+          SHOULD_READ_TIER=true
+          lastkey="$key"
+          ;;
+        --local|-l)
+          SHOULD_EXTRACT_LOCAL=true
+          lastkey="$key"
+          ;;
+        --local-search)
+          SHOULD_EXTRACT_LOCAL=true
+          SHOULD_SEARCH_LOCAL=true
+          lastkey="$key"
+          ;;
+        --help|-h)
+          display_usage
+          exit 0
+          ;;
+        *)
+          echo "Invalid parameter"
+          echo
+          display_usage
+          exit 1
+      esac
+    else
+      case "$lastkey" in
+        --local)
+          LOCAL_PATH="$key"
+          ;;
+        --local-search)
+          LOCAL_PATH="$key"
+          ;;
+        --download-for-tier)
+          TIER_MD="$key"
+          ;;
+        --download)
+          REQUIRED_VERSION=$(echo "$key" | cut -d- -f 1 -)
+          if [[ "$2" == *"-"* ]]; then
+            REQUIRED_TIER=$(echo "$key" | cut -d- -f 2 -)
+          fi
+          ;;
+      esac
+      lastkey=
+    fi
+  done
+}
+
+
+#
+# Validate args
+#
+
+parse_args "$@"
+
+if $SHOULD_EXTRACT_LOCAL; then
+  if [ -z "$LOCAL_PATH" ]; then
+    die "--local: path must be specified"
+  fi
+fi
+
+if $SHOULD_READ_TIER; then
+  if [ -z "$TIER_MD" ]; then
+    die "--download-for-tier: TIER.md path must be specified"
+  fi
+fi
+
+echo "Parameters:
+  SHOULD_BUILD_PACKAGES: $SHOULD_BUILD_PACKAGES
+  SHOULD_SEARCH_LOCAL:   $SHOULD_SEARCH_LOCAL
+  SHOULD_EXTRACT_LOCAL:  $SHOULD_EXTRACT_LOCAL
+  SHOULD_DOWNLOAD:       $SHOULD_DOWNLOAD
+  SHOULD_READ_TIER:      $SHOULD_READ_TIER
+  SHOULD_DECOMP:         $SHOULD_DECOMP
+  LOCAL_PATH:            $LOCAL_PATH
+  REQUIRED_VERSION:      $REQUIRED_VERSION
+  REQUIRED_TIER:         $REQUIRED_TIER
+"
+
+#
+# Get the most recent build for $TIER from downloads.keyman.com
+#
+function get_developer_remote_version {
+  local TIER="$1"
+  local JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+
+  local DOWNLOADS_VERSION_API=https://downloads.keyman.com/api/version/developer
+  local REMOTE_DEVELOPER_VERSIONS=`curl -s $DOWNLOADS_VERSION_API`
+  REQUIRED_VERSION=`echo $REMOTE_DEVELOPER_VERSIONS | $JQ -r ".developer.$TIER"`
+  echo "Latest downloadable version of kmcomp.zip for $TIER is $REQUIRED_VERSION"
+}
+
+#
+# We'll now get kmcomp.exe and friends from the built kmcomp-$version.zip.
+#
+function extract_local_compiler {
+  local SOURCE="$1"
+  if [ ! -f "$SOURCE" ]; then
+    die "Source zip $SOURCE not found"
+  fi
+
+  local TARGET="$KEYBOARDROOT/tools/kmcomp"
+  rm -rf "$TARGET"
+  mkdir -p "$TARGET"
+  unzip -o "$SOURCE" -d "$TARGET/" || die "Unable to unzip $SOURCE"
+}
+
+#
+# Locate the first kmcomp-<version>.zip in $LOCAL_PATH and update the variable
+#
+function find_local_compiler {
+  local COMPILERS=("$LOCAL_PATH"/*/kmcomp-*.zip)
+  if [ ${#COMPILERS[@]} -eq 0 ]; then
+    die "No kmcomp-<version>.zip found in immediate subdirectories of $LOCAL_PATH"
+  fi
+  LOCAL_PATH="${COMPILERS[0]}"
+  echo "Found local compiler at $LOCAL_PATH"
+}
+
+#
+# Extract tier from TIER.md
+#
+function read_tier_from_tier_md {
+  REQUIRED_TIER=`cat "$TIER_MD"` || die "Could not read $TIER_MD"
+}
+
+#------------------------------------------------------------------------------
+# main
+#------------------------------------------------------------------------------
+if $SHOULD_EXTRACT_LOCAL; then
+  if $SHOULD_SEARCH_LOCAL; then
+    find_local_compiler
+  fi
+  extract_local_compiler "$LOCAL_PATH"
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP"
+else
+  if $SHOULD_READ_TIER; then
+    read_tier_from_tier_md "$TIER_MD"
+  fi
+
+  if $SHOULD_DOWNLOAD; then
+    if [ -z "$REQUIRED_VERSION" ]; then
+      echo "Finding latest version of Keyman Developer for $REQUIRED_TIER"
+      get_developer_remote_version "$REQUIRED_TIER"
+    fi
+    download_and_unzip_kmcomp "$REQUIRED_VERSION" "$REQUIRED_TIER"
+  fi
+
+  regression_build "$SHOULD_BUILD_PACKAGES" "$SHOULD_DECOMP"
+fi

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -181,7 +181,7 @@ function extract_local_compiler {
   local TARGET="$KEYBOARDROOT/tools/kmcomp"
   rm -rf "$TARGET"
   mkdir -p "$TARGET"
-  unzip -o "$SOURCE" -d "$TARGET/" || die "Unable to unzip $SOURCE"
+  unzip -q -o "$SOURCE" -d "$TARGET/" || die "Unable to unzip $SOURCE"
 }
 
 #


### PR DESCRIPTION
This is part of a larger set of PRs coming which will automate the build of keyboards during the Keyman Developer build.

Adds scripts to do a full build of .kmx and .js files with a specific version of the compiler. Puts results into `output/<version>/` so that we can easily run diff scripts against different versions.

Will first be used in the Keyman Developer CI build, which will download latest version of compiler in the same tier, as well as using the build within the Keyman Developer `developer/release/<version>` folder, which should make for reasonably straightforward comparisons.

If the kmcomp.zip archive includes kmdecomp.exe, the script can also decompile the .kmx keyboards back to .kmn, again in the `output/<version>/` folder, so that we can do textual comparisons of the results.