### PR TITLE
[pid_piaroa] add ü̧/Ü̧ to keyboard

### DIFF
--- a/release/p/pid_piaroa/HISTORY.md
+++ b/release/p/pid_piaroa/HISTORY.md
@@ -4,6 +4,7 @@ Piaroa Change History
 1.2.0 (2022-08-08)
 ----------------
 * Add <kbd>ü̧</kbd> and <kbd>Ü̧</kbd>
+* Add <kbd>ñ</kbd> and <kbd>Ñ</kbd>
 
 1.1.1 (2019-09-10)
 ----------------

--- a/release/p/pid_piaroa/HISTORY.md
+++ b/release/p/pid_piaroa/HISTORY.md
@@ -1,6 +1,10 @@
 Piaroa Change History
 ====================
 
+1.2.0 (2022-08-08)
+----------------
+* Add <kbd>ü̧</kbd> and <kbd>Ü̧</kbd>
+
 1.1.1 (2019-09-10)
 ----------------
 * Prepare for inclusion in keymanapp/keyboards repository.

--- a/release/p/pid_piaroa/LICENSE.md
+++ b/release/p/pid_piaroa/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2019 Eddie Antonio Santos
+© 2019-2022 Eddie Antonio Santos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/p/pid_piaroa/README.md
+++ b/release/p/pid_piaroa/README.md
@@ -24,7 +24,11 @@ To type **ä**, press <kbd>Right Alt</kbd>+<kbd>a</kbd>
 
 To type **ö**, press <kbd>Right Alt</kbd>+<kbd>o</kbd>
 
+To type **ü**, press <kbd>Right Alt</kbd>+<kbd>u</kbd>
+
 To type a nasal vowel (a̧/ä̧/ȩ/i̧/o̧/ö̧/u̧/ü̧), type the vowel (a/ä/e/i/o/ö/u/ü), and then press <kbd>Right Alt</kbd>+<kbd>,</kbd>.
+
+To type **ñ**, press <kbd>Right Alt</kbd>+<kbd>n</kbd>
 
 Links
 -----

--- a/release/p/pid_piaroa/README.md
+++ b/release/p/pid_piaroa/README.md
@@ -1,9 +1,9 @@
 Piaroa keyboard
 ===============
 
-© 2019 Eddie Antonio Santos
+© 2022 Eddie Antonio Santos
 
-Version 1.1.1
+Version 1.2.0
 
 Description
 -----------
@@ -24,18 +24,12 @@ To type **ä**, press <kbd>Right Alt</kbd>+<kbd>a</kbd>
 
 To type **ö**, press <kbd>Right Alt</kbd>+<kbd>o</kbd>
 
-To type a nasal vowel (a̧/ä̧/ȩ/i̧/o̧/ö̧/u̧), type the vowel (a/ä/e/i/o/ö/u), and then press <kbd>Right Alt</kbd>+<kbd>,</kbd>.
+To type a nasal vowel (a̧/ä̧/ȩ/i̧/o̧/ö̧/u̧/ü̧), type the vowel (a/ä/e/i/o/ö/u/ü), and then press <kbd>Right Alt</kbd>+<kbd>,</kbd>.
 
 Links
 -----
 
  - [Jorge Emilio Rosés Labrada](https://sites.google.com/ualberta.ca/jrosesla/)
-
-
-TODO
-----
-
- - fix minor Spanish typos in `welcome.htm`
 
 Supported Platforms
 -------------------

--- a/release/p/pid_piaroa/pid_piaroa.kpj
+++ b/release/p/pid_piaroa/pid_piaroa.kpj
@@ -51,11 +51,11 @@
       <ID>id_91d1342ebc3981e6399d8cba8e44e18c</ID>
       <Filename>pid_piaroa.kmn</Filename>
       <Filepath>source\pid_piaroa.kmn</Filepath>
-      <FileVersion>1.1.1</FileVersion>
+      <FileVersion>1.2.0</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Piaroa</Name>
-        <Copyright>© 2019 Eddie Antonio Santos</Copyright>
+        <Copyright>© 2022 Eddie Antonio Santos</Copyright>
         <Message>Piaroa keyboard/teclado piaroa. Uses RightAlt+a/o to type ä/ö and RightAlt+, to type a̧. Utiliza la Alt derecha para escribir la ä/ö/a̧.</Message>
       </Details>
     </File>

--- a/release/p/pid_piaroa/source/help/pid_piaroa.php
+++ b/release/p/pid_piaroa/source/help/pid_piaroa.php
@@ -40,6 +40,8 @@
     <tr> <td>ä&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ü&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ñ</td> <td> <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
+    <tr> <td>Ñ</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>N</kbd></td> </tr>
   </tbody>
 </table>
 
@@ -92,6 +94,8 @@ funcionará!</em></p>
     <tr> <td>ä&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ü&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ñ</td> <td> <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
+    <tr> <td>Ñ</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
   </tbody>
 </table>
 
@@ -102,7 +106,7 @@ funcionará!</em></p>
 <hr>
 
 <h1>Change History</h1>
-<p>1.2.0: Add ü̧ and Ü̧.</p>
+<p>1.2.0: Add ü̧/Ü̧ and ñ/Ñ</p>
 <p>1.1.1: Prepare for inclusion in Keyman Keyboards repository.</p>
 <p>1.1.0: Prevent inserting extraneous cedillas.</p>
 <p>1.0.0: Initial release.</p>

--- a/release/p/pid_piaroa/source/help/pid_piaroa.php
+++ b/release/p/pid_piaroa/source/help/pid_piaroa.php
@@ -5,7 +5,7 @@
 ?>
 
 <nav>
-  <p lang="es"> <a href="#pid_piaroa-es">Lee este documento en español.</a> </p> 
+  <p lang="es"> <a href="#pid_piaroa-es">Lee este documento en español.</a> </p>
 </nav>
 
 <a id="pid_piaroa-en"></a>
@@ -14,7 +14,7 @@
 
 <h1>Fonts</h1>
 
-<p>There is no special font required to render Piaroa text, however, some fonts and applications struggle to render the combining cedilla (<span style="font-family: Calibri, Helvetica Neue">&nbsp;&#x0327;</span>) underneath the vowel.  On Windows, Calibri renders this correctly (<span style="font-family: Calibri">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧</span>); on macOS, Helvetica Neue renders these characters correctly (<span style="font-family: Helvetica Neue">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧</span>).</p>
+<p>There is no special font required to render Piaroa text, however, some fonts and applications struggle to render the combining cedilla (<span style="font-family: Calibri, Helvetica Neue">&nbsp;&#x0327;</span>) underneath the vowel.  On Windows, Calibri renders this correctly (<span style="font-family: Calibri">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧, ü̧</span>); on macOS, Helvetica Neue renders these characters correctly (<span style="font-family: Helvetica Neue">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧, ü̧</span>).</p>
 
 <h1>Characters</h1>
 
@@ -28,8 +28,10 @@
   <tbody>
     <tr> <td>ä</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>ö</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>ü</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>Ä</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>Ö</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>Ü</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>a&#x327;</td> <td> <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>e&#x327;</td> <td> <kbd>E</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>i&#x327;</td> <td> <kbd>I</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
@@ -37,6 +39,7 @@
     <tr> <td>u&#x327;</td> <td> <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ä&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ü&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
   </tbody>
 </table>
 
@@ -58,7 +61,7 @@ funcionará!</em></p>
 
 <h1 lang="es">Fuentes</h1>
 
-<p lang="es">Piaroa no requiere una fuente especial. Sin embargo, algunas fuentes no son capaces de renderizar la cedilla (<span style="font-family: Calibri, Helvetica Neue">&nbsp;&#x0327;</span>) debajo de vocales.  En sistemas Windows, la fuente Calibri renderiza la cedilla correctamente (<span style="font-family: Calibri">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧</span>); en sistemas macOS, la fuente Helvetica Neue renderiza la cedilla correctamente (<span style="font-family: Helvetica Neue">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧</span>).</p>
+<p lang="es">Piaroa no requiere una fuente especial. Sin embargo, algunas fuentes no son capaces de renderizar la cedilla (<span style="font-family: Calibri, Helvetica Neue">&nbsp;&#x0327;</span>) debajo de vocales.  En sistemas Windows, la fuente Calibri renderiza la cedilla correctamente (<span style="font-family: Calibri">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧, ü̧</span>); en sistemas macOS, la fuente Helvetica Neue renderiza la cedilla correctamente (<span style="font-family: Helvetica Neue">a̧, ä̧, ȩ, i̧, o̧, ö̧, u̧, ü̧</span>).</p>
 
 <aside>
   <p>Anteriormente, era necesario usar la fuente piaroa SILSophia, pero esta
@@ -77,8 +80,10 @@ funcionará!</em></p>
   <tbody>
     <tr> <td>ä</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>ö</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>ü</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>Ä</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>Ö</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>Ü</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>a&#x327;</td> <td> <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>e&#x327;</td> <td> <kbd>E</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>i&#x327;</td> <td> <kbd>I</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
@@ -86,6 +91,7 @@ funcionará!</em></p>
     <tr> <td>u&#x327;</td> <td> <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ä&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ü&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
   </tbody>
 </table>
 
@@ -96,8 +102,9 @@ funcionará!</em></p>
 <hr>
 
 <h1>Change History</h1>
+<p>1.2.0: Add ü̧ and Ü̧.</p>
 <p>1.1.1: Prepare for inclusion in Keyman Keyboards repository.</p>
 <p>1.1.0: Prevent inserting extraneous cedillas.</p>
 <p>1.0.0: Initial release.</p>
 
-<p>&copy; 2019 Eddie Antonio Santos</p>
+<p>&copy; 2022 Eddie Antonio Santos</p>

--- a/release/p/pid_piaroa/source/pid_piaroa.kmn
+++ b/release/p/pid_piaroa/source/pid_piaroa.kmn
@@ -1,12 +1,12 @@
 ﻿store(&VERSION) '9.0'
 store(&TARGETS) 'desktop'
 store(&NAME) 'Piaroa'
-store(&COPYRIGHT) '© 2019 Eddie Antonio Santos'
-store(&KEYBOARDVERSION) '1.1.1'
+store(&COPYRIGHT) '© 2022 Eddie Antonio Santos'
+store(&KEYBOARDVERSION) '1.2.0'
 store(&ETHNOLOGUECODE) 'pid'
-store(&MESSAGE) 'Piaroa keyboard/teclado piaroa. Uses RightAlt+a/o to type ä/ö and RightAlt+, to type a̧. Utiliza la Alt derecha para escribir la ä/ö/a̧.'
+store(&MESSAGE) 'Piaroa keyboard/teclado piaroa. Uses RightAlt+a/o/u to type ä/ö/ü and RightAlt+, to type a̧. Utiliza la Alt derecha para escribir la ä/ö/ü/a̧.'
 
-store(vowel) "aäeioöuAÄEIOÖU"
+store(vowel) "aäeioöuüAÄEIOÖUÜ"
 store(Cedilla) U+0327
 
 begin Unicode > use(main)
@@ -14,8 +14,10 @@ begin Unicode > use(main)
 group(main) using keys
 + [RALT K_A] > 'ä'
 + [RALT K_O] > 'ö'
-+ [SHIFT RALT K_O] > 'Ö'
++ [RALT K_U] > 'ü'
 + [SHIFT RALT K_A] > 'Ä'
++ [SHIFT RALT K_O] > 'Ö'
++ [SHIFT RALT K_U] > 'Ü'
 
 c Insert a combining cedilla only after a vowel.
 any(vowel) + [RALT K_COMMA] > index(vowel, 1) $Cedilla

--- a/release/p/pid_piaroa/source/pid_piaroa.kmn
+++ b/release/p/pid_piaroa/source/pid_piaroa.kmn
@@ -15,9 +15,11 @@ group(main) using keys
 + [RALT K_A] > 'ä'
 + [RALT K_O] > 'ö'
 + [RALT K_U] > 'ü'
++ [RALT K_N] > 'ñ'
 + [SHIFT RALT K_A] > 'Ä'
 + [SHIFT RALT K_O] > 'Ö'
 + [SHIFT RALT K_U] > 'Ü'
++ [SHIFT RALT K_N] > 'Ñ'
 
 c Insert a combining cedilla only after a vowel.
 any(vowel) + [RALT K_COMMA] > index(vowel, 1) $Cedilla

--- a/release/p/pid_piaroa/source/pid_piaroa.kps
+++ b/release/p/pid_piaroa/source/pid_piaroa.kps
@@ -17,8 +17,8 @@
   </StartMenu>
   <Info>
     <Name URL="">Piaroa</Name>
-    <Copyright URL="">© 2019 Eddie Antonio Santos</Copyright>
-    <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
+    <Copyright URL="">© 2022 Eddie Antonio Santos</Copyright>
+    <Author URL="mailto:hello@eddieantonio.ca">Eddie Antonio Santos</Author>
     <WebSite URL="https://eddieantonio.ca/">https://eddieantonio.ca/</WebSite>
   </Info>
   <Files>
@@ -45,7 +45,7 @@
     <Keyboard>
       <Name>Piaroa</Name>
       <ID>pid_piaroa</ID>
-      <Version>1.1.1</Version>
+      <Version>1.2.0</Version>
       <Languages>
         <Language ID="pid-Latn">Piaroa</Language>
       </Languages>

--- a/release/p/pid_piaroa/source/readme.htm
+++ b/release/p/pid_piaroa/source/readme.htm
@@ -41,7 +41,7 @@ selecciona el “hotkey”, luego debes cambiar el ”hotkey” o desactivarlo e
 Desde versión 1.0.0,
 “<b lang="en">Switch Keyman Desktop Off</b>” (“Desactivar Keyman Desktop”) usa Shift+Alt+O</p>
 
-<p>© 2019 Eddie Antonio Santos</p>
+<p>© 2022 Eddie Antonio Santos</p>
 
 </body>
 </html>

--- a/release/p/pid_piaroa/source/welcome.htm
+++ b/release/p/pid_piaroa/source/welcome.htm
@@ -79,6 +79,8 @@ This is the <kbd>Alt</kbd> or <kbd>⌥ Option</kbd> key to the
     <tr> <td>ä&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ü&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ñ</td> <td> <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
+    <tr> <td>Ñ</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>N</kbd></td> </tr>
   </tbody>
 </table>
 
@@ -115,6 +117,8 @@ funcionará!</em></p>
     <tr> <td>ä&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ü&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ñ</td> <td> <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
+    <tr> <td>Ñ</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>N</kbd></td> </tr>
   </tbody>
 </table>
 

--- a/release/p/pid_piaroa/source/welcome.htm
+++ b/release/p/pid_piaroa/source/welcome.htm
@@ -67,8 +67,10 @@ This is the <kbd>Alt</kbd> or <kbd>⌥ Option</kbd> key to the
   <tbody>
     <tr> <td>ä</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>ö</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>ü</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>Ä</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>Ö</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>Ü</td> <td> <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>a&#x327;</td> <td> <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>e&#x327;</td> <td> <kbd>E</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>i&#x327;</td> <td> <kbd>I</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
@@ -76,10 +78,11 @@ This is the <kbd>Alt</kbd> or <kbd>⌥ Option</kbd> key to the
     <tr> <td>u&#x327;</td> <td> <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ä&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>A</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>O</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ü&#x327;</td> <td> <kbd>AltGr</kbd> + <kbd>U</kbd>, then <kbd>AltGr</kbd> + <kbd>,</kbd> </td> </tr>
   </tbody>
 </table>
 
-<p class="copyright">© 2019 Eddie Antonio Santos</p>
+<p class="copyright">© 2022 Eddie Antonio Santos</p>
 
 <hr>
 
@@ -100,8 +103,10 @@ funcionará!</em></p>
   <tbody>
     <tr> <td>ä</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>ö</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>ü</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>Ä</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>A</kbd></td> </tr>
     <tr> <td>Ö</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>O</kbd></td> </tr>
+    <tr> <td>Ü</td> <td> <kbd>⇧ Mayús</kbd> + <kbd>Alt Gr</kbd> + <kbd>U</kbd></td> </tr>
     <tr> <td>a&#x327;</td> <td> <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>e&#x327;</td> <td> <kbd>E</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>i&#x327;</td> <td> <kbd>I</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
@@ -109,10 +114,11 @@ funcionará!</em></p>
     <tr> <td>u&#x327;</td> <td> <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ä&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>A</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
     <tr> <td>ö&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>O</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
+    <tr> <td>ü&#x327;</td> <td> <kbd>Alt Gr</kbd> + <kbd>U</kbd>, luego <kbd>Alt Gr</kbd> + <kbd>,</kbd> </td> </tr>
   </tbody>
 </table>
 
-<p lang="es" class="copyright">© 2019 Eddie Antonio Santos</p>
+<p lang="es" class="copyright">© 2022 Eddie Antonio Santos</p>
 
 </body>
 </html>


### PR DESCRIPTION
This updates the Piaroa keyboard to be able to type ü̧ and Ü̧  — a convention used by at least one community in Colombia.

To type ü̧, press <kbd>AltGr</kbd> + <kbd>u</kbd>, then press <kbd>AltGr</kbd> + <kbd>,</kbd>.

**NOTE**: I do not currently have access to a machine with Windows, so **I did not use Keyman Developer**, and was unable to test on Windows; I developed on my Mac, and used wine to run `kmcomp.x64.exe` to build and test the keyboard. I observed that I **could not use `[RALT]`** on my UK/Ireland Macbook keyboard, so while testing, I used ordinary `[ALT]`, then switched to `[RALT]` when committing the files.

Please let me know if I've missed anything!

**EDIT**: I have also added ñ/Ñ, also based on community requests!