### PR TITLE
put default layer first in .keyman-touch-layout file

### DIFF
--- a/release/fv/fv_australian/source/fv_australian.keyman-touch-layout
+++ b/release/fv/fv_australian/source/fv_australian.keyman-touch-layout
@@ -2,337 +2,6 @@
   "tablet": {
     "layer": [
       {
-        "id": "shift",
-        "row": [
-          {
-            "id": 1,
-            "key": [
-              {
-                "id": "T_Q",
-                "text": "Q",
-                "width": "100",
-                "pad": "21"
-              },
-              {
-                "id": "T_W",
-                "text": "W",
-                "width": "100"
-              },
-              {
-                "id": "T_E",
-                "text": "E",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ë",
-                    "id": "T_E_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_R",
-                "text": "R",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ṟ",
-                    "id": "T_R_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_T",
-                "text": "T",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ṯ",
-                    "id": "T_T_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_Y",
-                "text": "Y",
-                "width": "100"
-              },
-              {
-                "id": "T_U",
-                "text": "U",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ü",
-                    "id": "T_U_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_I",
-                "text": "I",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ï",
-                    "id": "T_I_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_O",
-                "text": "O",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ö",
-                    "id": "T_O_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_P",
-                "text": "P",
-                "width": "100"
-              },
-              {
-                "sp": "10",
-                "text": "",
-                "width": "21",
-                "pad": "0"
-              }
-            ]
-          },
-          {
-            "id": 2,
-            "key": [
-              {
-                "id": "T_A",
-                "text": "A",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ä",
-                    "id": "T_A_0"
-                  }
-                ],
-                "pad": "21"
-              },
-              {
-                "id": "T_S",
-                "text": "S",
-                "width": "100"
-              },
-              {
-                "id": "T_D",
-                "text": "D",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ḏ",
-                    "id": "T_D_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_F",
-                "text": "F",
-                "width": "100"
-              },
-              {
-                "id": "T_G",
-                "text": "G",
-                "width": "100"
-              },
-              {
-                "id": "T_H",
-                "text": "H",
-                "width": "100"
-              },
-              {
-                "id": "T_J",
-                "text": "J",
-                "width": "100"
-              },
-              {
-                "id": "T_K",
-                "text": "K",
-                "width": "100"
-              },
-              {
-                "id": "T_L",
-                "text": "L",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ḻ",
-                    "id": "T_L_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_COLON",
-                "text": "Ŋ",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "'",
-                    "id": "T_COLON_0"
-                  },
-                  {
-                    "text": "Ɲ",
-                    "id": "T_COLON_1"
-                  }
-                ]
-              },
-              {
-                "sp": "10",
-                "text": "",
-                "width": "21",
-                "pad": "0"
-              }
-            ]
-          },
-          {
-            "id": 3,
-            "key": [
-              {
-                "id": "K_SHIFT",
-                "text": "*Shift*",
-                "width": "136",
-                "sp": "1",
-                "nextlayer": "default",
-                "pad": "38"
-              },
-              {
-                "id": "T_Z",
-                "text": "Z",
-                "width": "100"
-              },
-              {
-                "id": "T_X",
-                "text": "X",
-                "width": "100"
-              },
-              {
-                "id": "T_C",
-                "text": "C",
-                "width": "100"
-              },
-              {
-                "id": "T_V",
-                "text": "V",
-                "width": "100"
-              },
-              {
-                "id": "T_B",
-                "text": "B",
-                "width": "100"
-              },
-              {
-                "id": "T_N",
-                "text": "N",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": "Ṉ",
-                    "id": "T_N_0"
-                  }
-                ]
-              },
-              {
-                "id": "T_M",
-                "text": "M",
-                "width": "100"
-              },
-              {
-                "id": "K_BKSP",
-                "text": "*BkSp*",
-                "width": "136",
-                "sp": "1"
-              },
-              {
-                "sp": "10",
-                "text": "",
-                "width": "37",
-                "pad": "0"
-              }
-            ]
-          },
-          {
-            "id": 4,
-            "key": [
-              {
-                "id": "K_NUMLOCK",
-                "text": "*123*",
-                "width": "136",
-                "sp": "1",
-                "nextlayer": "numeric"
-              },
-              {
-                "id": "K_LOPT",
-                "text": "*Menu*",
-                "width": "136",
-                "sp": "1"
-              },
-              {
-                "id": "K_SPACE",
-                "text": "",
-                "width": "438"
-              },
-              {
-                "id": "U_002E",
-                "text": ".",
-                "width": "100",
-                "sk": [
-                  {
-                    "text": ",",
-                    "id": "U_002C"
-                  },
-                  {
-                    "text": "!",
-                    "id": "U_0021"
-                  },
-                  {
-                    "text": "?",
-                    "id": "U_003F"
-                  },
-                  {
-                    "text": ";",
-                    "id": "U_003B"
-                  },
-                  {
-                    "text": ":",
-                    "id": "U_003A"
-                  },
-                  {
-                    "text": "'",
-                    "id": "U_0027"
-                  },
-                  {
-                    "text": "\"",
-                    "id": "U_0022"
-                  },
-                  {
-                    "text": "`",
-                    "id": "U_0060"
-                  },
-                  {
-                    "text": "~",
-                    "id": "U_007E"
-                  }
-                ]
-              },
-              {
-                "id": "K_ENTER",
-                "text": "*Enter*",
-                "width": "257",
-                "sp": "1"
-              }
-            ]
-          }
-        ]
-      },
-      {
         "id": "default",
         "row": [
           {
@@ -585,6 +254,337 @@
                 "sp": "10",
                 "text": "",
                 "width": "34",
+                "pad": "0"
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_NUMLOCK",
+                "text": "*123*",
+                "width": "136",
+                "sp": "1",
+                "nextlayer": "numeric"
+              },
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": "136",
+                "sp": "1"
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": "438"
+              },
+              {
+                "id": "U_002E",
+                "text": ".",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": ",",
+                    "id": "U_002C"
+                  },
+                  {
+                    "text": "!",
+                    "id": "U_0021"
+                  },
+                  {
+                    "text": "?",
+                    "id": "U_003F"
+                  },
+                  {
+                    "text": ";",
+                    "id": "U_003B"
+                  },
+                  {
+                    "text": ":",
+                    "id": "U_003A"
+                  },
+                  {
+                    "text": "'",
+                    "id": "U_0027"
+                  },
+                  {
+                    "text": "\"",
+                    "id": "U_0022"
+                  },
+                  {
+                    "text": "`",
+                    "id": "U_0060"
+                  },
+                  {
+                    "text": "~",
+                    "id": "U_007E"
+                  }
+                ]
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": "257",
+                "sp": "1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "shift",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "T_Q",
+                "text": "Q",
+                "width": "100",
+                "pad": "21"
+              },
+              {
+                "id": "T_W",
+                "text": "W",
+                "width": "100"
+              },
+              {
+                "id": "T_E",
+                "text": "E",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ë",
+                    "id": "T_E_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_R",
+                "text": "R",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ṟ",
+                    "id": "T_R_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_T",
+                "text": "T",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ṯ",
+                    "id": "T_T_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_Y",
+                "text": "Y",
+                "width": "100"
+              },
+              {
+                "id": "T_U",
+                "text": "U",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ü",
+                    "id": "T_U_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_I",
+                "text": "I",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ï",
+                    "id": "T_I_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_O",
+                "text": "O",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ö",
+                    "id": "T_O_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_P",
+                "text": "P",
+                "width": "100"
+              },
+              {
+                "sp": "10",
+                "text": "",
+                "width": "21",
+                "pad": "0"
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "T_A",
+                "text": "A",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ä",
+                    "id": "T_A_0"
+                  }
+                ],
+                "pad": "21"
+              },
+              {
+                "id": "T_S",
+                "text": "S",
+                "width": "100"
+              },
+              {
+                "id": "T_D",
+                "text": "D",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ḏ",
+                    "id": "T_D_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_F",
+                "text": "F",
+                "width": "100"
+              },
+              {
+                "id": "T_G",
+                "text": "G",
+                "width": "100"
+              },
+              {
+                "id": "T_H",
+                "text": "H",
+                "width": "100"
+              },
+              {
+                "id": "T_J",
+                "text": "J",
+                "width": "100"
+              },
+              {
+                "id": "T_K",
+                "text": "K",
+                "width": "100"
+              },
+              {
+                "id": "T_L",
+                "text": "L",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ḻ",
+                    "id": "T_L_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_COLON",
+                "text": "Ŋ",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "'",
+                    "id": "T_COLON_0"
+                  },
+                  {
+                    "text": "Ɲ",
+                    "id": "T_COLON_1"
+                  }
+                ]
+              },
+              {
+                "sp": "10",
+                "text": "",
+                "width": "21",
+                "pad": "0"
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_SHIFT",
+                "text": "*Shift*",
+                "width": "136",
+                "sp": "1",
+                "nextlayer": "default",
+                "pad": "38"
+              },
+              {
+                "id": "T_Z",
+                "text": "Z",
+                "width": "100"
+              },
+              {
+                "id": "T_X",
+                "text": "X",
+                "width": "100"
+              },
+              {
+                "id": "T_C",
+                "text": "C",
+                "width": "100"
+              },
+              {
+                "id": "T_V",
+                "text": "V",
+                "width": "100"
+              },
+              {
+                "id": "T_B",
+                "text": "B",
+                "width": "100"
+              },
+              {
+                "id": "T_N",
+                "text": "N",
+                "width": "100",
+                "sk": [
+                  {
+                    "text": "Ṉ",
+                    "id": "T_N_0"
+                  }
+                ]
+              },
+              {
+                "id": "T_M",
+                "text": "M",
+                "width": "100"
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": "136",
+                "sp": "1"
+              },
+              {
+                "sp": "10",
+                "text": "",
+                "width": "37",
                 "pad": "0"
               }
             ]


### PR DESCRIPTION
The only change to this file is switch the order of the shift layer and the default layer. Before the order was shift-default-numeric, now it's default-shift-numeric. This enables the help file to display correctly.
