### PR TITLE
[fv_all] Cleanup build.sh

### DIFF
--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -10,8 +10,7 @@ KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
 
 . "$KEYBOARDROOT/resources/util.sh"
 . "$KEYBOARDROOT/resources/environment.sh"
-
-JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+. "$KEYBOARDROOT/tools/jq.inc.sh"
 
 locate_kmcomp
 
@@ -99,7 +98,7 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
 
   mapfile -t kpsdata < <(./parse_kps.pl $keyboard/source/$id.kps)
   name=${kpsdata[0]}
-  version=${kpsdata[1]}
+  # version assigned later
   bcp47=${kpsdata[2]}
   langname=${kpsdata[3]}
   oskFont=${kpsdata[4]}
@@ -113,9 +112,6 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
   fi
 
   version=$(cat $keyboardInfo | $JQ -r '.version')
-  if [[ $version != ${kpsdata[1]} ]]; then
-    echo "WARNING: $id had version ${kpsdata[1]} vs $version"
-  fi
 
   # Override sil_euro_latin keyboard to English language
   if [[ $id = 'sil_euro_latin' ]]; then

--- a/tools/jq.inc.sh
+++ b/tools/jq.inc.sh
@@ -2,7 +2,7 @@
 #
 # Setup JQ environment variable according to the user's system
 #
-# Windows: /resources/build/jq-win64.exe
+# Windows: ./jq-win64.exe
 # Linux/macOS: jq
 #
 

--- a/tools/jq.inc.sh
+++ b/tools/jq.inc.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Setup JQ environment variable according to the user's system
+#
+# Windows: /resources/build/jq-win64.exe
+# Linux/macOS: jq
+#
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+JQ_THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+# . "${THIS_SCRIPT%/*}/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+case "${OSTYPE}" in
+  "cygwin")
+    JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
+    ;;
+  "msys")
+    JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
+    ;;
+  *)
+    JQ=jq
+    ;;
+esac
+
+readonly JQ
+
+# JQ with inplace file replacement
+function jqi() {
+  cat <<< "$($JQ -c "$1" < "$2")" > "$2"
+}


### PR DESCRIPTION
Addresses review comments from #2173 
* Use jq.inc.sh for cross-platform build
* Remove unnecessary assignments and logging

Not bumping fv_all version since no new functionality