### PR TITLE
add font ref to .keyboard.info

### DIFF
--- a/release/sil/sil_jarai/sil_jarai.keyboard_info
+++ b/release/sil/sil_jarai/sil_jarai.keyboard_info
@@ -1,7 +1,12 @@
 {
-    "license": "mit",
-    "languages": [
-        "jra-Khmr"
-    ],
-	  "description": "Jarai ចារាយ (SIL) keyboard is for typing Jarai language using Khmer script. The keyboard layouts for desktop and touch devices are adapted from Khmer NiDA keyboard."
+	"license": "mit",
+	"languages": {
+		"jra-Khmr": {
+			"font": {
+				"family": "Khmer Busra Kbd",
+				"source": ["khmer_busra_kbd.ttf"]
+			}
+		}
+	},
+	"description": "Jarai ចារាយ (SIL) keyboard is for typing Jarai language using Khmer script. The keyboard layouts for desktop and touch devices are adapted from Khmer NiDA keyboard."
 }


### PR DESCRIPTION
The .keyboard.info file requires a font reference for the OSK presented in the sil_jarai's help page to be shown correctly without any dotted circles.

It's to resolve this issue.
![image](https://user-images.githubusercontent.com/28331388/181146742-5c049fef-044e-48e0-aac8-116df2aaf83c.png)
