### PR TITLE
fix: broken pdf links

### DIFF
--- a/release/gff/gff_tigre/source/help/gff_tigre.php
+++ b/release/gff/gff_tigre/source/help/gff_tigre.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
   $pagename = "GFF Tigre";
   $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Tigre";
   $pagestyle = <<<END
@@ -72,16 +72,16 @@ END;
 <h2><a id="abstract" name="abstract"></a>Introduction</h2>
 
 <p style="text-align: justify;">
-This is a Tigre (tig, ትግሬ, ትግረ) language mnemonic input method that applies Eritrean writing conventions. 
-It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 
+This is a Tigre (tig, ትግሬ, ትግረ) language mnemonic input method that applies Eritrean writing conventions.
+It requires a font supporting Ethiopic script under the Unicode 3.0 standard.
 The Tigre keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard.  This means that the keyboard is designed to
 be intuitive and natural with respect to the sounds available in the English language via the standard English keyboard (known as QWERTY).
 The keyboard also supports mnemonic mappings from non-English letters found in European keyboards.
 </p>
 
-<p>A more complete typing manual is <a target="_blank" href="TigreTyping.pdf">provided as a PDF file</a> with this distribution.</p>
+<p>A more complete typing manual is <a target="_blank" href="TigreTyping-English.pdf">provided as a PDF file</a> with this distribution.</p>
 </div>
- 
+
 <h2><a id="status" name="status"></a>Typing Letter</h2>
 
 <p style="text-align: justify;">

--- a/release/gff/gff_tigrinya_eritrea/source/help/gff_tigrinya_eritrea.php
+++ b/release/gff/gff_tigrinya_eritrea/source/help/gff_tigrinya_eritrea.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
   $pagename = "GFF Eritrean Tigrinya";
   $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Eritrean Tigrinya";
   $pagestyle = <<<END
@@ -72,16 +72,16 @@ END;
 <h2><a id="abstract" name="abstract"></a>Introduction</h2>
 
 <p style="text-align: justify;">
-This is a Tigrinya (ti-ER, ትግርኛ-ኤርትራ) language mnemonic input method that applies Eritrean writing conventions. 
-It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 
+This is a Tigrinya (ti-ER, ትግርኛ-ኤርትራ) language mnemonic input method that applies Eritrean writing conventions.
+It requires a font supporting Ethiopic script under the Unicode 3.0 standard.
 The Tigrinya keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard.  This means that the keyboard is designed to
 be intuitive and natural with respect to the sounds available in the English language via the standard English keyboard (known as QWERTY).
 The keyboard also supports mnemonic mappings from non-English letters found in European keyboards.
 </p>
 
-<p>A more complete typing manual is <a target="_blank" href="TigrinyaErTyping.pdf">provided as a PDF file</a> with this distribution.</p>
+<p>A more complete typing manual is <a target="_blank" href="TigrinyaErTyping-English.pdf">provided as a PDF file</a> with this distribution.</p>
 </div>
- 
+
 <h2><a id="status" name="status"></a>Typing Letter</h2>
 
 <p style="text-align: justify;">


### PR DESCRIPTION
Fixes #2254.

Fixes links in gff_tigre.php and gff_tigrinya_eritrea.php. As nothing else has changed (and welcome.htm do not have the links at present), does not bump version numbers.