### PR TITLE
[2303_missing_js] Update some of the keyboards in this issue

### DIFF
--- a/release/b/balochi_scientific/HISTORY.md
+++ b/release/b/balochi_scientific/HISTORY.md
@@ -1,6 +1,10 @@
 Balochi Scientific Keyboard Change History
 ===============================
 
+1.0.5 (19 Jul 2023)
+------------------
+* Add mobile js to package
+
 1.0.4 (1 Sep 2022)
 ------------------
 * Use bal-Latn instead of bcc-Latn

--- a/release/b/balochi_scientific/LICENSE.md
+++ b/release/b/balochi_scientific/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2022 SIL International
+Copyright (c) 2017-2023 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/b/balochi_scientific/balochi_scientific.kpj
+++ b/release/b/balochi_scientific/balochi_scientific.kpj
@@ -16,7 +16,7 @@
       <FileType>.kmn</FileType>
       <Details>
         <Name>Balochi Scientific</Name>
-        <Copyright>Â© SIL International</Copyright>
+        <Copyright>© SIL International</Copyright>
         <Message>The Balochi Scientific keyboard is distributed under The MIT License (MIT).</Message>
       </Details>
     </File>

--- a/release/b/balochi_scientific/balochi_scientific.kpj
+++ b/release/b/balochi_scientific/balochi_scientific.kpj
@@ -12,11 +12,11 @@
       <ID>id_d51c2a5f9b3912b98e673848e9f7ac78</ID>
       <Filename>balochi_scientific.kmn</Filename>
       <Filepath>source\balochi_scientific.kmn</Filepath>
-      <FileVersion>1.0.4</FileVersion>
+      <FileVersion>1.0.5</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Balochi Scientific</Name>
-        <Copyright>© SIL International</Copyright>
+        <Copyright>Â© SIL International</Copyright>
         <Message>The Balochi Scientific keyboard is distributed under The MIT License (MIT).</Message>
       </Details>
     </File>
@@ -28,7 +28,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>Balochi Scientific</Name>
-        <Copyright>© 2017-2022 SIL International.</Copyright>
+        <Copyright>© 2017-2023 SIL International.</Copyright>
       </Details>
     </File>
     <File>
@@ -85,6 +85,14 @@
       <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
+      <ParentFileID>id_da97887dfbbd1f48dfe2922afd195a60</ParentFileID>
+    </File>
+    <File>
+      <ID>id_b621ecba02ef9e1f5d981c8d5d0b50d7</ID>
+      <Filename>balochi_scientific.js</Filename>
+      <Filepath>source\..\build\balochi_scientific.js</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.js</FileType>
       <ParentFileID>id_da97887dfbbd1f48dfe2922afd195a60</ParentFileID>
     </File>
   </Files>

--- a/release/b/balochi_scientific/source/balochi_scientific.kmn
+++ b/release/b/balochi_scientific/source/balochi_scientific.kmn
@@ -1,11 +1,11 @@
-﻿store(&VERSION) '9.0'
+store(&VERSION) '9.0'
 store(&TARGETS) 'any'
 store(&NAME) 'Balochi Scientific'
 store(&BITMAP) 'balochi_scientific.ico'
 store(&COPYRIGHT) '© SIL International'
 store(&MESSAGE) 'The Balochi Scientific keyboard is distributed under The MIT License (MIT).'
 store(&KMW_HELPTEXT) 'This is a Latin keyboard for transcription of Balochi languages using the method devised at Uppsala University.'
-store(&KEYBOARDVERSION) '1.0.4'
+store(&KEYBOARDVERSION) '1.0.5'
 store(&VISUALKEYBOARD) 'balochi_scientific.kvks'
 
 group(main) using keys

--- a/release/b/balochi_scientific/source/balochi_scientific.kps
+++ b/release/b/balochi_scientific/source/balochi_scientific.kps
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>15.0.268.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
     <ExecuteProgram></ExecuteProgram>
+    <ReadMeFile>readme.htm</ReadMeFile>
     <MSIFileName>C:\Data\Keyman\balochi_scientific\source\keymandesktop90.msi</MSIFileName>
     <MSIOptions></MSIOptions>
     <FollowKeyboardVersion/>
@@ -17,7 +18,7 @@
   <Info>
     <Version URL=""></Version>
     <Name URL="">Balochi Scientific</Name>
-    <Copyright URL="">© 2017-2022 SIL International.</Copyright>
+    <Copyright URL="">© 2017-2023 SIL International.</Copyright>
   </Info>
   <Files>
     <File>
@@ -25,12 +26,6 @@
       <Description>File welcome.htm</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.htm</FileType>
-    </File>
-    <File>
-      <Name>balochi_scientific.ico</Name>
-      <Description>File balochi_scientific.ico</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ico</FileType>
     </File>
     <File>
       <Name>..\build\balochi_scientific.kvk</Name>
@@ -62,12 +57,18 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.htm</FileType>
     </File>
+    <File>
+      <Name>..\build\balochi_scientific.js</Name>
+      <Description>File balochi_scientific.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.js</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Balochi Scientific</Name>
       <ID>balochi_scientific</ID>
-      <Version>1.0.4</Version>
+      <Version>1.0.5</Version>
       <Languages>
         <Language ID="bal-Latn">Baluchi (Latin)</Language>
       </Languages>

--- a/release/l/lao_phonetic/HISTORY.md
+++ b/release/l/lao_phonetic/HISTORY.md
@@ -1,6 +1,10 @@
 lao_phonetic Change History
 ====================
 
+1.1.3 (2023-07-19)
+------------------
+* Add js file for package to support mobile
+
 1.1.2 (2022-09-12)
 ------------------
 * Add support for touch devices

--- a/release/l/lao_phonetic/LICENSE.md
+++ b/release/l/lao_phonetic/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2015-2022 John Durdin
+© 2015-2023 John Durdin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/l/lao_phonetic/README.md
+++ b/release/l/lao_phonetic/README.md
@@ -1,7 +1,7 @@
 Lao Phonetic keyboard
 ==============
 
-© 2015-2022 John Durdin
+© John Durdin
 
 
 Description
@@ -13,6 +13,7 @@ be tidied up in a future version.
 
 Links
 -----
+https://keyman.com/keyboards/lao_phonetic
 http://www.laoscript.net/
 
 Supported Platforms

--- a/release/l/lao_phonetic/lao_phonetic.kpj
+++ b/release/l/lao_phonetic/lao_phonetic.kpj
@@ -12,11 +12,11 @@
       <ID>id_fc7dcfc14b094114389ff857b3e769dc</ID>
       <Filename>lao_phonetic.kmn</Filename>
       <Filepath>source\lao_phonetic.kmn</Filepath>
-      <FileVersion>1.1.2</FileVersion>
+      <FileVersion>1.1.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Lao Phonetic</Name>
-        <Copyright>© 2015-2022 John Durdin</Copyright>
+        <Copyright>© John Durdin</Copyright>
         <Message>Phonetic input Lao keyboard.</Message>
       </Details>
     </File>
@@ -28,8 +28,36 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>Lao Phonetic</Name>
-        <Copyright>© 2015-2022 John Durdin</Copyright>
+        <Copyright>© 2015-2023 John Durdin</Copyright>
       </Details>
+    </File>
+    <File>
+      <ID>id_ede98e4633e239f933cbfd1f4e1b766c</ID>
+      <Filename>HISTORY.md</Filename>
+      <Filepath>HISTORY.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_0730bb7c2e8f9ea2438b52e419dd86c9</ID>
+      <Filename>README.md</Filename>
+      <Filepath>README.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_53e892b8b41cc4caece1cfd5ef21d6e7</ID>
+      <Filename>LICENSE.md</Filename>
+      <Filepath>LICENSE.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <ID>id_371efb40fb5ef7cd545c51499f759564</ID>
+      <Filename>lao_phonetic.keyboard_info</Filename>
+      <Filepath>lao_phonetic.keyboard_info</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.keyboard_info</FileType>
     </File>
     <File>
       <ID>id_bdf72a71b26297c880c654cd43f643c0</ID>
@@ -120,32 +148,12 @@
       <ParentFileID>id_e23d5d267be2ec1e9de4dc058e60880b</ParentFileID>
     </File>
     <File>
-      <ID>id_ede98e4633e239f933cbfd1f4e1b766c</ID>
-      <Filename>HISTORY.md</Filename>
-      <Filepath>HISTORY.md</Filepath>
+      <ID>id_507ba2b7d076f45a69656ffe946740e3</ID>
+      <Filename>lao_phonetic.js</Filename>
+      <Filepath>source\..\build\lao_phonetic.js</Filepath>
       <FileVersion></FileVersion>
-      <FileType>.md</FileType>
-    </File>
-    <File>
-      <ID>id_0730bb7c2e8f9ea2438b52e419dd86c9</ID>
-      <Filename>README.md</Filename>
-      <Filepath>README.md</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.md</FileType>
-    </File>
-    <File>
-      <ID>id_53e892b8b41cc4caece1cfd5ef21d6e7</ID>
-      <Filename>LICENSE.md</Filename>
-      <Filepath>LICENSE.md</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.md</FileType>
-    </File>
-    <File>
-      <ID>id_371efb40fb5ef7cd545c51499f759564</ID>
-      <Filename>lao_phonetic.keyboard_info</Filename>
-      <Filepath>lao_phonetic.keyboard_info</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.keyboard_info</FileType>
+      <FileType>.js</FileType>
+      <ParentFileID>id_e23d5d267be2ec1e9de4dc058e60880b</ParentFileID>
     </File>
   </Files>
 </KeymanDeveloperProject>

--- a/release/l/lao_phonetic/source/help/lao_phonetic.php
+++ b/release/l/lao_phonetic/source/help/lao_phonetic.php
@@ -309,7 +309,7 @@ type any vowel letter, then press backspace to delete the Lao vowel character, l
   <b> + `</b><span class="wd"> &#8594; </span><b>¥</b>
   <b> + `</b><span class="wd"> &#8594; </span><b>$</b>
 </li></ul>
-<p>Copyright 2015-2022 <a href="http://laoscript.net/">Dr John M Durdin</a>, <a href="http://laoscript.net/">laoscript.net</a></p>
+<p>Copyright <a href="http://laoscript.net/">Dr John M Durdin</a>, <a href="http://laoscript.net/">laoscript.net</a></p>
 
 </body>
 </html>

--- a/release/l/lao_phonetic/source/lao_phonetic.kmn
+++ b/release/l/lao_phonetic/source/lao_phonetic.kmn
@@ -1,16 +1,16 @@
-﻿c Phonetic input Lao keyboard for Unicode fonts.
+c Phonetic input Lao keyboard for Unicode fonts.
 
 store(&VERSION) '10.0'
 store(&NAME) 'Lao Phonetic'
 store(&HOTKEY) '[CTRL SHIFT K_P]'
 store(&MESSAGE) 'Phonetic input Lao keyboard.'
-store(&COPYRIGHT) '© 2015-2022 John Durdin'
+store(&COPYRIGHT) '© John Durdin'
 store(&capsalwaysoff) "1"
 
 store(&TARGETS) 'any'
 store(&BITMAP) 'lao_phonetic.ico'
 store(&VISUALKEYBOARD) 'lao_phonetic.kvks'
-store(&KEYBOARDVERSION) '1.1.2'
+store(&KEYBOARDVERSION) '1.1.3'
 store(&LAYOUTFILE) 'lao_phonetic.keyman-touch-layout'
 
 begin Unicode > use(Start)

--- a/release/l/lao_phonetic/source/lao_phonetic.kps
+++ b/release/l/lao_phonetic/source/lao_phonetic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.61.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -18,9 +18,10 @@
   </StartMenu>
   <Info>
     <Name URL="">Lao Phonetic</Name>
-    <Copyright URL="">© 2015-2022 John Durdin</Copyright>
+    <Copyright URL="">© 2015-2023 John Durdin</Copyright>
     <Author URL="">John Durdin</Author>
     <WebSite URL="http://www.laoscript.net/">http://www.laoscript.net/</WebSite>
+    <Version URL=""></Version>
   </Info>
   <Files>
     <File>
@@ -83,12 +84,20 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.txt</FileType>
     </File>
+    <File>
+      <Name>..\build\lao_phonetic.js</Name>
+      <Description>File lao_phonetic.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.js</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Lao Phonetic</Name>
       <ID>lao_phonetic</ID>
-      <Version>1.1.1</Version>
+      <Version>1.1.3</Version>
+      <OSKFont>..\..\..\shared\fonts\laoo\saysettha\Saysettha OT.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\laoo\saysettha\Saysettha OT.ttf</DisplayFont>
       <Languages>
         <Language ID="lo">Lao</Language>
       </Languages>

--- a/release/l/lao_phonetic/source/readme.htm
+++ b/release/l/lao_phonetic/source/readme.htm
@@ -14,7 +14,7 @@
 <p>A transliteration (phonetic input) keyboard layout for Lao language,
 adapted from a layout used in <a href="http://laoscript.net/">Lao Script for Windows</a>, with a selection of Lao OpenType (Unicode)
 fonts, all of which are either royalty-free or licensed under the terms of <a href="http://scripts.sil.org/OFL">SIL Open Font License</a></p>
-<p>Copyright 2015-2018 <a href="http://laoscript.net/">John M Durdin</a></p>
+<p>Copyright <a href="http://laoscript.net/">John M Durdin</a></p>
 <p class="attr">Splash image adapted from photo of Vang Vieng by Nick Hubbard (Wikimedia Commons, 
 <a href="https://commons.wikimedia.org/wiki/File:Laos-10-310_(8685858457).jpg">https://commons.wikimedia.org/wiki/File:Laos-10-310_(8685858457).jpg</a>).</p>
 </body>

--- a/release/l/lao_phonetic/source/welcome.htm
+++ b/release/l/lao_phonetic/source/welcome.htm
@@ -311,6 +311,6 @@ type any vowel letter, then press backspace to delete the Lao vowel character, l
   <b> + `</b><span class="wd"> &#8594; </span><b>¥</b>
   <b> + `</b><span class="wd"> &#8594; </span><b>$</b>
 </li></ul>
-<p>Copyright 2015-2022 <a href="http://laoscript.net/">Dr John M Durdin</a>, <a href="http://laoscript.net/">laoscript.net</a></p>
+<p>Copyright <a href="http://laoscript.net/">Dr John M Durdin</a>, <a href="http://laoscript.net/">laoscript.net</a></p>
 </body>
 </html>

--- a/release/packages/gff_gurage_and_amharic/HISTORY.md
+++ b/release/packages/gff_gurage_and_amharic/HISTORY.md
@@ -1,5 +1,8 @@
 # Amharic (አማርኛ) & Gurage (ጉራጊና) Keyboards
 
+## 1.1(19 Jul 2023)
+* Add .js files to kps
+
 ## 1.0(05 Jul 2023)
 * Resync with Gurage 1.0 and Amharic 3.3 packages.
 

--- a/release/packages/gff_gurage_and_amharic/README.md
+++ b/release/packages/gff_gurage_and_amharic/README.md
@@ -1,9 +1,9 @@
 Amharic (አማርኛ) & Gurage (ጉራጊና) Keyboards
 ========================================
 
-Copyright (C) 2019-2023 Ge'ez Frontier Foundation
+Copyright (C) Ge'ez Frontier Foundation
 
-Version 1.0
+Version 1.1
 ===========
 
 This package aggregates the GFF Amharic and Gurage keyboards. Complete documentation on the keyboards
@@ -22,3 +22,4 @@ Supported Platforms
  * Windows
  * macOS
  * Linux 
+ * Mobile

--- a/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.kpj
+++ b/release/packages/gff_gurage_and_amharic/gff_gurage_and_amharic.kpj
@@ -36,12 +36,12 @@
       <ID>id_9fc3e3d4a484b7e55d32b73995631eed</ID>
       <Filename>gff_gurage_and_amharic.kps</Filename>
       <Filepath>source\gff_gurage_and_amharic.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Gurage and Amharic Keyboard Package</Name>
         <Copyright>© 2019-2023 Geʾez Frontier Foundation</Copyright>
-        <Version>1.0</Version>
+        <Version>1.1</Version>
       </Details>
     </File>
     <File>
@@ -234,6 +234,22 @@
       <Filepath>source\..\..\..\shared\fonts\noto\Ethi\NotoSerifEthiopic-Regular.ttf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.ttf</FileType>
+      <ParentFileID>id_9fc3e3d4a484b7e55d32b73995631eed</ParentFileID>
+    </File>
+    <File>
+      <ID>id_cbb75d97233f116811e3ac0c095b8c8f</ID>
+      <Filename>gff_gurage.js</Filename>
+      <Filepath>source\..\..\..\gff\gff_gurage\build\gff_gurage.js</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.js</FileType>
+      <ParentFileID>id_9fc3e3d4a484b7e55d32b73995631eed</ParentFileID>
+    </File>
+    <File>
+      <ID>id_378c7b1367d8f47a08bc61b7625899f0</ID>
+      <Filename>gff_amharic.js</Filename>
+      <Filepath>source\..\..\..\gff\gff_amharic\build\gff_amharic.js</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.js</FileType>
       <ParentFileID>id_9fc3e3d4a484b7e55d32b73995631eed</ParentFileID>
     </File>
   </Files>

--- a/release/packages/gff_gurage_and_amharic/source/gff_gurage_and_amharic.kps
+++ b/release/packages/gff_gurage_and_amharic/source/gff_gurage_and_amharic.kps
@@ -60,7 +60,7 @@
     </Items>
   </StartMenu>
   <Info>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.1</Version>
     <Name URL="">Gurage and Amharic Keyboard Package</Name>
     <Copyright URL="">© 2019-2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:keyboards@ethiopic.org">The Geʾez Frontier Foundation</Author>
@@ -199,20 +199,36 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.ttf</FileType>
     </File>
+    <File>
+      <Name>..\..\..\gff\gff_gurage\build\gff_gurage.js</Name>
+      <Description>File gff_gurage.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.js</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\gff\gff_amharic\build\gff_amharic.js</Name>
+      <Description>File gff_amharic.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.js</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>ጉራጌ (Gurage)</Name>
       <ID>gff_gurage</ID>
-      <Version>0.8.1</Version>
+      <Version>1.0</Version>
+      <OSKFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</DisplayFont>
       <Languages>
-        <Language ID="sgw-Ethi">Sebat Bet Gurage</Language>
+        <Language ID="sgw">Sebat Bet Gurage</Language>
       </Languages>
     </Keyboard>
     <Keyboard>
       <Name>አማርኛ (Amharic)</Name>
       <ID>gff_amharic</ID>
-      <Version>2.1</Version>
+      <Version>3.1.1</Version>
+      <OSKFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</DisplayFont>
       <Languages>
         <Language ID="am">Amharic</Language>
       </Languages>


### PR DESCRIPTION
Partially addresses #2303 

@mcdurdin I did not address:
```
gff_amh_7.kps
gff_amh_powerpack_7.kps
gff_ethiopic_7.kps
```
because those are deprecated. 
How do you want that handled? Or maybe you should not be testing deprecated keyboards?





