### PR TITLE
nepali_traditional add eyelash half RA in desktop layout

### DIFF
--- a/release/n/nepali_traditional/HISTORY.md
+++ b/release/n/nepali_traditional/HISTORY.md
@@ -12,3 +12,7 @@ Nepali Traditional Change History
 1.2 (2021-07-24)
 ----------------
 * add ऱ in all layouts and use ऱ् for ‍eyelash half ra (र्‍) in touch layouts
+
+1.3 (2023-06-07)
+----------------
+* add ऱ् instead of ऱ in desktop layout

--- a/release/n/nepali_traditional/LICENSE.md
+++ b/release/n/nepali_traditional/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-(c) 2023 Santosh Pradhan
+(c) 2021-2023 Santosh Pradhan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/n/nepali_traditional/LICENSE.md
+++ b/release/n/nepali_traditional/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-(c) 2021 Santosh Pradhan
+(c) 2023 Santosh Pradhan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/n/nepali_traditional/README.md
+++ b/release/n/nepali_traditional/README.md
@@ -1,9 +1,9 @@
 Nepali Traditional keyboard
 ==============
 
-(c) 2021 Santosh Pradhan
+(c) 2023 Santosh Pradhan
 
-Version 1.2.0
+Version 1.3.0
 
 Description
 -----------

--- a/release/n/nepali_traditional/nepali_traditional.kpj
+++ b/release/n/nepali_traditional/nepali_traditional.kpj
@@ -12,11 +12,11 @@
       <ID>id_5fb86a9ab786af4c61305e570d59cfee</ID>
       <Filename>nepali_traditional.kmn</Filename>
       <Filepath>source\nepali_traditional.kmn</Filepath>
-      <FileVersion>1.2.0</FileVersion>
+      <FileVersion>1.3.0</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Nepali Traditional</Name>
-        <Copyright>(c) 2021 Santosh Pradhan</Copyright>
+        <Copyright>(c) 2023 Santosh Pradhan</Copyright>
         <Message>Traditional Layout for Nepali in Devanagari script with dead keys for special characters</Message>
       </Details>
     </File>

--- a/release/n/nepali_traditional/source/nepali_traditional.kmn
+++ b/release/n/nepali_traditional/source/nepali_traditional.kmn
@@ -1,11 +1,11 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) 'Nepali Traditional'
-store(&KEYBOARDVERSION) '1.2.0'
+store(&KEYBOARDVERSION) '1.3.0'
 store(&TARGETS) 'any'
 store(&VISUALKEYBOARD) 'nepali_traditional.kvks'
 store(&LAYOUTFILE) 'nepali_traditional.keyman-touch-layout'
 store(&BITMAP) 'nepali_traditional.ico'
-store(&COPYRIGHT) '(c) 2021 Santosh Pradhan'
+store(&COPYRIGHT) '(c) 2023 Santosh Pradhan'
 store(&MESSAGE) 'Traditional Layout for Nepali in Devanagari script with dead keys for special characters'
 
 begin Unicode > use(main)
@@ -149,7 +149,7 @@ dk(curlyopen) + "." > "."
 dk(curlyopen) + "," > ","
 dk(curlyopen) + ">" > ">"
 dk(curlyopen) + "/" > "/"
-dk(curlyopen) + "?" > "ऱ"
+dk(curlyopen) + "?" > "ऱ्"
 
 c touch layout extensions 
 + [T_eyelash_half_rra] > "ऱ्"


### PR DESCRIPTION
in nepali text, RRA (ऱ) is always followed by halanta ( ् ) for eyelash half RA as in (पऱ्यो) , hence adding RRA halanta instead of RRA only