### PR TITLE
chore: Standardize usage of jq.inc.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -26,7 +26,7 @@ SHLVL=0
 # Define paths; note Windows hosted bash assumptions for now
 #
 KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+. "$KEYBOARDROOT/tools/jq.inc.sh"
 RSYNC="$KEYBOARDROOT/tools/rsync.exe"
 CI_CACHE="$KEYBOARDROOT/.cache"
 

--- a/resources/help-keyman-com.sh
+++ b/resources/help-keyman-com.sh
@@ -62,7 +62,7 @@ done
 
 KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 CI_CACHE="$KEYBOARDROOT/.cache"
-JQ="$KEYBOARDROOT/tools/jq-win64.exe"
+. "$KEYBOARDROOT/tools/jq.inc.sh"
 keyboards_to_push=0
 
 . "$KEYBOARDROOT/servervars.sh"

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -44,6 +44,7 @@ function display_usage {
 }
 
 KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+. "$KEYBOARDROOT/tools/jq.inc.sh"
 
 cd "$KEYBOARDROOT"
 
@@ -189,7 +190,6 @@ echo "Parameters:
 #
 function get_developer_remote_version {
   local TIER="$1"
-  local JQ="$KEYBOARDROOT/tools/jq-win64.exe"
 
   local DOWNLOADS_VERSION_API=https://downloads.keyman.com/api/version/developer
   local REMOTE_DEVELOPER_VERSIONS=`curl -s $DOWNLOADS_VERSION_API`


### PR DESCRIPTION
Addresses https://github.com/keymanapp/keyboards/pull/2180#pullrequestreview-1377011619

> A follow-up could update all other JQ references in ci.sh, help-keyman-com.sh, regression.sh scripts so that we can run keyboard builds on all CI agents.

Note, I only updated the include of jq.inc.sh, and intentionally am not refactoring all the `KEYBOARDROOT` defines with builder script.

Later on, we might also need to check other CI requirements like 7z.