### PR TITLE
GFF Geʾez Keyboard v2.0.1

### DIFF
--- a/release/gff/gff_geez/HISTORY.md
+++ b/release/gff/gff_geez/HISTORY.md
@@ -1,5 +1,8 @@
 # ግዕዝ (Geʾez) Change History
 
+## 2023-07-18 2.0.1
+* Removing gff_geez.js from package to avoid mobile platform listings.
+
 ## 2023-07-10 2.0
 * Vowel composition synched with other GFF keyboard revisions.
 * Smart punctuation composition added.

--- a/release/gff/gff_geez/README.md
+++ b/release/gff/gff_geez/README.md
@@ -3,7 +3,7 @@
 
 Copyright © 2009-2023 Geʾez Frontier Foundation
 
-Version 2.0
+Version 2.0.1
 
 This is a Geʾez (ግዕዝ, ISO-639-2 gez) language mnemonic input method.  It requires a font
 supporting Ethiopic script under the Unicode 4.1 standard.

--- a/release/gff/gff_geez/gff_geez.keyboard_info
+++ b/release/gff/gff_geez/gff_geez.keyboard_info
@@ -1,5 +1,5 @@
 {
-  "description": "<p>This is a Geʾez (ግዕዝ) language keyboard where the letters available are restricted to only those used in the Geʾez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b>  Thus these letters cannot be accidentally typed when composing a Geʾez language document.</p>",
+  "description": "This is a Geʾez (ግዕዝ) language keyboard where the letters available are restricted to *only* those used in the Geʾez language. The additional letters used in modern Ethiopic languages are *not* available from the keyboard. Thus these letters cannot be accidentally typed when composing a Geʾez language document.",
   "license": "mit",
   "languages": {
     "gez": {

--- a/release/gff/gff_geez/gff_geez.kpj
+++ b/release/gff/gff_geez/gff_geez.kpj
@@ -12,7 +12,7 @@
       <ID>id_8dc2f1f0cefbe3317bbb6eb3ef260a9d</ID>
       <Filename>gff_geez.kmn</Filename>
       <Filepath>source\gff_geez.kmn</Filepath>
-      <FileVersion>2.0</FileVersion>
+      <FileVersion>2.0.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ግዕዝ (Geʾez)</Name>
@@ -145,14 +145,6 @@
       <Filepath>source\..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Connected-Regular.ttf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.ttf</FileType>
-      <ParentFileID>id_c73863d1d8e4cbceab71be8d32570670</ParentFileID>
-    </File>
-    <File>
-      <ID>id_b28712cb8fd5af716ad51f5116e89fa3</ID>
-      <Filename>gff_geez.js</Filename>
-      <Filepath>source\..\build\gff_geez.js</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.js</FileType>
       <ParentFileID>id_c73863d1d8e4cbceab71be8d32570670</ParentFileID>
     </File>
     <File>

--- a/release/gff/gff_geez/source/gff_geez.kmn
+++ b/release/gff/gff_geez/source/gff_geez.kmn
@@ -13,7 +13,7 @@ c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
 store(&Version) '15.0'
-store(&KEYBOARDVERSION) '2.0'
+store(&KEYBOARDVERSION) '2.0.1'
 store(&Name) 'ግዕዝ (Geʾez)'    
 store(&COPYRIGHT) '© 2009-2023 Geʾez Frontier Foundation'
 store(&Message) 'This is a Geʾez language mnemonic input method. It requires a font supporting Ethiopic script under the Unicode 4.1 standard.'

--- a/release/gff/gff_geez/source/gff_geez.kps
+++ b/release/gff/gff_geez/source/gff_geez.kps
@@ -79,12 +79,6 @@
       <FileType>.pdf</FileType>
     </File>
     <File>
-      <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
-      <Description>Font Brana Regular</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
       <Name>..\..\..\shared\fonts\geez\OFL.txt</Name>
       <Description>File OFL.txt</Description>
       <CopyLocation>0</CopyLocation>
@@ -103,6 +97,18 @@
       <FileType>.htm</FileType>
     </File>
     <File>
+      <Name>AbbaGarima-Regular.ttf</Name>
+      <Description>Font Abba Garima Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
+      <Description>Font Brana Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>    
+    <File>
       <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
       <Description>Font Abyssinica SIL</Description>
       <CopyLocation>0</CopyLocation>
@@ -111,18 +117,6 @@
     <File>
       <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Connected-Regular.ttf</Name>
       <Description>Font Abyssinica SIL (Connected)</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\build\gff_geez.js</Name>
-      <Description>File gff_geez.js</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.js</FileType>
-    </File>
-    <File>
-      <Name>AbbaGarima-Regular.ttf</Name>
-      <Description>Font Abba Garima Regular</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.ttf</FileType>
     </File>

--- a/release/gff/gff_geez/source/help/gff_geez.php
+++ b/release/gff/gff_geez/source/help/gff_geez.php
@@ -64,8 +64,8 @@ END;
 <h2><a id="abstract" name="abstract"></a>Introduction</h2>
 
 <p style="text-align: justify;">
-This is a Geʾez (ግዕዝ, ISO-639-2: gez) language mnemonic input method.  It requires a font supporting Ethiopic script under the Unicode 4.1 standard.
-The Ge&rsquo;ez keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard.  This means that the keyboard is designed to
+This is a Geʾez (ግዕዝ, ISO-639-2: gez) language mnemonic input method. It requires a font supporting Ethiopic script under the Unicode 4.1 standard.
+The Ge&rsquo;ez keyboard is &ldquo;mnemonic&rdquo; and designed for the US English QWERTY keyboard. This means that the keyboard is designed to
 be intuitive and natural with respect to the sounds available in the English language via the standard English keyboard (known as QWERTY).
 The keyboard also supports mnemonic mappings from non-English letters found in European keyboards.
 </p>
@@ -76,8 +76,9 @@ The keyboard also supports mnemonic mappings from non-English letters found in E
 <h2><a id="status" name="status"></a>Typing Letters</h2>
 
 <p style="text-align: justify;">
-Only the letters used in the Geʾez language may be typed with this keyboard. To type additional Ethiopic letters used by other languages, please
-download a keyboard for the language needed or the <em>language-neutral</em> keyboard that supports composition of all Ethiopic symbols found in Unicode 4.1
+<em>Only</em> the letters used in the Geʾez language may be typed with this keyboard (i.e. no extra letters for Amharic, Tigrinya, etc. are typeable). 
+To type additional Ethiopic letters used by other languages, please download a keyboard for the language needed or the <a href="https://keyman.com/keyboards/gff_ethiopic"><em>language-neutral</em></a> keyboard 
+that supports composition of all Ethiopic symbols found in Unicode 14.
 </p>
 
 

--- a/release/gff/gff_geez/source/welcome.htm
+++ b/release/gff/gff_geez/source/welcome.htm
@@ -79,8 +79,9 @@ The keyboard also supports mnemonic mappings from non-English letters found in E
 <h2><a id="status" name="status"></a>Typing Letters</h2>
 
 <p style="text-align: justify;">
-Only the letters used in the Geʾez language may be typed with this keyboard. To type additional Ethiopic letters used by other languages, please
-download a keyboard for the language needed or the <em>language-neutral</em> keyboard that supports composition of all Ethiopic symbols found in Unicode 4.1
+<em>Only</em> the letters used in the Geʾez language may be typed with this keyboard (i.e. no extra letters for Amharic, Tigrinya, etc. are typeable). 
+To type additional Ethiopic letters used by other languages, please download a keyboard for the language needed or the <a href="https://keyman.com/keyboards/gff_ethiopic"><em>language-neutral</em></a> keyboard 
+that supports composition of all Ethiopic symbols found in Unicode 14.
 </p>
 
 


### PR DESCRIPTION
This version of the keyboard removes the `gff_geez.js` file from the packaging to avoid the listings of available mobile layouts.  Documentation has also been enhanced to provide a link to the language-neutral keyboard.