### PR TITLE
[armenian_mnemonic] Fixed Options rendering in Linux

### DIFF
--- a/release/a/armenian_mnemonic/armenian_mnemonic.kpj
+++ b/release/a/armenian_mnemonic/armenian_mnemonic.kpj
@@ -12,7 +12,7 @@
       <ID>id_e000625f18b7bd2e11317f4b181543cb</ID>
       <Filename>armenian_mnemonic.kmn</Filename>
       <Filepath>source\armenian_mnemonic.kmn</Filepath>
-      <FileVersion>1.1.7</FileVersion>
+      <FileVersion>1.1.8</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Armenian Mnemonic</Name>

--- a/release/a/armenian_mnemonic/source/armenian_mnemonic.kmn
+++ b/release/a/armenian_mnemonic/source/armenian_mnemonic.kmn
@@ -3,7 +3,7 @@ c with name "Armenian Mnemonic"
 store(&VERSION) '14.0'
 store(&NAME) 'Armenian Mnemonic'
 store(&COPYRIGHT) '© Dotland'
-store(&KEYBOARDVERSION) '1.1.7'
+store(&KEYBOARDVERSION) '1.1.8'
 store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'armenian_mnemonic.keyman-touch-layout'
 store(&BITMAP) 'armenian_mnemonic.ico'

--- a/release/a/armenian_mnemonic/source/options.htm
+++ b/release/a/armenian_mnemonic/source/options.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id='size'>
-  <h3>«Armenian Mnemonic» ստեղնաշարի կարգավորումները</h1>
+  <h3>«Armenian Mnemonic» ստեղնաշարի կարգավորումները</h3>
   <form method='get' action='keyman:ok'>
     <div id='formopt'>
 	<fieldset>
@@ -35,6 +35,7 @@
 </div>
 
   <script type='text/javascript'>
+  //<![CDATA[
     (function() {
       var loc = window.location.search.substr(1).split('&');
       for(var i = 0; i < loc.length; i++)
@@ -55,6 +56,7 @@
         }
       }
     })();
+  //]]>
   </script>
 
 </body>


### PR DESCRIPTION
In Linux Mint 21 the **Options** screen of the *Armenian Mnemonic* keyboard failed to render because of an incorrect tag pair and escaping ampersand symbol in the `<script>` tag.