### PR TITLE
[malar_malayalam] Update to version 1.6

### DIFF
--- a/release/m/malar_malayalam/HISTORY.md
+++ b/release/m/malar_malayalam/HISTORY.md
@@ -1,6 +1,11 @@
 Malar Malayalam Keyboard Change History
 ====================
 
+1.6 (2023-03-17)
+----------------
+* Fix `ntha` keystroke to get conjunct `n̪t̪a` `<0D28, 0D4D, 0D24>`.
+* Add shift modifier to `caps` (shift lock) layer in touch layout.
+
 1.5 (2023-03-11)
 ----------------
 * Add `XX` keystroke for ZWJ (200D).

--- a/release/m/malar_malayalam/README.md
+++ b/release/m/malar_malayalam/README.md
@@ -3,7 +3,7 @@ Malar Malayalam Keyboard
 
 2019-2023 © [Ramesh Kunnappully](mailto:ramesh1@protonmail.com)
 
-Version 1.5
+Version 1.6
 
 Description
 -----------

--- a/release/m/malar_malayalam/malar_malayalam.kpj
+++ b/release/m/malar_malayalam/malar_malayalam.kpj
@@ -12,7 +12,7 @@
       <ID>id_57f379b672d7f17e64931f93c05921c0</ID>
       <Filename>malar_malayalam.kmn</Filename>
       <Filepath>source\malar_malayalam.kmn</Filepath>
-      <FileVersion>1.5</FileVersion>
+      <FileVersion>1.6</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Malar Malayalam</Name>

--- a/release/m/malar_malayalam/source/malar_malayalam.keyman-touch-layout
+++ b/release/m/malar_malayalam/source/malar_malayalam.keyman-touch-layout
@@ -586,19 +586,23 @@
             "key": [
               {
                 "id": "K_BKQUOTE",
-                "text": "~"
+                "text": "~",
+                "layer": "shift"
               },
               {
                 "id": "K_1",
-                "text": "!"
+                "text": "!",
+                "layer": "shift"
               },
               {
                 "id": "K_2",
-                "text": "@"
+                "text": "@",
+                "layer": "shift"
               },
               {
                 "id": "K_3",
-                "text": "#"
+                "text": "#",
+                "layer": "shift"
               },
               {
                 "id": "U_20B9",
@@ -606,35 +610,43 @@
               },
               {
                 "id": "K_5",
-                "text": "%"
+                "text": "%",
+                "layer": "shift"
               },
               {
                 "id": "K_6",
-                "text": "^"
+                "text": "^",
+                "layer": "shift"
               },
               {
                 "id": "K_7",
-                "text": "&"
+                "text": "&",
+                "layer": "shift"
               },
               {
                 "id": "K_8",
-                "text": "*"
+                "text": "*",
+                "layer": "shift"
               },
               {
                 "id": "K_9",
-                "text": "("
+                "text": "(",
+                "layer": "shift"
               },
               {
                 "id": "K_0",
-                "text": ")"
+                "text": ")",
+                "layer": "shift"
               },
               {
                 "id": "K_HYPHEN",
-                "text": "_"
+                "text": "_",
+                "layer": "shift"
               },
               {
                 "id": "K_EQUAL",
-                "text": "+"
+                "text": "+",
+                "layer": "shift"
               }
             ]
           },
@@ -643,55 +655,68 @@
             "key": [
               {
                 "id": "K_Q",
-                "text": "Q"
+                "text": "Q",
+                "layer": "shift"
               },
               {
                 "id": "K_W",
-                "text": "W"
+                "text": "W",
+                "layer": "shift"
               },
               {
                 "id": "K_E",
-                "text": "E"
+                "text": "E",
+                "layer": "shift"
               },
               {
                 "id": "K_R",
-                "text": "R"
+                "text": "R",
+                "layer": "shift"
               },
               {
                 "id": "K_T",
-                "text": "T"
+                "text": "T",
+                "layer": "shift"
               },
               {
                 "id": "K_Y",
-                "text": "Y"
+                "text": "Y",
+                "layer": "shift"
               },
               {
                 "id": "K_U",
-                "text": "U"
+                "text": "U",
+                "layer": "shift"
               },
               {
                 "id": "K_I",
-                "text": "I"
+                "text": "I",
+                "layer": "shift"
               },
               {
                 "id": "K_O",
-                "text": "O"
+                "text": "O",
+                "layer": "shift"
               },
               {
                 "id": "K_P",
-                "text": "P"
+                "text": "P",
+                "layer": "shift"
               },
               {
                 "id": "K_LBRKT",
-                "text": "{"
+                "text": "{",
+                "layer": "shift"
               },
               {
                 "id": "K_RBRKT",
-                "text": "}"
+                "text": "}",
+                "layer": "shift"
               },
               {
                 "id": "K_BKSLASH",
-                "text": "|"
+                "text": "|",
+                "layer": "shift"
               }
             ]
           },
@@ -700,47 +725,58 @@
             "key": [
               {
                 "id": "K_A",
-                "text": "A"
+                "text": "A",
+                "layer": "shift"
               },
               {
                 "id": "K_S",
-                "text": "S"
+                "text": "S",
+                "layer": "shift"
               },
               {
                 "id": "K_D",
-                "text": "D"
+                "text": "D",
+                "layer": "shift"
               },
               {
                 "id": "K_F",
-                "text": "F"
+                "text": "F",
+                "layer": "shift"
               },
               {
                 "id": "K_G",
-                "text": "G"
+                "text": "G",
+                "layer": "shift"
               },
               {
                 "id": "K_H",
-                "text": "H"
+                "text": "H",
+                "layer": "shift"
               },
               {
                 "id": "K_J",
-                "text": "J"
+                "text": "J",
+                "layer": "shift"
               },
               {
                 "id": "K_K",
-                "text": "K"
+                "text": "K",
+                "layer": "shift"
               },
               {
                 "id": "K_L",
-                "text": "L"
+                "text": "L",
+                "layer": "shift"
               },
               {
                 "id": "K_COLON",
-                "text": ":"
+                "text": ":",
+                "layer": "shift"
               },
               {
                 "id": "K_QUOTE",
-                "text": "\""
+                "text": "\"",
+                "layer": "shift"
               },
               {
                 "id": "K_BKSP",
@@ -762,43 +798,53 @@
               },
               {
                 "id": "K_Z",
-                "text": "Z"
+                "text": "Z",
+                "layer": "shift"
               },
               {
                 "id": "K_X",
-                "text": "X"
+                "text": "X",
+                "layer": "shift"
               },
               {
                 "id": "K_C",
-                "text": "C"
+                "text": "C",
+                "layer": "shift"
               },
               {
                 "id": "K_V",
-                "text": "V"
+                "text": "V",
+                "layer": "shift"
               },
               {
                 "id": "K_B",
-                "text": "B"
+                "text": "B",
+                "layer": "shift"
               },
               {
                 "id": "K_N",
-                "text": "N"
+                "text": "N",
+                "layer": "shift"
               },
               {
                 "id": "K_M",
-                "text": "M"
+                "text": "M",
+                "layer": "shift"
               },
               {
                 "id": "K_COMMA",
-                "text": "<"
+                "text": "<",
+                "layer": "shift"
               },
               {
                 "id": "K_PERIOD",
-                "text": ">"
+                "text": ">",
+                "layer": "shift"
               },
               {
                 "id": "K_SLASH",
-                "text": "?"
+                "text": "?",
+                "layer": "shift"
               },
               {
                 "id": "K_SHIFT",
@@ -1726,43 +1772,53 @@
             "key": [
               {
                 "id": "K_Q",
-                "text": "Q"
+                "text": "Q",
+                "layer": "shift"
               },
               {
                 "id": "K_W",
-                "text": "W"
+                "text": "W",
+                "layer": "shift"
               },
               {
                 "id": "K_E",
-                "text": "E"
+                "text": "E",
+                "layer": "shift"
               },
               {
                 "id": "K_R",
-                "text": "R"
+                "text": "R",
+                "layer": "shift"
               },
               {
                 "id": "K_T",
-                "text": "T"
+                "text": "T",
+                "layer": "shift"
               },
               {
                 "id": "K_Y",
-                "text": "Y"
+                "text": "Y",
+                "layer": "shift"
               },
               {
                 "id": "K_U",
-                "text": "U"
+                "text": "U",
+                "layer": "shift"
               },
               {
                 "id": "K_I",
-                "text": "I"
+                "text": "I",
+                "layer": "shift"
               },
               {
                 "id": "K_O",
-                "text": "O"
+                "text": "O",
+                "layer": "shift"
               },
               {
                 "id": "K_P",
-                "text": "P"
+                "text": "P",
+                "layer": "shift"
               }
             ]
           },
@@ -1772,39 +1828,48 @@
               {
                 "id": "K_A",
                 "text": "A",
-                "pad": 70
+                "pad": 70,
+                "layer": "shift"
               },
               {
                 "id": "K_S",
-                "text": "S"
+                "text": "S",
+                "layer": "shift"
               },
               {
                 "id": "K_D",
-                "text": "D"
+                "text": "D",
+                "layer": "shift"
               },
               {
                 "id": "K_F",
-                "text": "F"
+                "text": "F",
+                "layer": "shift"
               },
               {
                 "id": "K_G",
-                "text": "G"
+                "text": "G",
+                "layer": "shift"
               },
               {
                 "id": "K_H",
-                "text": "H"
+                "text": "H",
+                "layer": "shift"
               },
               {
                 "id": "K_J",
-                "text": "J"
+                "text": "J",
+                "layer": "shift"
               },
               {
                 "id": "K_K",
-                "text": "K"
+                "text": "K",
+                "layer": "shift"
               },
               {
                 "id": "K_L",
-                "text": "L"
+                "text": "L",
+                "layer": "shift"
               },
               {
                 "id": "T_new_236",
@@ -1825,31 +1890,38 @@
               },
               {
                 "id": "K_Z",
-                "text": "Z"
+                "text": "Z",
+                "layer": "shift"
               },
               {
                 "id": "K_X",
-                "text": "X"
+                "text": "X",
+                "layer": "shift"
               },
               {
                 "id": "K_C",
-                "text": "C"
+                "text": "C",
+                "layer": "shift"
               },
               {
                 "id": "K_V",
-                "text": "V"
+                "text": "V",
+                "layer": "shift"
               },
               {
                 "id": "K_B",
-                "text": "B"
+                "text": "B",
+                "layer": "shift"
               },
               {
                 "id": "K_N",
-                "text": "N"
+                "text": "N",
+                "layer": "shift"
               },
               {
                 "id": "K_M",
-                "text": "M"
+                "text": "M",
+                "layer": "shift"
               },
               {
                 "id": "K_SLASH",
@@ -1922,7 +1994,8 @@
               },
               {
                 "id": "K_COMMA",
-                "text": ","
+                "text": ",",
+                "layer": "default"
               },
               {
                 "id": "K_BKQUOTE",

--- a/release/m/malar_malayalam/source/malar_malayalam.kmn
+++ b/release/m/malar_malayalam/source/malar_malayalam.kmn
@@ -1,7 +1,7 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) 'Malar Malayalam'
 store(&COPYRIGHT) '© 2019-2023 Ramesh Kunnappully'
-store(&KEYBOARDVERSION) '1.5'
+store(&KEYBOARDVERSION) '1.6'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'malar_malayalam.kvks'
 store(&LAYOUTFILE) 'malar_malayalam.keyman-touch-layout'
@@ -127,7 +127,7 @@ U+0D28 U+0D4D + [K_T] > U+0D7B U+0D4D U+0D31 U+0D4D                 c ൻ്റ�
 U+0D20 U+0D4D + [SHIFT K_T] > U+0D31 U+0D4D U+0D31 U+0D4D           c റ്റ്
 U+0D28 U+0D4D + [K_K] > U+0D19 U+0D4D U+0D15 U+0D4D                 c ങ്ക്
 U+0D28 U+0D4D + [K_G] > U+0D19 U+0D4D U+0D19 U+0D4D                 c ങ്ങ്
-U+0D28 U+0D4D U+0D31 U+0D4D + [K_H] > U+0D28 U+0D4D U+0D24 U+0D4D   c ന്ത്
+U+0D7B U+0D4D U+0D31 U+0D4D + [K_H] > U+0D28 U+0D4D U+0D24 U+0D4D   c ന്ത്
 U+0D28 U+0D4D U+005F dk(c1) + [K_H] > U+0D1E U+0D4D U+0D1A U+0D4D   c ഞ്ച് 
 
 c Chillu

--- a/release/m/malar_malayalam/source/malar_malayalam.kps
+++ b/release/m/malar_malayalam/source/malar_malayalam.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>16.0.138.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -82,7 +82,7 @@
     <Keyboard>
       <Name>Malar Malayalam</Name>
       <ID>malar_malayalam</ID>
-      <Version>1.5</Version>
+      <Version>1.6</Version>
       <Languages>
         <Language ID="ml">Malayalam</Language>
       </Languages>


### PR DESCRIPTION
#### Changes in Version 1.6
* Fix `ntha` keystroke to get conjunct `n̪t̪a` `<0D28, 0D4D, 0D24>`.
* Add shift modifier to `caps` (shift lock) layer in touch layout. (double-tapping Shift to reach a 'sticky' Caps Lock layer)