### PR TITLE
[karakalpak] Fix some of the wrong key bindings in touch keyboard's numeric layout

### DIFF
--- a/release/k/karakalpak_cyrillic/HISTORY.md
+++ b/release/k/karakalpak_cyrillic/HISTORY.md
@@ -1,5 +1,9 @@
 # Karakalpak Cyrillic Change History
 
+## 0.2 (2022-10-04)
+
+- Fix some of the wrong key bindings in touch keyboard's numeric layout
+
 ## 0.1 (2022-09-23)
 
 - Created by Shaǵala Lab

--- a/release/k/karakalpak_cyrillic/README.md
+++ b/release/k/karakalpak_cyrillic/README.md
@@ -1,6 +1,6 @@
 # Karakalpak Cyrillic keyboard
 
-Version 0.1
+Version 0.2
 
 ## Description
 

--- a/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.keyman-touch-layout
+++ b/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.keyman-touch-layout
@@ -588,14 +588,13 @@
             "id": 3,
             "key": [
               {
-                "id": "K_BKQUOTE",
+                "id": "U_0060",
                 "text": "`",
                 "pad": ""
               },
               {
-                "id": "K_BKQUOTE",
-                "text": "~",
-                "layer": "shift"
+                "id": "U_007E",
+                "text": "~"
               },
               {
                 "id": "U_005B",
@@ -617,7 +616,7 @@
                 ]
               },
               {
-                "id": "K_RBRKT",
+                "id": "U_005D",
                 "text": "]",
                 "sk": [
                   {
@@ -629,9 +628,8 @@
                     "text": ">"
                   },
                   {
-                    "id": "K_RBRKT",
-                    "text": "}",
-                    "layer": "shift"
+                    "id": "U_007D",
+                    "text": "}"
                   }
                 ]
               },
@@ -687,12 +685,11 @@
                 "layer": "default"
               },
               {
-                "id": "K_SLASH",
-                "text": "?",
-                "layer": "shift"
+                "id": "U_003F",
+                "text": "?"
               },
               {
-                "id": "K_SLASH",
+                "id": "U_002F",
                 "text": "/"
               },
               {

--- a/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.kmn
+++ b/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.kmn
@@ -3,7 +3,7 @@ c with name "Karakalpak Cyrillic"
 store(&VERSION) '10.0'
 store(&NAME) 'Karakalpak Cyrillic'
 store(&COPYRIGHT) '© Shaǵala Lab'
-store(&KEYBOARDVERSION) '0.1'
+store(&KEYBOARDVERSION) '0.2'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'karakalpak_cyrillic.kvks'
 store(&LAYOUTFILE) 'karakalpak_cyrillic.keyman-touch-layout'

--- a/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.kps
+++ b/release/k/karakalpak_cyrillic/source/karakalpak_cyrillic.kps
@@ -87,7 +87,7 @@
     <Keyboard>
       <Name>Karakalpak Cyrillic</Name>
       <ID>karakalpak_cyrillic</ID>
-      <Version>0.1</Version>
+      <Version>0.2</Version>
       <Languages>
         <Language ID="kaa">Kara-Kalpak</Language>
       </Languages>


### PR DESCRIPTION
I just found out that touch keyboard's numeric layout had wrong key bindings in some of the symbols. To be precise:
- typing `}` produces `Ъ`
- `~` -> `Ё`
- `[backquote symbol]` -> `ё`
- `?` -> `,`
- `/` -> `.`
- `]` -> `ъ`

All the wrong bindings have been fixed in this PR.