### PR TITLE
[armenian_mnemonic_r] Fixed Options rendering in Linux

### DIFF
--- a/release/a/armenian_mnemonic_r/armenian_mnemonic_r.kpj
+++ b/release/a/armenian_mnemonic_r/armenian_mnemonic_r.kpj
@@ -12,7 +12,7 @@
       <ID>id_9bcacb4fedc34c8563250a782e57f0b3</ID>
       <Filename>armenian_mnemonic_r.kmn</Filename>
       <Filepath>source\armenian_mnemonic_r.kmn</Filepath>
-      <FileVersion>1.0.7</FileVersion>
+      <FileVersion>1.0.8</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Armenian Mnemonic R</Name>

--- a/release/a/armenian_mnemonic_r/source/armenian_mnemonic_r.kmn
+++ b/release/a/armenian_mnemonic_r/source/armenian_mnemonic_r.kmn
@@ -3,7 +3,7 @@ c with name "Armenian Mnemonic R"
 store(&VERSION) '14.0'
 store(&NAME) 'Armenian Mnemonic R'
 store(&COPYRIGHT) '© Dotland'
-store(&KEYBOARDVERSION) '1.0.7'
+store(&KEYBOARDVERSION) '1.0.8'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'armenian_mnemonic_r.kvks'
 store(&LAYOUTFILE) 'armenian_mnemonic_r.keyman-touch-layout'

--- a/release/a/armenian_mnemonic_r/source/options.htm
+++ b/release/a/armenian_mnemonic_r/source/options.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id='size'>
-  <h3>«Armenian Mnemonic R» ստեղնաշարի կարգավորումները</h1>
+  <h3>«Armenian Mnemonic R» ստեղնաշարի կարգավորումները</h3>
   <form method='get' action='keyman:ok'>
     <div id='formopt'>
 	<fieldset>
@@ -35,6 +35,7 @@
 </div>
 
   <script type='text/javascript'>
+  //<![CDATA[
     (function() {
       var loc = window.location.search.substr(1).split('&');
       for(var i = 0; i < loc.length; i++)
@@ -55,6 +56,7 @@
         }
       }
     })();
+  //]]>
   </script>
 
 </body>


### PR DESCRIPTION
In Linux Mint 21 the **Options** screen of the *Armenian Mnemonic R* keyboard failed to render because of an incorrect tag pair and escaping ampersand symbol in the `<script>` tag.