### PR TITLE
chore: Remove extraneous begin statements

### DIFF
--- a/release/k/karakalpak_latin/source/karakalpak_latin.kmn
+++ b/release/k/karakalpak_latin/source/karakalpak_latin.kmn
@@ -8,8 +8,6 @@ store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'karakalpak_latin.kvks'
 store(&LAYOUTFILE) 'karakalpak_latin.keyman-touch-layout'
 
-begin Unicode > use(main)
-
 c Note three entry points, rather than the traditional single entry point
 
 begin Unicode > use(main)

--- a/release/rac/rac_torwali/source/rac_torwali.kmn
+++ b/release/rac/rac_torwali/source/rac_torwali.kmn
@@ -15,8 +15,6 @@ store(&LAYOUTFILE) 'rac_torwali.keyman-touch-layout'
 store(&KMW_RTL) '1'
 store(&ETHNOLOGUECODE) 'trw'
 store(&KMW_HELPTEXT) 'https://help.keyman.com/keyboard/rac_torwali/1.0/rac_torwali.php'
-begin Unicode > use(main)
-
 
 begin Unicode > use(main)
 

--- a/release/sil/sil_yi/source/sil_yi.kmn
+++ b/release/sil/sil_yi/source/sil_yi.kmn
@@ -15,10 +15,6 @@ store(&KEYBOARDVERSION) '1.3.1'
 store(&VISUALKEYBOARD) 'sil_yi.kvks'
 store(&LAYOUTFILE) 'sil_yi.keyman-touch-layout'
 
-begin Unicode > use(main)
-
-group(main) using keys
-
 begin Unicode > use(Unicode Group)
 
 store(nul) "ABCDEFGHIJKLMNOPQRSTUVWXYZ@$^&" '"'


### PR DESCRIPTION
From keymanapp/keyman#7583, the upcoming kmcomp 16.0 will flag keyboards that have duplicated `begin` statements.

No functional changes so I'm not bumping any keyboard versions.