### PR TITLE
Migration to the Noto Ethiopic Web Fonts.

### DIFF
--- a/release/gff/gff_amh_7/gff_amh_7.keyboard_info
+++ b/release/gff/gff_amh_7/gff_amh_7.keyboard_info
@@ -1,16 +1,21 @@
 {
   "name": "Amharic",
+  "description": "This is an Amharic (amh, አማርኛ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "license": "mit",
-	"description": "This is an Amharic (amh, አማርኛ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "languages": {
     "am": {
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.woff",
-          "wookianos.ttf",
-          "wookianos.mobileconfig",
-          "ETHIOPI0.eot"
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
         ]
       },
       "example": {

--- a/release/gff/gff_amharic/gff_amharic.keyboard_info
+++ b/release/gff/gff_amharic/gff_amharic.keyboard_info
@@ -1,5 +1,6 @@
 {
   "name": "Amharic",
+  "description": "This is an Amharic (amh, አማርኛ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "license": "mit",
   "languages": {
     "am": {
@@ -24,7 +25,6 @@
       }
     }
   },
-	"description": "This is an Amharic (amh, አማርኛ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "related": {
     "gff_amh_powerpack_7": {
       "deprecates": true

--- a/release/gff/gff_amharic_classic/gff_amharic_classic.keyboard_info
+++ b/release/gff/gff_amharic_classic/gff_amharic_classic.keyboard_info
@@ -1,15 +1,21 @@
 {
   "name": "Amharic Classic",
+  "description": "This is an Amharic (amh, አማርኛ) language mnemonic input method for mobile platforms based on a US-QWERTY layout.",
   "license": "mit",
   "languages": {
     "am": {
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.woff",
-          "wookianos.ttf",
-          "wookianos.mobileconfig",
-          "ETHIOPI0.eot"
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
         ]
       },
       "example": {
@@ -19,7 +25,6 @@
       }
     }
   },
-  "description": "This is an Amharic (amh, አማርኛ) language mnemonic input method for mobile platforms based on a US-QWERTY layout.",
   "related": {
     "gff_amharic": {
       "deprecates": false

--- a/release/gff/gff_blin/gff_blin.keyboard_info
+++ b/release/gff/gff_blin/gff_blin.keyboard_info
@@ -1,7 +1,23 @@
 {
+  "name": "Blin",
+  "description": "An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.",
   "license": "mit",
   "languages": {
     "byn-Ethi": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      },
       "example": {
         "keys": "blina",
         "text": "ብሊና",
@@ -9,7 +25,6 @@
       }
     }
   },
-  "description": "An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.",
   "related": {
     "gff-byn-powerpack-7": {
       "deprecates": true

--- a/release/gff/gff_geez/gff_geez.keyboard_info
+++ b/release/gff/gff_geez/gff_geez.keyboard_info
@@ -1,5 +1,4 @@
 {
-  "name": "Ge'ez",
   "description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b>  Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>",
   "license": "mit",
   "languages": {
@@ -17,7 +16,7 @@
           "NotoSansEthiopic-Regular.woff2",
           "NotoSansEthiopic-Regular.ttf"
         ]
-      },
+      }
     }
   },
   "related": {

--- a/release/gff/gff_geez/gff_geez.keyboard_info
+++ b/release/gff/gff_geez/gff_geez.keyboard_info
@@ -1,16 +1,31 @@
 {
-	"license": "mit",
-	"languages": {
-		"gez-Ethi": {
-		}
-	},
-	"description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b>  Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>",
-	"related": {
-		"gff_gez_7": {
-			"deprecates": true
-		},
-		"gff-gez-7": {
-			"deprecates": true
-		}
-	}
+  "name": "Geʾez",
+  "description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b>  Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>",
+  "license": "mit",
+  "languages": {
+    "gez-Ethi": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      },
+    }
+  },
+  "related": {
+    "gff_gez_7": {
+      "deprecates": true
+    },
+    "gff-gez-7": {
+      "deprecates": true
+    }
+  }
 }

--- a/release/gff/gff_geez/gff_geez.keyboard_info
+++ b/release/gff/gff_geez/gff_geez.keyboard_info
@@ -1,5 +1,5 @@
 {
-  "name": "Geʾez",
+  "name": "Ge'ez",
   "description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b>  Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>",
   "license": "mit",
   "languages": {

--- a/release/gff/gff_gurage/gff_gurage.keyboard_info
+++ b/release/gff/gff_gurage/gff_gurage.keyboard_info
@@ -1,11 +1,25 @@
 {
   "name": "Gurage",
+  "description": "This is a Gurage (ጉራጊና , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard. A collection of five fonts with names beginning with \"Gurage\" are included with this package.",
   "license": "mit",
   "languages": {
     "sgw-Ethi": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      }
     }
   },
-  "description": "This is a Gurage (ጉራጊና , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting the Ethiopic Extended-B block defined in the Unicode 14 standard. A collection of five fonts with names beginning with \"Gurage\" are included with this package.",
   "minKeymanVersion": "10.0",
   "related": {
     "gff_sgw_7": {

--- a/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
+++ b/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
@@ -1,5 +1,5 @@
 {
-  "name": "Gurage",
+  "name": "Gurage (Legacy)",
   "description": "This is a Gurage (ጉራጌ , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "license": "mit",
   "languages": {

--- a/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
+++ b/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
@@ -1,11 +1,25 @@
 {
   "name": "Gurage",
+  "description": "This is a Gurage (ጉራጌ , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "license": "mit",
   "languages": {
     "sgw-Ethi": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      },
     }
   },
-  "description": "This is a Gurage (ጉራጌ , ISO-639-2 swg) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.",
   "related": {
     "gff_sgw_7": {
       "deprecates": true

--- a/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
+++ b/release/gff/gff_gurage_legacy/gff_gurage_legacy.keyboard_info
@@ -17,7 +17,7 @@
           "NotoSansEthiopic-Regular.woff2",
           "NotoSansEthiopic-Regular.ttf"
         ]
-      },
+      }
     }
   },
   "related": {

--- a/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.keyboard_info
+++ b/release/gff/gff_tigrinya_eritrea/gff_tigrinya_eritrea.keyboard_info
@@ -1,19 +1,34 @@
 {
-    "license": "mit",
-    "languages": {
-        "ti-Ethi-ER": {
-            "example": {
-                "keys": "tgrNa",
-                "text": "\u1275\u130d\u122d\u129b",
-                "note": "Name of language"
-            }
-        }
-    },
-    "description": "An intuitive, easy to use, keyboard for entering Eritrean Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.",
-    "related": {
-        "gff-tir-er-powerpack-7": { "deprecates": true },
-        "gff_tir_er_7": { "deprecates": true },
-        "tir_er_uni_ez": { "deprecates": true },
-        "tir-er-uni": { "deprecates": true }
+  "name": "Tigrinya (Er)",
+  "description": "An intuitive, easy to use, keyboard for entering Eritrean Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.",
+  "license": "mit",
+  "languages": {
+    "ti-ER": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      },
+      "example": {
+        "keys": "tgrNa",
+        "text": "\u1275\u130d\u122d\u129b",
+        "note": "Name of language"
+      }
     }
+  },
+  "related": {
+    "gff-tir-er-powerpack-7": { "deprecates": true },
+    "gff_tir_er_7": { "deprecates": true },
+    "tir_er_uni_ez": { "deprecates": true },
+    "tir-er-uni": { "deprecates": true }
+  }
 }

--- a/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.keyboard_info
+++ b/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.keyboard_info
@@ -1,19 +1,34 @@
 {
-    "license": "mit",
-    "languages": {
-        "ti-ET": {
-            "example": {
-                "keys": "tgrNa",
-                "text": "\u1275\u130d\u122d\u129b",
-                "note": "Name of language"
-            }
-        }
-    },
-    "description": "An intuitive, easy to use, keyboard for entering Ethiopian Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.",
-    "related": {
-        	"gff-tir-et-powerpack-7": { "deprecates": true },
-        	"gff_tir_et_7": { "deprecates": true },
-        "tir_et_uni_ez": { "deprecates": true },
-        "tir-et-uni": { "deprecates": true }
+  "name": "Tigrinya (Et)",
+  "description": "An intuitive, easy to use, keyboard for entering Ethiopian Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.",
+  "license": "mit",
+  "languages": {
+    "ti-ET": {
+      "font": {
+        "family": "GeezWeb",
+        "source": [
+          "NotoSerifEthiopic-Regular.woff2",
+          "NotoSerifEthiopic-Regular.ttf"
+        ]
+      },
+      "oskFont": {
+        "family": "GeezWebOsk",
+        "source": [
+          "NotoSansEthiopic-Regular.woff2",
+          "NotoSansEthiopic-Regular.ttf"
+        ]
+      },
+      "example": {
+        "keys": "tgrNa",
+        "text": "\u1275\u130d\u122d\u129b",
+        "note": "Name of language"
+      }
     }
+  },
+  "related": {
+    "gff-tir-et-powerpack-7": { "deprecates": true },
+    "gff_tir_et_7": { "deprecates": true },
+    "tir_et_uni_ez": { "deprecates": true },
+    "tir-et-uni": { "deprecates": true }
+  }
 }


### PR DESCRIPTION
This PR changes all references to the Wookianos (and other) web fonts referenced in the `.keyboard_info` files of the GFF keyboards.  The `fonts` field entry was also added to a number of keyboards that did not have it set.  An exception is the gff_ethiopic_7 (language-neutral) keyboard where a correct update would need more time and so will be revisited later.

The formatting of the `.keyboard_info` files was also synchronized.

This PR should complete #2072 