### PR TITLE
[fv_all] - Use jq to determine included keyboard versions

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.5 (26 Mar 2023)
+* Fix keyboard versions
+
 ## 12.4 (02 Feb 2022)
 * Associate sil_euro_latin keyboard with English
 

--- a/release/packages/fv_all/LICENSE.md
+++ b/release/packages/fv_all/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2020 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
+Copyright (c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/packages/fv_all/README.md
+++ b/release/packages/fv_all/README.md
@@ -1,9 +1,7 @@
 FirstVoices Keyboard Package
 ==================================================
 
-(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
-
-Version 12.4
+(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
 __DESCRIPTION__
 

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -11,6 +11,8 @@ KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
 . "$KEYBOARDROOT/resources/util.sh"
 . "$KEYBOARDROOT/resources/environment.sh"
 
+JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+
 locate_kmcomp
 
 # Parse parameters
@@ -102,6 +104,18 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   langname=${kpsdata[3]}
   oskFont=${kpsdata[4]}
   displayFont=${kpsdata[5]}
+
+  # Parse .keyboard_info file to override keyboard version because
+  # some are blank due to <FollowKeyboardVersion/> (#2143)
+  keyboardInfo="$KEYBOARDROOT/release/$group/$id/build/$id.keyboard_info"
+  if [[ ! -f $keyboardInfo ]]; then
+    die "$keyboardInfo does not exist"
+  fi
+
+  version=$(cat $keyboardInfo | $JQ -r '.version')
+  if [[ $version != ${kpsdata[1]} ]]; then
+    echo "WARNING: $id had version ${kpsdata[1]} vs $version"
+  fi
 
   # Override sil_euro_latin keyboard to English language
   if [[ $id = 'sil_euro_latin' ]]; then

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -15,10 +15,10 @@
     <Items/>
   </StartMenu>
   <Info>
-    <Copyright URL="">(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
+    <Copyright URL="">(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.4</Version>
+    <Version URL="">12.5</Version>
   </Info>
   <Files>
     <File>

--- a/release/packages/fv_all/source/readme.htm
+++ b/release/packages/fv_all/source/readme.htm
@@ -9,7 +9,7 @@
 
 <h1>FirstVoices Keyboard Package</h1>
 
-<p style='margin:0px'>(c) 2015-2022 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
+<p style='margin:0px'>(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
        
 <p>This package includes all the FirstVoices keyboards for Windows and mobile. It is distributed as part of the FirstVoices project.</p>
 


### PR DESCRIPTION
Fixes #2143

> We may need to fixup fv_all/build.sh to read from the .kmp files.

I elected to update build.sh to use jq to parse the compiled `.keyboard_info` files to determine the updated keyboard versions for all the keyboards included in fv_all.kmp.

Also bumped the version of fv_all to 12.5.

Tagging @caforbes 

