### PR TITLE
gff_harari.keybaord_info Fix

### DIFF
--- a/release/gff/gff_harari/gff_harari.keyboard_info
+++ b/release/gff/gff_harari/gff_harari.keyboard_info
@@ -1,9 +1,9 @@
 {
   "name": "ሐረሪ (Harari)",
-  "description": "This is an Harari (har, ሐረሪ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 3 standard.",
+  "description": "This is an Harari (har, ሐረሪ) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.",
   "license": "mit",
   "languages": {
-    "am": {
+    "har": {
       "font": {
         "family": "GeezWeb",
         "source": [


### PR DESCRIPTION
Replaces the "am" language code with "har".

As per the the defect found here:  https://github.com/keymanapp/keyboards/pull/2196#issuecomment-1533644193