### PR TITLE
[malar_malayalam] Update to version 1.6

### DIFF
--- a/release/m/malar_malayalam/HISTORY.md
+++ b/release/m/malar_malayalam/HISTORY.md
@@ -1,6 +1,10 @@
 Malar Malayalam Keyboard Change History
 ====================
 
+1.6 (2023-03-17)
+----------------
+* Fix `ntha` keystroke to get conjunct `n̪t̪a` `<0D28, 0D4D, 0D24>`.
+
 1.5 (2023-03-11)
 ----------------
 * Add `XX` keystroke for ZWJ (200D).

--- a/release/m/malar_malayalam/README.md
+++ b/release/m/malar_malayalam/README.md
@@ -3,7 +3,7 @@ Malar Malayalam Keyboard
 
 2019-2023 © [Ramesh Kunnappully](mailto:ramesh1@protonmail.com)
 
-Version 1.5
+Version 1.6
 
 Description
 -----------

--- a/release/m/malar_malayalam/malar_malayalam.kpj
+++ b/release/m/malar_malayalam/malar_malayalam.kpj
@@ -12,7 +12,7 @@
       <ID>id_57f379b672d7f17e64931f93c05921c0</ID>
       <Filename>malar_malayalam.kmn</Filename>
       <Filepath>source\malar_malayalam.kmn</Filepath>
-      <FileVersion>1.5</FileVersion>
+      <FileVersion>1.6</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Malar Malayalam</Name>

--- a/release/m/malar_malayalam/source/malar_malayalam.kmn
+++ b/release/m/malar_malayalam/source/malar_malayalam.kmn
@@ -1,7 +1,7 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) 'Malar Malayalam'
 store(&COPYRIGHT) '© 2019-2023 Ramesh Kunnappully'
-store(&KEYBOARDVERSION) '1.5'
+store(&KEYBOARDVERSION) '1.6'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'malar_malayalam.kvks'
 store(&LAYOUTFILE) 'malar_malayalam.keyman-touch-layout'
@@ -127,7 +127,7 @@ U+0D28 U+0D4D + [K_T] > U+0D7B U+0D4D U+0D31 U+0D4D                 c ൻ്റ�
 U+0D20 U+0D4D + [SHIFT K_T] > U+0D31 U+0D4D U+0D31 U+0D4D           c റ്റ്
 U+0D28 U+0D4D + [K_K] > U+0D19 U+0D4D U+0D15 U+0D4D                 c ങ്ക്
 U+0D28 U+0D4D + [K_G] > U+0D19 U+0D4D U+0D19 U+0D4D                 c ങ്ങ്
-U+0D28 U+0D4D U+0D31 U+0D4D + [K_H] > U+0D28 U+0D4D U+0D24 U+0D4D   c ന്ത്
+U+0D7B U+0D4D U+0D31 U+0D4D + [K_H] > U+0D28 U+0D4D U+0D24 U+0D4D   c ന്ത്
 U+0D28 U+0D4D U+005F dk(c1) + [K_H] > U+0D1E U+0D4D U+0D1A U+0D4D   c ഞ്ച് 
 
 c Chillu

--- a/release/m/malar_malayalam/source/malar_malayalam.kps
+++ b/release/m/malar_malayalam/source/malar_malayalam.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>16.0.138.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -82,7 +82,7 @@
     <Keyboard>
       <Name>Malar Malayalam</Name>
       <ID>malar_malayalam</ID>
-      <Version>1.5</Version>
+      <Version>1.6</Version>
       <Languages>
         <Language ID="ml">Malayalam</Language>
       </Languages>


### PR DESCRIPTION
#### Changes in Version 1.6
* Fix `ntha` keystroke to get conjunct `n̪t̪a` `<0D28, 0D4D, 0D24>`.