### PR TITLE
GFF Harege Fidelat & Mesobe Fidelat Adjustments for Keyman Web

### DIFF
--- a/release/gff/gff_harege_fidelat/gff_harege_fidelat.keyboard_info
+++ b/release/gff/gff_harege_fidelat/gff_harege_fidelat.keyboard_info
@@ -26,5 +26,10 @@
     "xan",
     "jnj",
     "zwa"
-  ]
+  ],
+  "platformSupport": {
+    "ios": "basic",
+    "android": "basic",
+    "mobileWeb": "basic"
+  }
 }

--- a/release/gff/gff_harege_fidelat/source/help/gff_harege_fidelat.php
+++ b/release/gff/gff_harege_fidelat/source/help/gff_harege_fidelat.php
@@ -120,7 +120,7 @@ The Harege Fidelat tablet layout is identical to the mobile phone layout.
 
 <div id="Troubleshooting">
 <h2>Troubleshooting</h2>
-<p class='keymanweb'>It is expected some of the newer letters introduced for the Gurage language will not appear on screen when using
+<p class='keymanweb' style="text-align: justify;">It is expected some of the newer letters introduced for the Gurage language will not appear on screen when using
 Keyman with other apps, such as for text messaging.  This will be resolved in the near future when companies like Apple and Samsung update
 their products.</p>
 
@@ -158,7 +158,8 @@ their products.</p>
 <div id="Technical">
 <h2>Technical Information</h2>
 <h3>System Requirements</h3>
-<p>Due to the keyboard's width it is ideally suited for tablet devices but is also suitable for larger mobile phones.
+<p style="text-align: justify;">
+Due to the keyboard's width it is ideally suited for tablet devices but is also suitable for larger mobile phones.
 </p>
 <h3>Unicode Version</h3>
 <p>This keyboard complies with Unicode 14</p>
@@ -175,14 +176,14 @@ their products.</p>
 
 <div id="Author">
 <h3>Keyboard Authorship</h3>
-<p>
+<p style="text-align: justify;">
 This keyboard was created by the Geʾez Frontier Foundation.  SIL International graciously acknowledges the contribution made by the authors in developing this keyboard and making it freely available for use with Keyman Mobile. Their effort assists in enabling people to communicate in their own language.
 </p>
 </div>
 
 <div id="Copyright">
 <h3>Copyright and Terms of Use</h3>
-<p>
+<p style="text-align: justify;">
 The Harege Fidelat keyboard layout for Keyman Mobile is Copyright 2022 Geʾez Frontier Foundation and SIL International.  It may be freely distributed and used under the terms of <a href="https://opensource.org/licenses/MIT">The MIT License</a>.
 </p>
 </div>

--- a/release/gff/gff_mesobe_fidelat/gff_mesobe_fidelat.keyboard_info
+++ b/release/gff/gff_mesobe_fidelat/gff_mesobe_fidelat.keyboard_info
@@ -26,5 +26,10 @@
     "xan",
     "jnj",
     "zwa"
-  ]
+  ],
+  "platformSupport": {
+    "ios": "basic",
+    "android": "basic",
+    "mobileWeb": "basic"
+  }
 }

--- a/release/gff/gff_mesobe_fidelat/source/help/gff_mesobe_fidelat.php
+++ b/release/gff/gff_mesobe_fidelat/source/help/gff_mesobe_fidelat.php
@@ -136,7 +136,6 @@ Simply tap the <code>ሀለሐ</code> key to return to the Mesob letters layers.
 
 <div id="TabletLayout">
 <h2>Tablet Layout &amp; Layers</h2>
-
 <p style="text-align: justify;">
 The Mesob tablet layout is <em>identical</em> to the mobile phone layout with the exception that a single punctuation layer is used. The single takes advantage of the greater screen space available.  The larger punctuation layer is shown in the following image:
 </p>
@@ -147,7 +146,7 @@ The Mesob tablet layout is <em>identical</em> to the mobile phone layout with th
 
 <div id="Troubleshooting">
 <h2>Troubleshooting</h2>
-<p class='keymanweb'>It is expected some of the newer letters introduced for the Gurage language will not appear on screen when using
+<p class='keymanweb' style="text-align: justify;">It is expected some of the newer letters introduced for the Gurage language will not appear on screen when using
 Keyman with other apps, such as for text messaging.  This will be resolved in the near future when companies like Apple and Samsung update
 their products.</p>
 
@@ -185,7 +184,8 @@ their products.</p>
 <div id="Technical">
 <h2>Technical Information</h2>
 <h3>System Requirements</h3>
-<p>Due to the keyboard's width it is ideally suited for tablet devices but is also suitable for larger mobile phones.
+<p style="text-align: justify;">
+Due to the keyboard's width it is ideally suited for tablet devices but is also suitable for larger mobile phones.
 </p>
 <h3>Unicode Version</h3>
 <p>This keyboard complies with Unicode 14</p>
@@ -203,13 +203,13 @@ their products.</p>
 
 <div id="Author">
 <h3>Keyboard Authorship</h3>
-<p>
+<p style="text-align: justify;">
 This keyboard was created by the Geʾez Frontier Foundation.  SIL International graciously acknowledges the contribution made by the authors in developing this keyboard and making it freely available for use with Keyman Desktop and KeymanWeb. Their effort assists in enabling people to communicate in their own language.
 </p>
 </div>
 <div id="Copyright">
 <h3>Copyright and Terms of Use</h3>
-<p>
+<p style="text-align: justify;">
 The Amharic keyboard layout for Keyman Desktop and KeymanWeb is Copyright 2022 Geʾez Frontier Foundation and SIL International.  It may be freely distributed and used under the terms of <a href="https://opensource.org/licenses/MIT">The MIT License</a>.
 </p>
 


### PR DESCRIPTION
These are updates to the `.keyboard_info` files to Harege Fidelat and Mesobe Fidelat to avoid appearing as Keyman Web options.

Paragraph justification is added to the respective `.php` help pages where it was missing.

These updates are as per the recommendations in the Keyman Community form discussions here:  https://community.software.sil.org/t/question-on-keyman-web-the-kmd-web-target/6972/1