### PR TITLE
chore: remove old fields from keyboard_info 🎺

### DIFF
--- a/legacy/a/acoli/acoli.keyboard_info
+++ b/legacy/a/acoli/acoli.keyboard_info
@@ -7,7 +7,6 @@
     "ach"
   ],
   "lastModifiedDate": "2014-05-19T12:41:37Z",
-  "links": [],
   "packageFilename": "acoli.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 681
+  }
 }

--- a/legacy/a/africadeadkey/africadeadkey.keyboard_info
+++ b/legacy/a/africadeadkey/africadeadkey.keyboard_info
@@ -36,7 +36,6 @@
     "yo"
   ],
   "lastModifiedDate": "2014-08-08T16:18:47Z",
-  "links": [],
   "packageFilename": "africadeadkey.kmp",
   "encodings": [
     "unicode"
@@ -49,7 +48,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 688,
-  "documentationFilename": "sil unicode keyboard chart for africa using deadkeys.pdf"
+  }
 }

--- a/legacy/a/africaus/africaus.keyboard_info
+++ b/legacy/a/africaus/africaus.keyboard_info
@@ -36,7 +36,6 @@
     "yo"
   ],
   "lastModifiedDate": "2014-08-08T16:37:56Z",
-  "links": [],
   "packageFilename": "africaus.kmp",
   "encodings": [
     "unicode"
@@ -49,7 +48,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 692,
-  "documentationFilename": "sil unicode keyboard chart for africa using shiftkeys.pdf"
+  }
 }

--- a/legacy/a/afro/afro.keyboard_info
+++ b/legacy/a/afro/afro.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "afro",
   "name": "AFRO",
-  "description": "Pour les langues d'Afrique de l'Ouest à partir d'un clavier français.\r\n\r\nTouches modificatrices \"<\" \">\"\r\nTouches mortes Ton Bas \",\" point souscrit \";\" Ton Haut \":\" Tilde souscrit \"!\" ...\r\n\r\nMali (bambara, bozo, dogon, songhoy, soninke, tamasheq)\r\nNiger (fulfulde, hausa, kanuri, t?majaq, so?ay-zarma)\r\nSénégal (bambara, balante, pulaar, serer, wolof, joola)\r\n",
+  "description": "Pour les langues d'Afrique de l'Ouest à partir d'un clavier français.\r\n\r\nTouches modificatrices \"<\" \">\"\r\nTouches mortes Ton Bas \",\" point souscrit \";\" Ton Haut \":\" Tilde souscrit \"!\" ...\r\n\r\nMali (bambara, bozo, dogon, songhoy, soninke, tamasheq)\r\nNiger (fulfulde, hausa, kanuri, t?majaq, so?ay-zarma)\r\nSénégal (bambara, balante, pulaar, serer, wolof, joola)\r\n\n<ul>\n  <li><a href='http://llacan.vjf.cnrs.fr'>CNRS-LLACAN</a></li>\n</ul>\n",
   "authorName": "LLACAN-CNRS",
   "license": "freeware",
   "languages": [
@@ -25,12 +25,6 @@
     "dje"
   ],
   "lastModifiedDate": "2006-02-23T11:16:46Z",
-  "links": [
-    {
-      "name": "CNRS-LLACAN",
-      "url": "http://llacan.vjf.cnrs.fr"
-    }
-  ],
   "packageFilename": "afro.kmp",
   "encodings": [
     "unicode"
@@ -43,7 +37,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 377,
-  "documentationFilename": "clavier afro.html"
+  }
 }

--- a/legacy/a/amazigh_lat.kmn/amazigh_lat.kmn.keyboard_info
+++ b/legacy/a/amazigh_lat.kmn/amazigh_lat.kmn.keyboard_info
@@ -31,7 +31,6 @@
     "zen"
   ],
   "lastModifiedDate": "2012-03-20T13:43:37Z",
-  "links": [],
   "packageFilename": "amazigh_lat.kmn.kmp",
   "encodings": [
     "unicode"
@@ -46,7 +45,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 626,
-  "documentationFilename": "amazigh keyboard help.pdf"
+  }
 }

--- a/legacy/a/amazigh_lat/amazigh_lat.keyboard_info
+++ b/legacy/a/amazigh_lat/amazigh_lat.keyboard_info
@@ -40,7 +40,6 @@
     "windows": "full",
     "macos": "full"
   },
-  "documentationFilename": "amazigh keyboard help.pdf",
   "related": {
     "amazigh_lat.kmn": {
       "deprecates": true

--- a/legacy/a/anii_2015_fr_pack2/anii_2015_fr_pack2.keyboard_info
+++ b/legacy/a/anii_2015_fr_pack2/anii_2015_fr_pack2.keyboard_info
@@ -8,7 +8,6 @@
     "blo"
   ],
   "lastModifiedDate": "2016-03-22T07:23:27Z",
-  "links": [],
   "packageFilename": "anii_2015_fr_pack2.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 700,
-  "documentationFilename": "anii_2015_fr-help.htm"
+  }
 }

--- a/legacy/a/aramaic/aramaic.keyboard_info
+++ b/legacy/a/aramaic/aramaic.keyboard_info
@@ -9,7 +9,6 @@
     "syc"
   ],
   "lastModifiedDate": "2007-12-20T19:18:30Z",
-  "links": [],
   "packageFilename": "aramaic.kmp",
   "encodings": [
     "unicode"
@@ -25,6 +24,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 417
+  }
 }

--- a/legacy/a/armenian unicode/armenian unicode.keyboard_info
+++ b/legacy/a/armenian unicode/armenian unicode.keyboard_info
@@ -8,7 +8,6 @@
     "hy"
   ],
   "lastModifiedDate": "2006-02-03T16:35:56Z",
-  "links": [],
   "packageFilename": "armenian unicode.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 376
+  }
 }

--- a/legacy/a/armenian/armenian.keyboard_info
+++ b/legacy/a/armenian/armenian.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "armenian",
   "name": "Armenian Unicode",
-  "description": "Replacement of standard 'Armenian Eastern' and 'Armenian Western' keyboard layouts, supplied with Windows XP. The standard ones do not work properly with non-Unicode applications, which use Unicode. These keyboards do. It can be used with standard fonts: Sylfaen or Arial Unicode MS.",
+  "description": "Replacement of standard 'Armenian Eastern' and 'Armenian Western' keyboard layouts, supplied with Windows XP. The standard ones do not work properly with non-Unicode applications, which use Unicode. These keyboards do. It can be used with standard fonts: Sylfaen or Arial Unicode MS.\n<ul>\n  <li><a href='http://www.popdict.com/'>Author's website</a></li>\n  <li><a href='http://www.popdict.com/clicks/clicks.php?uri=Armenian.kmp'>Armenian Eastern</a></li>\n  <li><a href='http://www.popdict.com/clicks/clicks.php?uri=Armenian_w.kmp'>Armenian Western</a></li>\n</ul>\n",
   "authorName": "Artyom Lukanin",
   "license": "freeware",
   "languages": [
     "hy"
   ],
   "lastModifiedDate": "2006-02-03T16:12:35Z",
-  "links": [
-    {
-      "name": "Author's website",
-      "url": "http://www.popdict.com/"
-    },
-    {
-      "name": "Armenian Eastern",
-      "url": "http://www.popdict.com/clicks/clicks.php?uri=Armenian.kmp"
-    },
-    {
-      "name": "Armenian Western",
-      "url": "http://www.popdict.com/clicks/clicks.php?uri=Armenian_w.kmp"
-    }
-  ],
   "packageFilename": "armenian.kmp",
   "encodings": [
     "unicode"
@@ -35,6 +21,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 301,
   "jsFilename": "armenian.js"
 }

--- a/legacy/a/australian/australian.keyboard_info
+++ b/legacy/a/australian/australian.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2012-01-23T17:56:51Z",
-  "links": [],
   "packageFilename": "australian.kmp",
   "encodings": [
     "unicode"
@@ -16,6 +15,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 636
+  }
 }

--- a/legacy/b/basiclao/basiclao.keyboard_info
+++ b/legacy/b/basiclao/basiclao.keyboard_info
@@ -8,7 +8,6 @@
     "lo"
   ],
   "lastModifiedDate": "2009-05-15T16:53:21Z",
-  "links": [],
   "packageFilename": "basiclao.kmp",
   "encodings": [
     "ansi"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 304
+  }
 }

--- a/legacy/b/benasm/benasm.keyboard_info
+++ b/legacy/b/benasm/benasm.keyboard_info
@@ -9,7 +9,6 @@
     "bn"
   ],
   "lastModifiedDate": "2006-10-09T15:14:17Z",
-  "links": [],
   "packageFilename": "benasm.kmp",
   "encodings": [
     "unicode"
@@ -18,7 +17,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 395,
-  "documentationFilename": "bangla asamiya keyboard layout.pdf"
+  }
 }

--- a/legacy/b/blackfoot_syllabics_u/blackfoot_syllabics_u.keyboard_info
+++ b/legacy/b/blackfoot_syllabics_u/blackfoot_syllabics_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "blackfoot_syllabics_u",
   "name": "Blackfoot Syllabics",
-  "description": "Keyboard layout mapping for typing Blackfoot in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.",
+  "description": "Keyboard layout mapping for typing Blackfoot in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/algon/keyboards/blackfoot_tr.kmp'>Blackfoot Unicode keyboard</a></li>\n  <li><a href='http://www.languagegeek.com/algon/keyboards/keymap_blackfoot_tr.html'>How to use Blackfoot keyboard/font package (Unicode)</a></li>\n  <li><a href='http://www.languagegeek.com/algon/keyboards/bf_kbds.html'>Keyboards for Blackfoot Syllabics</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,28 +9,6 @@
     "bla"
   ],
   "lastModifiedDate": "2012-01-23T17:57:04Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Blackfoot Unicode keyboard",
-      "url": "http://www.languagegeek.com/algon/keyboards/blackfoot_tr.kmp"
-    },
-    {
-      "name": "How to use Blackfoot keyboard/font package (Unicode)",
-      "url": "http://www.languagegeek.com/algon/keyboards/keymap_blackfoot_tr.html"
-    },
-    {
-      "name": "Keyboards for Blackfoot Syllabics",
-      "url": "http://www.languagegeek.com/algon/keyboards/bf_kbds.html"
-    }
-  ],
   "packageFilename": "blackfoot_syllabics_u.kmp",
   "encodings": [
     "unicode"
@@ -41,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 637
+  }
 }

--- a/legacy/b/bu/bu.keyboard_info
+++ b/legacy/b/bu/bu.keyboard_info
@@ -12,7 +12,6 @@
     "es"
   ],
   "lastModifiedDate": "2008-07-07T14:37:00Z",
-  "links": [],
   "packageFilename": "bu.kmp",
   "encodings": [
     "unicode",
@@ -27,6 +26,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 391
+  }
 }

--- a/legacy/b/buang/buang.keyboard_info
+++ b/legacy/b/buang/buang.keyboard_info
@@ -9,7 +9,6 @@
     "bzh"
   ],
   "lastModifiedDate": "2008-06-30T15:27:04Z",
-  "links": [],
   "packageFilename": "buang.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 439
+  }
 }

--- a/legacy/b/bukawa/bukawa.keyboard_info
+++ b/legacy/b/bukawa/bukawa.keyboard_info
@@ -8,7 +8,6 @@
     "buk"
   ],
   "lastModifiedDate": "2014-08-07T11:03:30Z",
-  "links": [],
   "packageFilename": "bukawa.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 683
+  }
 }

--- a/legacy/b/busau/busau.keyboard_info
+++ b/legacy/b/busau/busau.keyboard_info
@@ -11,7 +11,6 @@
     "bqp"
   ],
   "lastModifiedDate": "2011-08-09T09:38:02Z",
-  "links": [],
   "packageFilename": "busau.kmp",
   "encodings": [
     "unicode"
@@ -27,7 +26,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 429,
-  "documentationFilename": "welcome.htm"
+  }
 }

--- a/legacy/c/camazert/camazert.keyboard_info
+++ b/legacy/c/camazert/camazert.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "camazert",
   "name": "Cameroun AZERTY Legacy (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cameroon_azerty'>https://keyman.com/keyboards/sil_cameroon_azerty</a>. (This keyboard supports the languages of Cameroon with a single, standardized layout based on French AZERTY keyboard. Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and Unicode versions of these keyboards.)",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cameroon_azerty'>https://keyman.com/keyboards/sil_cameroon_azerty</a>. (This keyboard supports the languages of Cameroon with a single, standardized layout based on French AZERTY keyboard. Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and Unicode versions of these keyboards.)\n<ul>\n  <li><a href='http://cameroon.keymankeyboards.com/'>Cameroon Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd",
   "license": "freeware",
   "languages": [
@@ -249,12 +249,6 @@
     "zuy"
   ],
   "lastModifiedDate": "2008-06-30T15:10:45Z",
-  "links": [
-    {
-      "name": "Cameroon Keyboards Homepage",
-      "url": "http://cameroon.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "camazert.kmp",
   "encodings": [
     "ansi"
@@ -263,7 +257,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 437,
-  "documentationFilename": "cameroun azerty keyboard chart.pdf"
+  }
 }

--- a/legacy/c/cameroon azerty unicode/cameroon azerty unicode.keyboard_info
+++ b/legacy/c/cameroon azerty unicode/cameroon azerty unicode.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "cameroon azerty unicode",
   "name": "Cameroun AZERTY Unicode",
-  "description": "This keyboard supports the languages of Cameroon with a single, standardized layout based on French AZERTY keyboard layout. Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and legacy keyboards.",
+  "description": "This keyboard supports the languages of Cameroon with a single, standardized layout based on French AZERTY keyboard layout. Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and legacy keyboards.\n<ul>\n  <li><a href='http://cameroon.keymankeyboards.com/'>Cameroon Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd",
   "license": "freeware",
   "languages": [
@@ -249,12 +249,6 @@
     "zuy"
   ],
   "lastModifiedDate": "2008-06-30T15:10:48Z",
-  "links": [
-    {
-      "name": "Cameroon Keyboards Homepage",
-      "url": "http://cameroon.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "cameroon azerty unicode.kmp",
   "encodings": [
     "unicode"
@@ -268,7 +262,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 438,
-  "documentationFilename": "cameroun azerty unicode keyboard chart.pdf"
+  }
 }

--- a/legacy/c/cameroon qwerty non-u kbd-fonts/cameroon qwerty non-u kbd-fonts.keyboard_info
+++ b/legacy/c/cameroon qwerty non-u kbd-fonts/cameroon qwerty non-u kbd-fonts.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "cameroon qwerty non-u kbd-fonts",
   "name": "Cameroon QWERTY Legacy (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cameroon_qwerty'>https://keyman.com/keyboards/sil_cameroon_qwerty</a>. (This keyboard supports the languages of Cameroon with a single, standardized layout based on US English keyboard.  Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for a Unicode version and alternative layouts.)",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cameroon_qwerty'>https://keyman.com/keyboards/sil_cameroon_qwerty</a>. (This keyboard supports the languages of Cameroon with a single, standardized layout based on US English keyboard.  Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for a Unicode version and alternative layouts.)\n<ul>\n  <li><a href='http://cameroon.keymankeyboards.com/'>Cameroon Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd",
   "license": "freeware",
   "languages": [
@@ -249,12 +249,6 @@
     "zuy"
   ],
   "lastModifiedDate": "2008-06-30T15:10:38Z",
-  "links": [
-    {
-      "name": "Cameroon Keyboards Homepage",
-      "url": "http://cameroon.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "cameroon qwerty non-u kbd-fonts.kmp",
   "encodings": [
     "ansi"
@@ -268,7 +262,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 435,
-  "documentationFilename": "cameroon qwerty keyboard chart.pdf"
+  }
 }

--- a/legacy/c/cameroonqwertyunicode50/cameroonqwertyunicode50.keyboard_info
+++ b/legacy/c/cameroonqwertyunicode50/cameroonqwertyunicode50.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "cameroonqwertyunicode50",
   "name": "Cameroon QWERTY Unicode",
-  "description": "This keyboard supports the languages of Cameroon with a single, standardized layout based on US English keyboard.  Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and legacy keyboards.",
+  "description": "This keyboard supports the languages of Cameroon with a single, standardized layout based on US English keyboard.  Please see <a href='http://cameroon.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">cameroon.keymankeyboards.com</a> for alternative layouts and legacy keyboards.\n<ul>\n  <li><a href='http://cameroon.keymankeyboards.com/'>Cameroon Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd",
   "license": "freeware",
   "languages": [
@@ -249,12 +249,6 @@
     "zuy"
   ],
   "lastModifiedDate": "2010-10-22T08:26:29Z",
-  "links": [
-    {
-      "name": "Cameroon Keyboards Homepage",
-      "url": "http://cameroon.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "cameroonqwertyunicode50.kmp",
   "encodings": [
     "unicode"
@@ -270,6 +264,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 436
+  }
 }

--- a/legacy/c/cayuga_u/cayuga_u.keyboard_info
+++ b/legacy/c/cayuga_u/cayuga_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "cayuga_u",
   "name": "Cayuga Unicode",
-  "description": "Keyboard layout for typing Cayuga using Unicode fonts.",
+  "description": "Keyboard layout for typing Cayuga using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Cayuga Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "lre"
   ],
   "lastModifiedDate": "2012-01-23T17:57:22Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Cayuga Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "cayuga_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 307
+  }
 }

--- a/legacy/c/cherokee-nation-unicode/cherokee-nation-unicode.keyboard_info
+++ b/legacy/c/cherokee-nation-unicode/cherokee-nation-unicode.keyboard_info
@@ -8,7 +8,6 @@
     "chr"
   ],
   "lastModifiedDate": "2012-03-20T12:14:34Z",
-  "links": [],
   "packageFilename": "cherokee-nation-unicode.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 638
+  }
 }

--- a/legacy/c/cherokee6/cherokee6.keyboard_info
+++ b/legacy/c/cherokee6/cherokee6.keyboard_info
@@ -8,7 +8,6 @@
     "chr"
   ],
   "lastModifiedDate": "2012-01-23T17:57:35Z",
-  "links": [],
   "packageFilename": "cherokee6.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 639
+  }
 }

--- a/legacy/c/chey-unicode/chey-unicode.keyboard_info
+++ b/legacy/c/chey-unicode/chey-unicode.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "chey-unicode",
   "name": "Cheyenne Unicode",
-  "description": "Type Cheyenne language using the special symbols of the modern Cheyenne alphabet.\r\n\r\nAn Unicode version of the original Cheyenne keyboard.",
+  "description": "Type Cheyenne language using the special symbols of the modern Cheyenne alphabet.\r\n\r\nAn Unicode version of the original Cheyenne keyboard.\n<ul>\n  <li><a href='http://webspace.webring.com/people/cc/cheyenne_language/'>Cheyenne language website</a></li>\n</ul>\n",
   "authorName": "Wayne Leman",
   "license": "freeware",
   "languages": [
     "chy"
   ],
   "lastModifiedDate": "2014-05-15T16:37:02Z",
-  "links": [
-    {
-      "name": "Cheyenne language website",
-      "url": "http://webspace.webring.com/people/cc/cheyenne_language/"
-    }
-  ],
   "packageFilename": "chey-unicode.kmp",
   "encodings": [
     "unicode"
@@ -21,7 +15,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 680,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/legacy/c/cheyenne/cheyenne.keyboard_info
+++ b/legacy/c/cheyenne/cheyenne.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "cheyenne",
   "name": "Cheyenne (obsolete)",
-  "description": "Cheyenne - historical research. This keyboard requires fonts no longer available. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cheyenne/'>https://keyman.com/keyboards/sil_cheyenne/</a>.",
+  "description": "Cheyenne - historical research. This keyboard requires fonts no longer available. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_cheyenne/'>https://keyman.com/keyboards/sil_cheyenne/</a>.\n<ul>\n  <li><a href='http://webspace.webring.com/people/cc/cheyenne_language/'>Cheyenne language website</a></li>\n</ul>\n",
   "authorName": "Wayne Leman",
   "license": "freeware",
   "languages": [
     "chy"
   ],
   "lastModifiedDate": "2010-05-21T15:53:28Z",
-  "links": [
-    {
-      "name": "Cheyenne language website",
-      "url": "http://webspace.webring.com/people/cc/cheyenne_language/"
-    }
-  ],
   "packageFilename": "cheyenne.kmp",
   "encodings": [
     "ansi"
@@ -21,7 +15,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 308,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/legacy/c/clavier du burkina/clavier du burkina.keyboard_info
+++ b/legacy/c/clavier du burkina/clavier du burkina.keyboard_info
@@ -36,7 +36,6 @@
     "taq"
   ],
   "lastModifiedDate": "2008-01-04T12:15:58Z",
-  "links": [],
   "packageFilename": "clavier du burkina.kmp",
   "encodings": [
     "unicode"
@@ -50,7 +49,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 412,
-  "documentationFilename": "clavier du burkina.pdf"
+  }
 }

--- a/legacy/c/creekeysdesktop3/creekeysdesktop3.keyboard_info
+++ b/legacy/c/creekeysdesktop3/creekeysdesktop3.keyboard_info
@@ -8,7 +8,6 @@
     "crj"
   ],
   "lastModifiedDate": "2009-02-13T15:56:03Z",
-  "links": [],
   "packageFilename": "creekeysdesktop3.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 470
+  }
 }

--- a/legacy/c/cs-pinyin/cs-pinyin.keyboard_info
+++ b/legacy/c/cs-pinyin/cs-pinyin.keyboard_info
@@ -8,7 +8,6 @@
     "cmn"
   ],
   "lastModifiedDate": "2011-11-14T16:23:11Z",
-  "links": [],
   "packageFilename": "cs-pinyin.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 355
+  }
 }

--- a/legacy/d/dakelh1_u/dakelh1_u.keyboard_info
+++ b/legacy/d/dakelh1_u/dakelh1_u.keyboard_info
@@ -8,7 +8,6 @@
     "crx"
   ],
   "lastModifiedDate": "2012-01-23T17:57:46Z",
-  "links": [],
   "packageFilename": "dakelh1_u.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 641
+  }
 }

--- a/legacy/d/dakelh2_u/dakelh2_u.keyboard_info
+++ b/legacy/d/dakelh2_u/dakelh2_u.keyboard_info
@@ -8,7 +8,6 @@
     "crx"
   ],
   "lastModifiedDate": "2012-01-23T17:57:55Z",
-  "links": [],
   "packageFilename": "dakelh2_u.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 642
+  }
 }

--- a/legacy/d/dene_a/dene_a.keyboard_info
+++ b/legacy/d/dene_a/dene_a.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "dene_a",
   "name": "Dene A",
-  "description": "A keyboard layout for typing Athapascan languages like Dene and Slavey.  \r\n",
+  "description": "A keyboard layout for typing Athapascan languages like Dene and Slavey.  \r\n\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/dene/keyboards/ndene.html'>Unicode Keyboards for Dene family languages</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "scs"
   ],
   "lastModifiedDate": "2012-01-23T17:58:01Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Unicode Keyboards for Dene family languages",
-      "url": "http://www.languagegeek.com/dene/keyboards/ndene.html"
-    }
-  ],
   "packageFilename": "dene_a.kmp",
   "encodings": [
     "unicode"
@@ -37,6 +23,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 313,
   "jsFilename": "dene_a.js"
 }

--- a/legacy/d/dene_c/dene_c.keyboard_info
+++ b/legacy/d/dene_c/dene_c.keyboard_info
@@ -9,7 +9,6 @@
     "scs"
   ],
   "lastModifiedDate": "2012-01-23T17:58:07Z",
-  "links": [],
   "packageFilename": "dene_c.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 643,
   "jsFilename": "dene_c.js"
 }

--- a/legacy/d/devu-mikes/devu-mikes.keyboard_info
+++ b/legacy/d/devu-mikes/devu-mikes.keyboard_info
@@ -12,7 +12,6 @@
     "sa"
   ],
   "lastModifiedDate": "2006-08-04T13:06:13Z",
-  "links": [],
   "packageFilename": "devu-mikes.kmp",
   "encodings": [
     "unicode"
@@ -26,7 +25,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 392,
-  "documentationFilename": "devu-mikes keyboard layout.pdf"
+  }
 }

--- a/legacy/d/diitiidatx_u/diitiidatx_u.keyboard_info
+++ b/legacy/d/diitiidatx_u/diitiidatx_u.keyboard_info
@@ -8,7 +8,6 @@
     "myh"
   ],
   "lastModifiedDate": "2013-04-12T15:44:12Z",
-  "links": [],
   "packageFilename": "diitiidatx_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 660,
-  "documentationFilename": "diitiidatx - basic usage.pdf"
+  }
 }

--- a/legacy/d/dlia25bas/dlia25bas.keyboard_info
+++ b/legacy/d/dlia25bas/dlia25bas.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "dlia25bas",
   "name": "Dinka",
-  "description": "This keyboard provides input mapping for typing Dinka, using Unicode fonts.",
+  "description": "This keyboard provides input mapping for typing Dinka, using Unicode fonts.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/dinka'>OpenRoad Dinka Home page</a></li>\n</ul>\n",
   "authorName": "Andrew Cunningham",
   "license": "freeware",
   "languages": [
@@ -12,12 +12,6 @@
     "dik"
   ],
   "lastModifiedDate": "2014-08-08T16:57:19Z",
-  "links": [
-    {
-      "name": "OpenRoad Dinka Home page",
-      "url": "http://www.openroad.net.au/languages/dinka"
-    }
-  ],
   "packageFilename": "dlia25bas.kmp",
   "encodings": [
     "unicode"
@@ -35,7 +29,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 314,
-  "jsFilename": "dlia25bas.js",
-  "documentationFilename": "dliabasic25.pdf"
+  "jsFilename": "dlia25bas.js"
 }

--- a/legacy/d/dvsp/dvsp.keyboard_info
+++ b/legacy/d/dvsp/dvsp.keyboard_info
@@ -8,7 +8,6 @@
     "es"
   ],
   "lastModifiedDate": "2011-08-04T15:38:38Z",
-  "links": [],
   "packageFilename": "dvsp.kmp",
   "packageIncludes": [
     "documentation",
@@ -20,7 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 357,
-  "documentationFilename": "welcome.htm"
+  }
 }

--- a/legacy/d/dzongkha/dzongkha.keyboard_info
+++ b/legacy/d/dzongkha/dzongkha.keyboard_info
@@ -8,7 +8,6 @@
     "dz"
   ],
   "lastModifiedDate": "2012-06-01T15:15:37Z",
-  "links": [],
   "packageFilename": "dzongkha.kmp",
   "encodings": [
     "unicode"
@@ -26,7 +25,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 652,
-  "jsFilename": "dzongkha.js",
-  "documentationFilename": "welcome.pdf"
+  "jsFilename": "dzongkha.js"
 }

--- a/legacy/e/easy chakma new/easy chakma new.keyboard_info
+++ b/legacy/e/easy chakma new/easy chakma new.keyboard_info
@@ -8,7 +8,6 @@
     "ccp"
   ],
   "lastModifiedDate": "2016-07-12T16:32:55Z",
-  "links": [],
   "packageFilename": "easy chakma new.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 703
+  }
 }

--- a/legacy/e/ecgunicode/ecgunicode.keyboard_info
+++ b/legacy/e/ecgunicode/ecgunicode.keyboard_info
@@ -18,7 +18,6 @@
     "tmv"
   ],
   "lastModifiedDate": "2007-02-08T13:59:12Z",
-  "links": [],
   "packageFilename": "ecgunicode.kmp",
   "encodings": [
     "unicode"
@@ -31,7 +30,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 402,
-  "documentationFilename": "ecgkeymankeyboardlayout.pdf"
+  }
 }

--- a/legacy/e/enhlao/enhlao.keyboard_info
+++ b/legacy/e/enhlao/enhlao.keyboard_info
@@ -8,7 +8,6 @@
     "lo"
   ],
   "lastModifiedDate": "2012-02-07T10:43:41Z",
-  "links": [],
   "packageFilename": "enhlao.kmp",
   "encodings": [
     "ansi"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 315
+  }
 }

--- a/legacy/e/esperanto/esperanto.keyboard_info
+++ b/legacy/e/esperanto/esperanto.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "esperanto",
   "name": "Esperanto AltGr",
-  "description": "Type Esperanto (in Unicode-aware applications) using following 'x' and/or ctrl/alt/shift combinations to add accents. (Windows XP/2000/NT4 only)",
+  "description": "Type Esperanto (in Unicode-aware applications) using following 'x' and/or ctrl/alt/shift combinations to add accents. (Windows XP/2000/NT4 only)\n<ul>\n  <li><a href='http://www.bekasoft.com/'>Author's website</a></li>\n</ul>\n",
   "authorName": "Koen Bekaert",
   "license": "freeware",
   "languages": [
     "eo"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [
-    {
-      "url": "http://www.bekasoft.com/",
-      "name": "Author's website"
-    }
-  ],
   "packageFilename": "esperanto.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +15,5 @@
   "version": "1.0",
   "platformSupport": {
     "windows": "basic"
-  },
-  "legacyId": 316
+  }
 }

--- a/legacy/e/esperantohx/esperantohx.keyboard_info
+++ b/legacy/e/esperantohx/esperantohx.keyboard_info
@@ -8,7 +8,6 @@
     "eo"
   ],
   "lastModifiedDate": "2014-08-08T16:17:32Z",
-  "links": [],
   "packageFilename": "esperantohx.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 684
+  }
 }

--- a/legacy/e/european/european.keyboard_info
+++ b/legacy/e/european/european.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "european",
   "name": "EuroLatin keyboard",
-  "description": "<p>This keyboard enables simple input of all European Latin-script languages and most Latin-script languages from around the world. The keyboard uses key sequences to access diacritics and other letters not available on a standard keyboard. It has been designed for use with any Latin hardware keyboard.</p>    \r\n<p><a href='http://keymanweb.com/#eng,Keyboard_european2'>Try this keyboard online now with KeymanWeb!</a> (no download required)</p>  ",
+  "description": "<p>This keyboard enables simple input of all European Latin-script languages and most Latin-script languages from around the world. The keyboard uses key sequences to access diacritics and other letters not available on a standard keyboard. It has been designed for use with any Latin hardware keyboard.</p>    \r\n<p><a href='http://keymanweb.com/#eng,Keyboard_european2'>Try this keyboard online now with KeymanWeb!</a> (no download required)</p>  \n<ul>\n  <li><a href='http://keyman.com/eurolatin'>EuroLatin Homepage</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd",
   "license": "freeware",
   "languages": [
@@ -406,12 +406,6 @@
     "zu"
   ],
   "lastModifiedDate": "2015-03-30T08:41:10Z",
-  "links": [
-    {
-      "name": "EuroLatin Homepage",
-      "url": "http://keyman.com/eurolatin"
-    }
-  ],
   "packageFilename": "european.kmp",
   "encodings": [
     "unicode"
@@ -430,7 +424,5 @@
     "android": "none",
     "macos": "full"
   },
-  "legacyId": 348,
-  "jsFilename": "european.js",
-  "documentationFilename": "eurolatin1.6.pdf"
+  "jsFilename": "european.js"
 }

--- a/legacy/e/ezrasil251/ezrasil251.keyboard_info
+++ b/legacy/e/ezrasil251/ezrasil251.keyboard_info
@@ -9,7 +9,6 @@
     "hbo"
   ],
   "lastModifiedDate": "2014-08-08T16:18:00Z",
-  "links": [],
   "packageFilename": "ezrasil251.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 685,
-  "documentationFilename": "ezra sil keyboard chart2.4.pdf"
+  }
 }

--- a/legacy/f/farsi_unicode/farsi_unicode.keyboard_info
+++ b/legacy/f/farsi_unicode/farsi_unicode.keyboard_info
@@ -8,7 +8,6 @@
     "pes"
   ],
   "lastModifiedDate": "2008-03-24T21:17:25Z",
-  "links": [],
   "packageFilename": "farsi_unicode.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 318
+  }
 }

--- a/legacy/g/galaxiebiblescriptmnemonic/galaxiebiblescriptmnemonic.keyboard_info
+++ b/legacy/g/galaxiebiblescriptmnemonic/galaxiebiblescriptmnemonic.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "galaxiebiblescriptmnemonic",
   "name": "Galaxie BibleScript Mnemonic Keyboards",
-  "description": "Now optimised for European and US hardware keyboards, <a href='http://www.galaxie.com/' target='_blank'>Galaxie</a> BibleScript Mnemonic is the perfect toolkit for the Bible Scholar who needs to publish documents in Classical Greek and Biblical Hebrew. The BibleScript Unicode package includes Unicode fonts and keyboard layouts for typing in both languages.\r\n\r\n</p><p>\r\n\r\nThis package is a subset of the original BibleScript package.  Please visit <a href='http://www.galaxie.com/' target='_blank'>www.galaxie.com</a> for more details.</p>",
+  "description": "Now optimised for European and US hardware keyboards, <a href='http://www.galaxie.com/' target='_blank'>Galaxie</a> BibleScript Mnemonic is the perfect toolkit for the Bible Scholar who needs to publish documents in Classical Greek and Biblical Hebrew. The BibleScript Unicode package includes Unicode fonts and keyboard layouts for typing in both languages.\r\n\r\n</p><p>\r\n\r\nThis package is a subset of the original BibleScript package.  Please visit <a href='http://www.galaxie.com/' target='_blank'>www.galaxie.com</a> for more details.</p>\n<ul>\n  <li><a href='http://www.galaxie.com/'>Galaxie Website</a></li>\n  <li><a href='http://help.keyman.com/keyboard/galaxiebiblescriptmnemonic/1.0/galaxiebiblescriptmnemonic.php'>Online Keyboard Help</a></li>\n</ul>\n",
   "authorName": "Hampton Keathley",
   "license": "freeware",
   "languages": [
@@ -15,16 +15,6 @@
     "yej"
   ],
   "lastModifiedDate": "2014-08-08T16:57:26Z",
-  "links": [
-    {
-      "name": "Galaxie Website",
-      "url": "http://www.galaxie.com/"
-    },
-    {
-      "name": "Online Keyboard Help",
-      "url": "http://help.keyman.com/keyboard/galaxiebiblescriptmnemonic/1.0/galaxiebiblescriptmnemonic.php"
-    }
-  ],
   "packageFilename": "galaxiebiblescriptmnemonic.kmp",
   "encodings": [
     "unicode"
@@ -40,7 +30,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 629,
-  "documentationFilename": "readme.htm"
+  }
 }

--- a/legacy/g/galaxiegreekandhebrew/galaxiegreekandhebrew.keyboard_info
+++ b/legacy/g/galaxiegreekandhebrew/galaxiegreekandhebrew.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "galaxiegreekandhebrew",
   "name": "Galaxie BibleScript Phonetic Keyboards",
-  "description": "<a href='http://www.galaxie.com/' target='_blank'>Galaxie</a> BibleScript Phonetic is the perfect toolkit for the Bible Scholar who needs to publish documents in Classical Greek and Biblical Hebrew. The BibleScript Unicode package includes Unicode fonts and keyboard layouts for typing in both languages.\r\n\r\n</p><p>\r\n\r\nThis package is a subset of the original BibleScript package.  Please visit <a href='http://www.galaxie.com/' target='_blank'>www.galaxie.com</a> for more details.</p>",
+  "description": "<a href='http://www.galaxie.com/' target='_blank'>Galaxie</a> BibleScript Phonetic is the perfect toolkit for the Bible Scholar who needs to publish documents in Classical Greek and Biblical Hebrew. The BibleScript Unicode package includes Unicode fonts and keyboard layouts for typing in both languages.\r\n\r\n</p><p>\r\n\r\nThis package is a subset of the original BibleScript package.  Please visit <a href='http://www.galaxie.com/' target='_blank'>www.galaxie.com</a> for more details.</p>\n<ul>\n  <li><a href='http://www.galaxie.com/'>Galaxie Home Page</a></li>\n  <li><a href='http://www.tavultesoft.com/greek/'>Greek Keyboards Home Page</a></li>\n</ul>\n",
   "authorName": "Hampton Keathley",
   "license": "freeware",
   "languages": [
@@ -11,16 +11,6 @@
     "hbo"
   ],
   "lastModifiedDate": "2011-09-05T15:55:30Z",
-  "links": [
-    {
-      "name": "Galaxie Home Page",
-      "url": "http://www.galaxie.com/"
-    },
-    {
-      "name": "Greek Keyboards Home Page",
-      "url": "http://www.tavultesoft.com/greek/"
-    }
-  ],
   "packageFilename": "galaxiegreekandhebrew.kmp",
   "encodings": [
     "unicode"
@@ -36,7 +26,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 413,
-  "documentationFilename": "manual.pdf"
+  }
 }

--- a/legacy/g/gandhari-keyboard-2.7/gandhari-keyboard-2.7.keyboard_info
+++ b/legacy/g/gandhari-keyboard-2.7/gandhari-keyboard-2.7.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "gandhari-keyboard-2.7",
   "name": "Gandhari Unicode",
-  "description": "Gandhari Sanskrit Unicode keyboard for Latin alphabet transliteration.  Gandhari Unicode 5.1 font recommended (see link below).",
+  "description": "Gandhari Sanskrit Unicode keyboard for Latin alphabet transliteration.  Gandhari Unicode 5.1 font recommended (see link below).\n<ul>\n  <li><a href='http://ebmp.org/downloads/Gandhari-Keyboard_Keyman.pdf'>Keyboard layout and description</a></li>\n  <li><a href='http://ebmp.org/index.php'>About Gandhari manuscripts</a></li>\n  <li><a href='http://andrewglass.org/download.php?fname=gu5-110_ttf&extn=zip'>Gandhari Unicode 5.1 Font</a></li>\n</ul>\n",
   "authorName": "Andrew Glass",
   "license": "freeware",
   "languages": [
     "sa"
   ],
   "lastModifiedDate": "2011-10-21T08:43:45Z",
-  "links": [
-    {
-      "name": "Keyboard layout and description",
-      "url": "http://ebmp.org/downloads/Gandhari-Keyboard_Keyman.pdf"
-    },
-    {
-      "name": "About Gandhari manuscripts",
-      "url": "http://ebmp.org/index.php"
-    },
-    {
-      "name": "Gandhari Unicode 5.1 Font",
-      "url": "http://andrewglass.org/download.php?fname=gu5-110_ttf&extn=zip"
-    }
-  ],
   "packageFilename": "gandhari-keyboard-2.7.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 398,
-  "documentationFilename": "gandhari-keyboard_keyman.pdf"
+  }
 }

--- a/legacy/g/garpsinhala/garpsinhala.keyboard_info
+++ b/legacy/g/garpsinhala/garpsinhala.keyboard_info
@@ -8,7 +8,6 @@
     "si"
   ],
   "lastModifiedDate": "2010-08-20T08:37:30Z",
-  "links": [],
   "packageFilename": "garpsinhala.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 625,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/legacy/g/gensalish/gensalish.keyboard_info
+++ b/legacy/g/gensalish/gensalish.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2013-03-22T14:34:54Z",
-  "links": [],
   "packageFilename": "gensalish.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 658
+  }
 }

--- a/legacy/g/gensalishu/gensalishu.keyboard_info
+++ b/legacy/g/gensalishu/gensalishu.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2012-03-23T08:21:19Z",
-  "links": [],
   "packageFilename": "gensalishu.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 650
+  }
 }

--- a/legacy/g/georgian/georgian.keyboard_info
+++ b/legacy/g/georgian/georgian.keyboard_info
@@ -8,7 +8,6 @@
     "ka"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "georgian.kmp",
   "encodings": [
     "unicode"
@@ -20,7 +19,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 319,
-  "jsFilename": "georgian.js",
-  "documentationFilename": "readme.txt"
+  "jsFilename": "georgian.js"
 }

--- a/legacy/g/ghanakeyboards/ghanakeyboards.keyboard_info
+++ b/legacy/g/ghanakeyboards/ghanakeyboards.keyboard_info
@@ -13,7 +13,6 @@
     "nzi"
   ],
   "lastModifiedDate": "2010-01-12T10:02:43Z",
-  "links": [],
   "packageFilename": "ghanakeyboards.kmp",
   "encodings": [
     "unicode"
@@ -27,6 +26,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 621
+  }
 }

--- a/legacy/g/gitsenimx_u/gitsenimx_u.keyboard_info
+++ b/legacy/g/gitsenimx_u/gitsenimx_u.keyboard_info
@@ -8,7 +8,6 @@
     "git"
   ],
   "lastModifiedDate": "2012-01-23T17:58:12Z",
-  "links": [],
   "packageFilename": "gitsenimx_u.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 644
+  }
 }

--- a/legacy/g/greek polytonic sa/greek polytonic sa.keyboard_info
+++ b/legacy/g/greek polytonic sa/greek polytonic sa.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "greek polytonic sa",
   "name": "Greek Polytonic SA",
-  "description": "A very complete Greek Polytonic keyboard for serious students of classical and modern Greek.",
+  "description": "A very complete Greek Polytonic keyboard for serious students of classical and modern Greek.\n<ul>\n  <li><a href='http://www.stanthonysmonastery.org/GreekPolytonic.htm'>Greek Polytonic SA Keyboard</a></li>\n</ul>\n",
   "authorName": "St. Anthony's Greek Orthodox Monastery",
   "license": "freeware",
   "languages": [
     "el"
   ],
   "lastModifiedDate": "2009-12-21T12:14:15Z",
-  "links": [
-    {
-      "name": "Greek Polytonic SA Keyboard",
-      "url": "http://www.stanthonysmonastery.org/GreekPolytonic.htm"
-    }
-  ],
   "packageFilename": "greek polytonic sa.kmp",
   "encodings": [
     "unicode"
@@ -28,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 320
+  }
 }

--- a/legacy/g/grkpoly2/grkpoly2.keyboard_info
+++ b/legacy/g/grkpoly2/grkpoly2.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "grkpoly2",
   "name": "Greek Polytonic Unicode",
-  "description": "This keyboard enables the user to enter polytonic Greek using any of the\ncurrently available Unicode Greek fonts.  The basic alphabet follows the\nmodern Greek keyboard; additional keystrokes have been added for polytonic\naccents and Coptic letters. \n\nThis keyboard is free for personal or educational use; commercial users should\ncontact the author for a licence.",
+  "description": "This keyboard enables the user to enter polytonic Greek using any of the\ncurrently available Unicode Greek fonts.  The basic alphabet follows the\nmodern Greek keyboard; additional keystrokes have been added for polytonic\naccents and Coptic letters. \n\nThis keyboard is free for personal or educational use; commercial users should\ncontact the author for a licence.\n<ul>\n  <li><a href='http://scholarsfonts.net/contact.html'>Author's contact information</a></li>\n  <li><a href='http://scholarsfonts.net'>Author's homepage</a></li>\n  <li><a href='https://keyman.com/greek/'>Greek Keyboards Home Page</a></li>\n</ul>\n",
   "authorName": "David J. Perry",
   "license": "other",
   "languages": [
@@ -10,20 +10,6 @@
     "cop-Grek"
   ],
   "lastModifiedDate": "2010-05-21T15:54:24Z",
-  "links": [
-    {
-      "name": "Author's contact information",
-      "url": "http://scholarsfonts.net/contact.html"
-    },
-    {
-      "name": "Author's homepage",
-      "url": "http://scholarsfonts.net"
-    },
-    {
-      "name": "Greek Keyboards Home Page",
-      "url": "https://keyman.com/greek/"
-    }
-  ],
   "packageFilename": "grkpoly2.kmp",
   "encodings": [
     "unicode"
@@ -43,6 +29,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 321,
   "jsFilename": "grkpoly2.js"
 }

--- a/legacy/g/grkpolycompv103/grkpolycompv103.keyboard_info
+++ b/legacy/g/grkpolycompv103/grkpolycompv103.keyboard_info
@@ -9,7 +9,6 @@
     "grc"
   ],
   "lastModifiedDate": "2014-08-08T16:18:14Z",
-  "links": [],
   "packageFilename": "grkpolycompv103.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 686,
-  "documentationFilename": "greek poly comp kbrd layout.pdf"
+  }
 }

--- a/legacy/gff/gff-amh-powerpack-7/gff-amh-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-amh-powerpack-7/gff-amh-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-amh-powerpack-7",
   "name": "GFF Amharic Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Amharic with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  ",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Amharic with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  \n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "am"
   ],
   "lastModifiedDate": "2012-03-20T10:58:47Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-amh-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 455,
-  "documentationFilename": "amharictyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-awn-powerpack-7/gff-awn-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-awn-powerpack-7/gff-awn-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-awn-powerpack-7",
   "name": "GFF Awngi Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Awngi with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>    ",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Awngi with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>    \n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "awn"
   ],
   "lastModifiedDate": "2012-03-20T10:58:49Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-awn-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 456,
-  "documentationFilename": "awngityping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-bcq-powerpack-7/gff-bcq-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-bcq-powerpack-7/gff-bcq-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-bcq-powerpack-7",
   "name": "GFF Bench Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Bench with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Bench with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "bcq"
   ],
   "lastModifiedDate": "2012-03-20T10:58:51Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-bcq-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 457,
-  "documentationFilename": "benchtyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-byn-powerpack-7/gff-byn-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-byn-powerpack-7/gff-byn-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-byn-powerpack-7",
   "name": "GFF Blin Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Bilen (Blin) with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "byn"
   ],
   "lastModifiedDate": "2012-03-20T10:58:53Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-byn-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 458,
-  "documentationFilename": "blintyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-gez-powerpack-7/gff-gez-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-gez-powerpack-7/gff-gez-powerpack-7.keyboard_info
@@ -1,18 +1,12 @@
 {
   "name": "GFF Ge'ez Language Keyboard + Font Power Pack",
-  "description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b> Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>    <p>For Amharic, use the  <a href='http://keyman.com/keyboards/gff_amharic'>GFF Amharic</a> keyboard. The Ge'ez keyboard cannot be used for Amharic.</p>    <p><a href='https://keyman.com/amharic/'>Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>This is a Geez (Ge'ez) language keyboard where the letters available are restricted to only those used in the Ge'ez language. <b>The additional letters used in modern Ethiopic languages are not available from the keyboard.</b> Thus these letters cannot be accidentally typed when composing a Ge'ez language document.</p>    <p>For Amharic, use the  <a href='http://keyman.com/keyboards/gff_amharic'>GFF Amharic</a> keyboard. The Ge'ez keyboard cannot be used for Amharic.</p>    <p><a href='https://keyman.com/amharic/'>Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "gez"
   ],
   "lastModifiedDate": "2012-03-20T10:59:00Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-gez-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -28,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 461,
-  "documentationFilename": "geeztyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-mym-powerpack-7/gff-mym-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-mym-powerpack-7/gff-mym-powerpack-7.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "gff-mym-powerpack-7",
   "name": "GFF Me'en/Mursi/Suri/Dizi Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Me'en, Mursi, Suri or Dizi with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Me'en, Mursi, Suri or Dizi with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
@@ -11,12 +11,6 @@
     "suq"
   ],
   "lastModifiedDate": "2012-03-20T10:59:03Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-mym-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +26,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 462,
-  "documentationFilename": "meentyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-sgw-powerpack-7/gff-sgw-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-sgw-powerpack-7/gff-sgw-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-sgw-powerpack-7",
   "name": "GFF Sebatbeit Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Sebat Bet Gurage (Sebatbeit) with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  ",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Sebat Bet Gurage (Sebatbeit) with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  \n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "sgw"
   ],
   "lastModifiedDate": "2012-03-20T10:59:05Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-sgw-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 463,
-  "documentationFilename": "sebatbeittyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-tir-er-powerpack-7/gff-tir-er-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-tir-er-powerpack-7/gff-tir-er-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-tir-er-powerpack-7",
   "name": "GFF Eritrean-Tigrinya Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Eritrean Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Eritrean Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "ti"
   ],
   "lastModifiedDate": "2012-11-16T15:40:56Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-tir-er-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 459,
-  "documentationFilename": "tigrinyaertyping-english.pdf"
+  }
 }

--- a/legacy/gff/gff-tir-et-powerpack-7/gff-tir-et-powerpack-7.keyboard_info
+++ b/legacy/gff/gff-tir-et-powerpack-7/gff-tir-et-powerpack-7.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "gff-tir-et-powerpack-7",
   "name": "GFF Ethiopian-Tigrinya Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Ethiopian Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Ethiopian Tigrinya with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "ti"
   ],
   "lastModifiedDate": "2012-11-16T15:41:08Z",
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
-  ],
   "packageFilename": "gff-tir-et-powerpack-7.kmp",
   "encodings": [
     "unicode"
@@ -28,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 460,
-  "documentationFilename": "tigrinyaettyping-english.pdf"
+  }
 }

--- a/legacy/h/haida_u/haida_u.keyboard_info
+++ b/legacy/h/haida_u/haida_u.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "haida_u",
   "name": "Haida Unicode",
-  "description": "A keyboard for typing Haida. ",
+  "description": "A keyboard for typing Haida. \n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/isolate/xaadas.html'>Haida Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "hdn"
   ],
   "lastModifiedDate": "2012-01-23T17:58:19Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Haida Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/isolate/xaadas.html"
-    }
-  ],
   "packageFilename": "haida_u.kmp",
   "encodings": [
     "unicode"
@@ -32,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 322
+  }
 }

--- a/legacy/h/haisla_u/haisla_u.keyboard_info
+++ b/legacy/h/haisla_u/haisla_u.keyboard_info
@@ -8,7 +8,6 @@
     "has"
   ],
   "lastModifiedDate": "2013-04-12T15:44:28Z",
-  "links": [],
   "packageFilename": "haisla_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 661,
-  "documentationFilename": "haisla - basic usage.pdf"
+  }
 }

--- a/legacy/h/halqemeylem_u/halqemeylem_u.keyboard_info
+++ b/legacy/h/halqemeylem_u/halqemeylem_u.keyboard_info
@@ -8,9 +8,7 @@
     "hur"
   ],
   "lastModifiedDate": "2013-04-12T15:44:39Z",
-  "links": [],
   "packageFilename": "halqemeylem_u.kmp",
-  "documentationFilename": "halqemeylem - basic usage.pdf",
   "encodings": [
     "unicode"
   ],
@@ -20,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 662
+  }
 }

--- a/legacy/h/hararab/hararab.keyboard_info
+++ b/legacy/h/hararab/hararab.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "hararab",
   "name": "Harari (Arabi harfi)",
-  "description": "This keyboard layout was designed for use with the revised Harari Arabic orthography. It uses the Unified Harari keyboard layout and is suitable for people who are familiar with the revised Harari Latin orthography.",
+  "description": "This keyboard layout was designed for use with the revised Harari Arabic orthography. It uses the Unified Harari keyboard layout and is suitable for people who are familiar with the revised Harari Latin orthography.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/harari/'>Open Road Harari resources</a></li>\n</ul>\n",
   "authorName": "Vicnet, State Library of Victoria",
   "license": "freeware",
   "languages": [
     "har"
   ],
   "lastModifiedDate": "2009-10-23T08:21:23Z",
-  "links": [
-    {
-      "name": "Open Road Harari resources",
-      "url": "http://www.openroad.net.au/languages/african/harari/"
-    }
-  ],
   "packageFilename": "hararab.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 616,
-  "documentationFilename": "harari-keyman-20-20090422.pdf"
+  }
 }

--- a/legacy/h/hararabalt/hararabalt.keyboard_info
+++ b/legacy/h/hararabalt/hararabalt.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "hararabalt",
   "name": "Harari (Arabi muxxi harfi)",
-  "description": "This keyboard is an alternative layout for the revised Harari Arabic orthography. It is derived from the standard Arabic 101 keyboard layout and is suitable for typing in Harari and Arabic.",
+  "description": "This keyboard is an alternative layout for the revised Harari Arabic orthography. It is derived from the standard Arabic 101 keyboard layout and is suitable for typing in Harari and Arabic.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/harari/'>Open Road Harari support</a></li>\n</ul>\n",
   "authorName": "Vicnet, State Library of Victoria",
   "license": "freeware",
   "languages": [
     "har"
   ],
   "lastModifiedDate": "2010-05-21T15:54:38Z",
-  "links": [
-    {
-      "name": "Open Road Harari support",
-      "url": "http://www.openroad.net.au/languages/african/harari/"
-    }
-  ],
   "packageFilename": "hararabalt.kmp",
   "encodings": [
     "unicode"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 620
+  }
 }

--- a/legacy/h/harethi/harethi.keyboard_info
+++ b/legacy/h/harethi/harethi.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "harethi",
   "name": "Harari (Sabai harfi)",
-  "description": "This keyboard layout was designed for use with the \r\nrevised Harari Ethiopic orthography. It uses the Unified Harari keyboard layout and is suitable for people who are familiar with the revised Harari Latin orthography.",
+  "description": "This keyboard layout was designed for use with the \r\nrevised Harari Ethiopic orthography. It uses the Unified Harari keyboard layout and is suitable for people who are familiar with the revised Harari Latin orthography.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/harari/'>Open Road: Harari resources</a></li>\n</ul>\n",
   "authorName": "Vicnet, State Library of Victoria",
   "license": "freeware",
   "languages": [
     "har"
   ],
   "lastModifiedDate": "2009-10-23T08:22:14Z",
-  "links": [
-    {
-      "name": "Open Road: Harari resources",
-      "url": "http://www.openroad.net.au/languages/african/harari/"
-    }
-  ],
   "packageFilename": "harethi.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 615,
-  "documentationFilename": "harari-keyman-20-20090422.pdf"
+  }
 }

--- a/legacy/h/harethialt/harethialt.keyboard_info
+++ b/legacy/h/harethialt/harethialt.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "harethialt",
   "name": "Harari (Sabai muxxi harfi)",
-  "description": "This keyboard is an alternative layout for the revised Harari Ethiopic orthography.",
+  "description": "This keyboard is an alternative layout for the revised Harari Ethiopic orthography.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/harari/'>Open Road: Harari resources</a></li>\n</ul>\n",
   "authorName": "Vicnet, State Library of Victoria",
   "license": "freeware",
   "languages": [
     "har"
   ],
   "lastModifiedDate": "2009-10-23T08:22:30Z",
-  "links": [
-    {
-      "name": "Open Road: Harari resources",
-      "url": "http://www.openroad.net.au/languages/african/harari/"
-    }
-  ],
   "packageFilename": "harethialt.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 617,
-  "documentationFilename": "harari-keyman-20-20090422.pdf"
+  }
 }

--- a/legacy/h/harlatn/harlatn.keyboard_info
+++ b/legacy/h/harlatn/harlatn.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "harlatn",
   "name": "Harari (Lâtîn harfi)",
-  "description": "This keyboard uses the revised Harari Latin orthography.",
+  "description": "This keyboard uses the revised Harari Latin orthography.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/harari/'>Open Road Harari page</a></li>\n</ul>\n",
   "authorName": "Vicnet, State Library of Victoria",
   "license": "freeware",
   "languages": [
     "har"
   ],
   "lastModifiedDate": "2009-10-23T08:22:02Z",
-  "links": [
-    {
-      "name": "Open Road Harari page",
-      "url": "http://www.openroad.net.au/languages/african/harari/"
-    }
-  ],
   "packageFilename": "harlatn.kmp",
   "encodings": [
     "unicode"
@@ -29,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 614,
-  "documentationFilename": "harari-keyman-20-20090422.pdf"
+  }
 }

--- a/legacy/h/hebgrktransuni/hebgrktransuni.keyboard_info
+++ b/legacy/h/hebgrktransuni/hebgrktransuni.keyboard_info
@@ -11,7 +11,6 @@
     "hbo"
   ],
   "lastModifiedDate": "2014-08-08T16:18:28Z",
-  "links": [],
   "packageFilename": "hebgrktransuni.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 687,
-  "documentationFilename": "hebgrktransuni.pdf"
+  }
 }

--- a/legacy/h/heidelberginputsolution/heidelberginputsolution.keyboard_info
+++ b/legacy/h/heidelberginputsolution/heidelberginputsolution.keyboard_info
@@ -10,7 +10,6 @@
     "sa"
   ],
   "lastModifiedDate": "2014-08-08T16:19:41Z",
-  "links": [],
   "packageFilename": "heidelberginputsolution.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 362,
-  "documentationFilename": "the heidelberg input solution.pdf"
+  }
 }

--- a/legacy/h/heiltsuk/heiltsuk.keyboard_info
+++ b/legacy/h/heiltsuk/heiltsuk.keyboard_info
@@ -8,7 +8,6 @@
     "hei"
   ],
   "lastModifiedDate": "2008-07-04T15:35:25Z",
-  "links": [],
   "packageFilename": "heiltsuk.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 440
+  }
 }

--- a/legacy/h/henqeminem_u/henqeminem_u.keyboard_info
+++ b/legacy/h/henqeminem_u/henqeminem_u.keyboard_info
@@ -8,7 +8,6 @@
     "hur"
   ],
   "lastModifiedDate": "2013-04-12T15:44:55Z",
-  "links": [],
   "packageFilename": "henqeminem_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 663,
-  "documentationFilename": "henqeminem - basic usage.pdf"
+  }
 }

--- a/legacy/h/hi-keyboard/hi-keyboard.keyboard_info
+++ b/legacy/h/hi-keyboard/hi-keyboard.keyboard_info
@@ -8,7 +8,6 @@
     "haw"
   ],
   "lastModifiedDate": "2009-01-30T12:24:47Z",
-  "links": [],
   "packageFilename": "hi-keyboard.kmp",
   "encodings": [
     "unicode",
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 467
+  }
 }

--- a/legacy/i/icetot/icetot.keyboard_info
+++ b/legacy/i/icetot/icetot.keyboard_info
@@ -8,7 +8,6 @@
     "ikx"
   ],
   "lastModifiedDate": "2009-02-20T11:37:31Z",
-  "links": [],
   "packageFilename": "icetot.kmp",
   "encodings": [
     "ansi"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 326,
-  "documentationFilename": "using_icetot.pdf"
+  }
 }

--- a/legacy/i/indic roman transliteration/indic roman transliteration.keyboard_info
+++ b/legacy/i/indic roman transliteration/indic roman transliteration.keyboard_info
@@ -10,7 +10,6 @@
     "hi-fonipa"
   ],
   "lastModifiedDate": "2007-12-03T09:43:29Z",
-  "links": [],
   "packageFilename": "indic roman transliteration.kmp",
   "encodings": [
     "unicode"
@@ -25,7 +24,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 409,
-  "documentationFilename": "indic roman transliteration.pdf"
+  }
 }

--- a/legacy/i/inuktitut_4/inuktitut_4.keyboard_info
+++ b/legacy/i/inuktitut_4/inuktitut_4.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "inuktitut_4",
   "name": "Inuktitut/Inuvialuktun Syllabics",
-  "description": "Keyboard layout for typing Inuktitut syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.",
+  "description": "Keyboard layout for typing Inuktitut syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/inu/inu_syllabarium.html'>Inuktitut Unicode keyboard and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "ikt"
   ],
   "lastModifiedDate": "2012-01-23T17:58:26Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Inuktitut Unicode keyboard and information",
-      "url": "http://www.languagegeek.com/inu/inu_syllabarium.html"
-    }
-  ],
   "packageFilename": "inuktitut_4.kmp",
   "encodings": [
     "unicode"
@@ -36,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 328
+  }
 }

--- a/legacy/i/ipa93_km5/ipa93_km5.keyboard_info
+++ b/legacy/i/ipa93_km5/ipa93_km5.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "ipa93_km5",
   "name": "SIL IPA 93 (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_ipa'>https://keyman.com/keyboards/sil_ipa</a>. (Keyman 5 update of SIL's IPA93 keyboard, for use with SIL's Encore IPA fonts (included)).",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/sil_ipa'>https://keyman.com/keyboards/sil_ipa</a>. (Keyman 5 update of SIL's IPA93 keyboard, for use with SIL's Encore IPA fonts (included)).\n<ul>\n  <li><a href='http://scripts.sil.org/IPAhome'>SIL IPA Fonts home page</a></li>\n</ul>\n",
   "authorName": "SIL",
   "license": "freeware",
   "languages": [
     "und-fonipa"
   ],
   "lastModifiedDate": "2006-06-26T15:28:03Z",
-  "links": [
-    {
-      "name": "SIL IPA Fonts home page",
-      "url": "http://scripts.sil.org/IPAhome"
-    }
-  ],
   "packageFilename": "ipa93_km5.kmp",
   "encodings": [
     "ansi"
@@ -26,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 354
+  }
 }

--- a/legacy/i/ipatep/ipatep.keyboard_info
+++ b/legacy/i/ipatep/ipatep.keyboard_info
@@ -9,7 +9,6 @@
     "tla"
   ],
   "lastModifiedDate": "2008-06-30T11:06:47Z",
-  "links": [],
   "packageFilename": "ipatep.kmp",
   "encodings": [
     "ansi"
@@ -18,7 +17,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 361,
-  "documentationFilename": "mextep.pdf"
+  }
 }

--- a/legacy/i/ipatotal/ipatotal.keyboard_info
+++ b/legacy/i/ipatotal/ipatotal.keyboard_info
@@ -8,7 +8,6 @@
     "und-fonipa"
   ],
   "lastModifiedDate": "2009-01-09T11:29:43Z",
-  "links": [],
   "packageFilename": "ipatotal.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 454
+  }
 }

--- a/legacy/i/ipauni111/ipauni111.keyboard_info
+++ b/legacy/i/ipauni111/ipauni111.keyboard_info
@@ -1,31 +1,13 @@
 {
   "id": "ipauni111",
   "name": "SIL IPA Unicode‌",
-  "description": "The \"IPA Unicode 1.1\" keyboard, developed by Martin Hosken, is a mnemonic compiled Keyman 6 keyboard. It is intended to provide a text input method for Unicode-based applications, in order to access IPA characters. The keyboard layout is similar to that provided for the old pre-Unicode SIL IPA93 fonts.\r\n\r\nThis package includes documentation for the keyboard, but does not include any fonts.",
+  "description": "The \"IPA Unicode 1.1\" keyboard, developed by Martin Hosken, is a mnemonic compiled Keyman 6 keyboard. It is intended to provide a text input method for Unicode-based applications, in order to access IPA characters. The keyboard layout is similar to that provided for the old pre-Unicode SIL IPA93 fonts.\r\n\r\nThis package includes documentation for the keyboard, but does not include any fonts.\n<ul>\n  <li><a href='http://scripts.sil.org/UniIPAKeyboard'>SIL IPA Unicode keyboard home</a></li>\n  <li><a href='http://scripts.sil.org/DoulosSILfont'>Doulos SIL font home</a></li>\n  <li><a href='http://scripts.sil.org/CharisSILfont'>Charis SIL font home</a></li>\n  <li><a href='http://scripts.sil.org/Gentium'>Gentium font home</a></li>\n</ul>\n",
   "authorName": "SIL International",
   "license": "freeware",
   "languages": [
     "und-fonipa"
   ],
   "lastModifiedDate": "2007-03-13T11:10:29Z",
-  "links": [
-    {
-      "name": "SIL IPA Unicode keyboard home",
-      "url": "http://scripts.sil.org/UniIPAKeyboard"
-    },
-    {
-      "name": "Doulos SIL font home",
-      "url": "http://scripts.sil.org/DoulosSILfont"
-    },
-    {
-      "name": "Charis SIL font home",
-      "url": "http://scripts.sil.org/CharisSILfont"
-    },
-    {
-      "name": "Gentium font home",
-      "url": "http://scripts.sil.org/Gentium"
-    }
-  ],
   "packageFilename": "ipauni111.kmp",
   "encodings": [
     "unicode"
@@ -39,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 383,
-  "documentationFilename": "ipa unicode 1.1 keyman keyboard.pdf"
+  }
 }

--- a/legacy/i/iroquoian/iroquoian.keyboard_info
+++ b/legacy/i/iroquoian/iroquoian.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "iroquoian",
   "name": "Iroquoian Unicode",
-  "description": "Keyboard layout for typing Iroquoian languages using Unicode fonts.",
+  "description": "Keyboard layout for typing Iroquoian languages using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Iroquoianist Unicode keyboard and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "lre"
   ],
   "lastModifiedDate": "2012-01-23T17:58:32Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Iroquoianist Unicode keyboard and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "iroquoian.kmp",
   "encodings": [
     "unicode"
@@ -32,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 329
+  }
 }

--- a/legacy/isis/isis/isis.keyboard_info
+++ b/legacy/isis/isis/isis.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "isis",
   "name": "ISIS (All Indic Languages)",
-  "description": "<p>Mnemonic (Romanized) keyboards for all major Indian scripts.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes ISIS keyboards for all the languages listed.  Packages for specific languages can be downloaded from the <a href='http://isis.keymankeyboards.com/'>ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for all major Indian scripts.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes ISIS keyboards for all the languages listed.  Packages for specific languages can be downloaded from the <a href='http://isis.keymankeyboards.com/'>ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Gautam Sengupta",
   "license": "freeware",
   "languages": [
@@ -22,12 +22,6 @@
     "te"
   ],
   "lastModifiedDate": "2011-10-14T11:19:43Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis.kmp",
   "encodings": [
     "unicode"
@@ -42,6 +36,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 330
+  }
 }

--- a/legacy/isis/isis_bangla/isis_bangla.keyboard_info
+++ b/legacy/isis/isis_bangla/isis_bangla.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "isis_bangla",
   "name": "ISIS (Bangla)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Bangla Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Bengali and Assamese languages.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Bangla Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Bengali and Assamese languages.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
@@ -9,12 +9,6 @@
     "bn"
   ],
   "lastModifiedDate": "2011-10-14T11:19:48Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_bangla.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +26,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 419,
-  "jsFilename": "isis_bangla.js",
-  "documentationFilename": "isis_bangla.pdf"
+  "jsFilename": "isis_bangla.js"
 }

--- a/legacy/isis/isis_devanagari/isis_devanagari.keyboard_info
+++ b/legacy/isis/isis_devanagari/isis_devanagari.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "isis_devanagari",
   "name": "ISIS (Devanagari)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Devanagari Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Hindi, Konkani, Marathi, Marawi, and Sanskrit languages.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Devanagari Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Hindi, Konkani, Marathi, Marawi, and Sanskrit languages.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
@@ -12,12 +12,6 @@
     "sa"
   ],
   "lastModifiedDate": "2011-10-14T11:19:50Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_devanagari.kmp",
   "encodings": [
     "unicode"
@@ -35,7 +29,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 420,
-  "jsFilename": "isis_devanagari.js",
-  "documentationFilename": "isis_devanagari.pdf"
+  "jsFilename": "isis_devanagari.js"
 }

--- a/legacy/isis/isis_gujarati/isis_gujarati.keyboard_info
+++ b/legacy/isis/isis_gujarati/isis_gujarati.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_gujarati",
   "name": "ISIS (Gujarati)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Gujarati Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Gujarati language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Gujarati Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Gujarati language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "gu"
   ],
   "lastModifiedDate": "2011-10-14T11:19:54Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_gujarati.kmp",
   "encodings": [
     "unicode"
@@ -30,7 +24,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 421,
-  "jsFilename": "isis_gujarati.js",
-  "documentationFilename": "welcome.htm"
+  "jsFilename": "isis_gujarati.js"
 }

--- a/legacy/isis/isis_gurmukhi/isis_gurmukhi.keyboard_info
+++ b/legacy/isis/isis_gurmukhi/isis_gurmukhi.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "isis_gurmukhi",
   "name": "ISIS (Gurmukhi)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Gurmukhi Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Panjabi language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Gurmukhi Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Panjabi language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
@@ -10,12 +10,6 @@
     "pnb"
   ],
   "lastModifiedDate": "2011-10-14T11:20:00Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_gurmukhi.kmp",
   "encodings": [
     "unicode"
@@ -33,7 +27,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 422,
-  "jsFilename": "isis_gurmukhi.js",
-  "documentationFilename": "isis_gurmukhi.pdf"
+  "jsFilename": "isis_gurmukhi.js"
 }

--- a/legacy/isis/isis_kannada/isis_kannada.keyboard_info
+++ b/legacy/isis/isis_kannada/isis_kannada.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_kannada",
   "name": "ISIS (Kannada)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Kannada Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Kannada language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Kannada Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Kannada language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "kn"
   ],
   "lastModifiedDate": "2011-10-14T11:20:05Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_kannada.kmp",
   "encodings": [
     "unicode"
@@ -31,7 +25,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 423,
-  "jsFilename": "isis_kannada.js",
-  "documentationFilename": "welcome.htm"
+  "jsFilename": "isis_kannada.js"
 }

--- a/legacy/isis/isis_malayalam/isis_malayalam.keyboard_info
+++ b/legacy/isis/isis_malayalam/isis_malayalam.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_malayalam",
   "name": "ISIS (Malayalam)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Malayalam Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Malayalam language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/'>ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/'>Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Malayalam Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Malayalam language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/'>ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/'>Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "ml"
   ],
   "lastModifiedDate": "2011-10-14T11:20:09Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_malayalam.kmp",
   "encodings": [
     "unicode"
@@ -33,7 +27,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 424,
-  "jsFilename": "isis_malayalam.js",
-  "documentationFilename": "readme.htm"
+  "jsFilename": "isis_malayalam.js"
 }

--- a/legacy/isis/isis_oriya/isis_oriya.keyboard_info
+++ b/legacy/isis/isis_oriya/isis_oriya.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_oriya",
   "name": "ISIS (Oriya)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Oriya Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Oriya language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Oriya Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Oriya language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "or"
   ],
   "lastModifiedDate": "2011-10-14T11:20:13Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_oriya.kmp",
   "encodings": [
     "unicode"
@@ -33,7 +27,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 425,
-  "jsFilename": "isis_oriya.js",
-  "documentationFilename": "welcome.htm"
+  "jsFilename": "isis_oriya.js"
 }

--- a/legacy/isis/isis_tamil/isis_tamil.keyboard_info
+++ b/legacy/isis/isis_tamil/isis_tamil.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_tamil",
   "name": "ISIS (Tamil)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Tamil Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Tamil language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Tamil Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Tamil language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2011-10-14T11:20:18Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_tamil.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +26,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 426,
-  "jsFilename": "isis_tamil.js",
-  "documentationFilename": "readme.htm"
+  "jsFilename": "isis_tamil.js"
 }

--- a/legacy/isis/isis_telugu/isis_telugu.keyboard_info
+++ b/legacy/isis/isis_telugu/isis_telugu.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "isis_telugu",
   "name": "ISIS (Telugu)",
-  "description": "<p>Mnemonic (Romanized) keyboards for Telugu Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Telugu language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  ",
+  "description": "<p>Mnemonic (Romanized) keyboards for Telugu Indian script.  ISIS is free and easy to use. Developed by Gautam Sengupta, Center for Applied Linguistics & Translation Studies, University of Hyderabad. Requires Windows 2000/XP.</p>    <p>This package includes an ISIS keyboard for Telugu language.  Packages for other languages can be downloaded from the <a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">ISIS homepage</a>.</p>    <p><a href='http://isis.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Try these keyboards online now!</a></p>  \n<ul>\n  <li><a href='http://isis.keymankeyboards.com/'>ISIS keyboards home page</a></li>\n</ul>\n",
   "authorName": "Mr Gautam Sengupta",
   "license": "freeware",
   "languages": [
     "te"
   ],
   "lastModifiedDate": "2011-10-14T11:20:22Z",
-  "links": [
-    {
-      "name": "ISIS keyboards home page",
-      "url": "http://isis.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "isis_telugu.kmp",
   "encodings": [
     "unicode"
@@ -31,7 +25,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 427,
-  "jsFilename": "isis_telugu.js",
-  "documentationFilename": "welcome.htm"
+  "jsFilename": "isis_telugu.js"
 }

--- a/legacy/k/keymancolombia/keymancolombia.keyboard_info
+++ b/legacy/k/keymancolombia/keymancolombia.keyboard_info
@@ -39,7 +39,6 @@
     "yui"
   ],
   "lastModifiedDate": "2007-11-17T09:25:39Z",
-  "links": [],
   "packageFilename": "keymancolombia.kmp",
   "encodings": [
     "ansi"
@@ -53,7 +52,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 411,
-  "documentationFilename": "colombia_teclado.pdf"
+  }
 }

--- a/legacy/k/keymanguahibo/keymanguahibo.keyboard_info
+++ b/legacy/k/keymanguahibo/keymanguahibo.keyboard_info
@@ -8,7 +8,6 @@
     "guh"
   ],
   "lastModifiedDate": "2007-11-17T09:25:15Z",
-  "links": [],
   "packageFilename": "keymanguahibo.kmp",
   "encodings": [
     "ansi"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 410
+  }
 }

--- a/legacy/k/khmer10/khmer10.keyboard_info
+++ b/legacy/k/khmer10/khmer10.keyboard_info
@@ -8,7 +8,6 @@
     "km"
   ],
   "lastModifiedDate": "2007-02-08T13:43:29Z",
-  "links": [],
   "packageFilename": "khmer10.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 401,
-  "jsFilename": "khmer10.js",
-  "documentationFilename": "khmer10.html"
+  "jsFilename": "khmer10.js"
 }

--- a/legacy/k/khowar/khowar.keyboard_info
+++ b/legacy/k/khowar/khowar.keyboard_info
@@ -8,7 +8,6 @@
     "khw"
   ],
   "lastModifiedDate": "2017-06-23T10:58:12Z",
-  "links": [],
   "packageFilename": "khowar.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 659
+  }
 }

--- a/legacy/k/klallam/klallam.keyboard_info
+++ b/legacy/k/klallam/klallam.keyboard_info
@@ -8,7 +8,6 @@
     "clm"
   ],
   "lastModifiedDate": "2013-04-12T15:45:07Z",
-  "links": [],
   "packageFilename": "klallam.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 664,
-  "documentationFilename": "klallam - basic usage.pdf"
+  }
 }

--- a/legacy/k/km_cree/km_cree.keyboard_info
+++ b/legacy/k/km_cree/km_cree.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "km_cree",
   "name": "Cree Syllabics",
-  "description": "Keyboard layouts for typing Cree in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.",
+  "description": "Keyboard layouts for typing Cree in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html'>Cree Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "crk"
   ],
   "lastModifiedDate": "2012-01-23T17:57:41Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Cree Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html"
-    }
-  ],
   "packageFilename": "km_cree.kmp",
   "encodings": [
     "unicode"
@@ -37,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 640
+  }
 }

--- a/legacy/k/km_ojibwasyllabics/km_ojibwasyllabics.keyboard_info
+++ b/legacy/k/km_ojibwasyllabics/km_ojibwasyllabics.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "km_ojibwasyllabics",
   "name": "Ojibwa Syllabics",
-  "description": "Keyboard layouts for typing Ojibwa in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.",
+  "description": "Keyboard layouts for typing Ojibwa in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html'>Ojibwe Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "ojb"
   ],
   "lastModifiedDate": "2012-01-23T17:59:18Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Ojibwe Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html"
-    }
-  ],
   "packageFilename": "km_ojibwasyllabics.kmp",
   "encodings": [
     "unicode"
@@ -37,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 647
+  }
 }

--- a/legacy/k/km_ojicreesyllabics/km_ojicreesyllabics.keyboard_info
+++ b/legacy/k/km_ojicreesyllabics/km_ojicreesyllabics.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "km_ojicreesyllabics",
   "name": "Oji-Cree Syllabics",
-  "description": "Keyboard layouts for typing Oji-Cree in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.",
+  "description": "Keyboard layouts for typing Oji-Cree in Unicode syllabics.  Some characters are not standard Unicode, so \r\nplease download and use the Aboriginal Serif Unicode font.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html'>Oji-Cree Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "ojs"
   ],
   "lastModifiedDate": "2012-01-23T17:59:26Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Oji-Cree Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html"
-    }
-  ],
   "packageFilename": "km_ojicreesyllabics.kmp",
   "encodings": [
     "unicode"
@@ -37,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 341
+  }
 }

--- a/legacy/k/kmhmu/kmhmu.keyboard_info
+++ b/legacy/k/kmhmu/kmhmu.keyboard_info
@@ -8,7 +8,6 @@
     "kjg"
   ],
   "lastModifiedDate": "2008-08-29T15:44:45Z",
-  "links": [],
   "packageFilename": "kmhmu.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 441
+  }
 }

--- a/legacy/k/korda/korda.keyboard_info
+++ b/legacy/k/korda/korda.keyboard_info
@@ -8,7 +8,6 @@
     "ko"
   ],
   "lastModifiedDate": "2012-01-19T11:51:23Z",
-  "links": [],
   "packageFilename": "korda.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 631,
-  "documentationFilename": "korean korda keyboards help.pdf"
+  }
 }

--- a/legacy/k/korean_morse/korean_morse.keyboard_info
+++ b/legacy/k/korean_morse/korean_morse.keyboard_info
@@ -8,7 +8,6 @@
     "ko"
   ],
   "lastModifiedDate": "2011-11-11T14:41:44Z",
-  "links": [],
   "packageFilename": "korean_morse.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 632,
-  "documentationFilename": "korean morse keyboard help.pdf"
+  }
 }

--- a/legacy/k/ktunaxa/ktunaxa.keyboard_info
+++ b/legacy/k/ktunaxa/ktunaxa.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "ktunaxa",
   "name": "Ktunaxa/Kutenai",
-  "description": "A keyboard for typing Ktunaxa (Kutenai).",
+  "description": "A keyboard for typing Ktunaxa (Kutenai).\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/isolate/ktunaxa.html'>Kootenai family Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "kut"
   ],
   "lastModifiedDate": "2012-01-23T17:58:40Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Kootenai family Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/isolate/ktunaxa.html"
-    }
-  ],
   "packageFilename": "ktunaxa.kmp",
   "encodings": [
     "unicode"
@@ -32,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 331
+  }
 }

--- a/legacy/k/kwakwala_u/kwakwala_u.keyboard_info
+++ b/legacy/k/kwakwala_u/kwakwala_u.keyboard_info
@@ -8,7 +8,6 @@
     "kwk"
   ],
   "lastModifiedDate": "2013-04-12T15:45:18Z",
-  "links": [],
   "packageFilename": "kwakwala_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 665,
-  "documentationFilename": "kwak'wala - basic usage.pdf"
+  }
 }

--- a/legacy/kbd/kbda1/kbda1.keyboard_info
+++ b/legacy/kbd/kbda1/kbda1.keyboard_info
@@ -8,7 +8,6 @@
     "arb"
   ],
   "lastModifiedDate": "2009-05-15T14:32:48Z",
-  "links": [],
   "packageFilename": "kbda1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 473
+  }
 }

--- a/legacy/kbd/kbda2/kbda2.keyboard_info
+++ b/legacy/kbd/kbda2/kbda2.keyboard_info
@@ -8,7 +8,6 @@
     "arb"
   ],
   "lastModifiedDate": "2009-05-15T14:32:48Z",
-  "links": [],
   "packageFilename": "kbda2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 474
+  }
 }

--- a/legacy/kbd/kbda3/kbda3.keyboard_info
+++ b/legacy/kbd/kbda3/kbda3.keyboard_info
@@ -8,7 +8,6 @@
     "arb"
   ],
   "lastModifiedDate": "2009-05-15T14:32:49Z",
-  "links": [],
   "packageFilename": "kbda3.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 475
+  }
 }

--- a/legacy/kbd/kbdal/kbdal.keyboard_info
+++ b/legacy/kbd/kbdal/kbdal.keyboard_info
@@ -8,7 +8,6 @@
     "sq"
   ],
   "lastModifiedDate": "2016-10-06T12:34:08Z",
-  "links": [],
   "packageFilename": "kbdal.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 476
+  }
 }

--- a/legacy/kbd/kbdarme/kbdarme.keyboard_info
+++ b/legacy/kbd/kbdarme/kbdarme.keyboard_info
@@ -8,7 +8,6 @@
     "hy"
   ],
   "lastModifiedDate": "2009-05-15T14:32:51Z",
-  "links": [],
   "packageFilename": "kbdarme.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 477
+  }
 }

--- a/legacy/kbd/kbdarmw/kbdarmw.keyboard_info
+++ b/legacy/kbd/kbdarmw/kbdarmw.keyboard_info
@@ -8,7 +8,6 @@
     "hy"
   ],
   "lastModifiedDate": "2009-05-15T14:32:52Z",
-  "links": [],
   "packageFilename": "kbdarmw.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 478
+  }
 }

--- a/legacy/kbd/kbdaze/kbdaze.keyboard_info
+++ b/legacy/kbd/kbdaze/kbdaze.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:32:53Z",
-  "links": [],
   "packageFilename": "kbdaze.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 479
+  }
 }

--- a/legacy/kbd/kbdazel/kbdazel.keyboard_info
+++ b/legacy/kbd/kbdazel/kbdazel.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:32:54Z",
-  "links": [],
   "packageFilename": "kbdazel.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 480
+  }
 }

--- a/legacy/kbd/kbdbash/kbdbash.keyboard_info
+++ b/legacy/kbd/kbdbash/kbdbash.keyboard_info
@@ -8,7 +8,6 @@
     "ba"
   ],
   "lastModifiedDate": "2009-05-15T16:18:19Z",
-  "links": [],
   "packageFilename": "kbdbash.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 481
+  }
 }

--- a/legacy/kbd/kbdbe/kbdbe.keyboard_info
+++ b/legacy/kbd/kbdbe/kbdbe.keyboard_info
@@ -8,7 +8,6 @@
     "fr"
   ],
   "lastModifiedDate": "2009-05-15T14:32:56Z",
-  "links": [],
   "packageFilename": "kbdbe.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 482
+  }
 }

--- a/legacy/kbd/kbdbene/kbdbene.keyboard_info
+++ b/legacy/kbd/kbdbene/kbdbene.keyboard_info
@@ -8,7 +8,6 @@
     "fr"
   ],
   "lastModifiedDate": "2009-05-15T14:32:57Z",
-  "links": [],
   "packageFilename": "kbdbene.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 483
+  }
 }

--- a/legacy/kbd/kbdbgph/kbdbgph.keyboard_info
+++ b/legacy/kbd/kbdbgph/kbdbgph.keyboard_info
@@ -8,7 +8,6 @@
     "bg"
   ],
   "lastModifiedDate": "2009-05-15T14:32:58Z",
-  "links": [],
   "packageFilename": "kbdbgph.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 484
+  }
 }

--- a/legacy/kbd/kbdbhc/kbdbhc.keyboard_info
+++ b/legacy/kbd/kbdbhc/kbdbhc.keyboard_info
@@ -8,7 +8,6 @@
     "bs"
   ],
   "lastModifiedDate": "2009-05-15T14:32:58Z",
-  "links": [],
   "packageFilename": "kbdbhc.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 485
+  }
 }

--- a/legacy/kbd/kbdblr/kbdblr.keyboard_info
+++ b/legacy/kbd/kbdblr/kbdblr.keyboard_info
@@ -8,7 +8,6 @@
     "be"
   ],
   "lastModifiedDate": "2009-05-15T14:32:59Z",
-  "links": [],
   "packageFilename": "kbdblr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 486
+  }
 }

--- a/legacy/kbd/kbdbr/kbdbr.keyboard_info
+++ b/legacy/kbd/kbdbr/kbdbr.keyboard_info
@@ -8,7 +8,6 @@
     "pt"
   ],
   "lastModifiedDate": "2009-05-15T14:33:00Z",
-  "links": [],
   "packageFilename": "kbdbr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 487
+  }
 }

--- a/legacy/kbd/kbdbu/kbdbu.keyboard_info
+++ b/legacy/kbd/kbdbu/kbdbu.keyboard_info
@@ -8,7 +8,6 @@
     "bg"
   ],
   "lastModifiedDate": "2009-05-15T17:20:19Z",
-  "links": [],
   "packageFilename": "kbdbu.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 488
+  }
 }

--- a/legacy/kbd/kbdbulg/kbdbulg.keyboard_info
+++ b/legacy/kbd/kbdbulg/kbdbulg.keyboard_info
@@ -8,7 +8,6 @@
     "bg"
   ],
   "lastModifiedDate": "2009-05-15T17:20:09Z",
-  "links": [],
   "packageFilename": "kbdbulg.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 489
+  }
 }

--- a/legacy/kbd/kbdca/kbdca.keyboard_info
+++ b/legacy/kbd/kbdca/kbdca.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:33:03Z",
-  "links": [],
   "packageFilename": "kbdca.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 490
+  }
 }

--- a/legacy/kbd/kbdcr/kbdcr.keyboard_info
+++ b/legacy/kbd/kbdcr/kbdcr.keyboard_info
@@ -8,7 +8,6 @@
     "hr"
   ],
   "lastModifiedDate": "2009-05-15T14:33:04Z",
-  "links": [],
   "packageFilename": "kbdcr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 491
+  }
 }

--- a/legacy/kbd/kbdcz/kbdcz.keyboard_info
+++ b/legacy/kbd/kbdcz/kbdcz.keyboard_info
@@ -8,7 +8,6 @@
     "cs"
   ],
   "lastModifiedDate": "2009-05-15T14:33:05Z",
-  "links": [],
   "packageFilename": "kbdcz.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 492
+  }
 }

--- a/legacy/kbd/kbdcz1/kbdcz1.keyboard_info
+++ b/legacy/kbd/kbdcz1/kbdcz1.keyboard_info
@@ -8,7 +8,6 @@
     "cs"
   ],
   "lastModifiedDate": "2009-05-15T14:33:06Z",
-  "links": [],
   "packageFilename": "kbdcz1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 493
+  }
 }

--- a/legacy/kbd/kbdcz2/kbdcz2.keyboard_info
+++ b/legacy/kbd/kbdcz2/kbdcz2.keyboard_info
@@ -8,7 +8,6 @@
     "cs"
   ],
   "lastModifiedDate": "2009-05-15T14:33:07Z",
-  "links": [],
   "packageFilename": "kbdcz2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 494
+  }
 }

--- a/legacy/kbd/kbdda/kbdda.keyboard_info
+++ b/legacy/kbd/kbdda/kbdda.keyboard_info
@@ -8,7 +8,6 @@
     "da"
   ],
   "lastModifiedDate": "2009-05-15T14:33:08Z",
-  "links": [],
   "packageFilename": "kbdda.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 495
+  }
 }

--- a/legacy/kbd/kbddiv1/kbddiv1.keyboard_info
+++ b/legacy/kbd/kbddiv1/kbddiv1.keyboard_info
@@ -8,7 +8,6 @@
     "dv"
   ],
   "lastModifiedDate": "2009-05-15T14:33:09Z",
-  "links": [],
   "packageFilename": "kbddiv1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 496
+  }
 }

--- a/legacy/kbd/kbddiv2/kbddiv2.keyboard_info
+++ b/legacy/kbd/kbddiv2/kbddiv2.keyboard_info
@@ -8,7 +8,6 @@
     "dv"
   ],
   "lastModifiedDate": "2009-05-15T14:33:10Z",
-  "links": [],
   "packageFilename": "kbddiv2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 497
+  }
 }

--- a/legacy/kbd/kbddv/kbddv.keyboard_info
+++ b/legacy/kbd/kbddv/kbddv.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:33:10Z",
-  "links": [],
   "packageFilename": "kbddv.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 498
+  }
 }

--- a/legacy/kbd/kbdes/kbdes.keyboard_info
+++ b/legacy/kbd/kbdes/kbdes.keyboard_info
@@ -8,7 +8,6 @@
     "es"
   ],
   "lastModifiedDate": "2009-05-15T14:33:11Z",
-  "links": [],
   "packageFilename": "kbdes.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 499
+  }
 }

--- a/legacy/kbd/kbdest/kbdest.keyboard_info
+++ b/legacy/kbd/kbdest/kbdest.keyboard_info
@@ -8,7 +8,6 @@
     "et"
   ],
   "lastModifiedDate": "2009-05-15T14:33:12Z",
-  "links": [],
   "packageFilename": "kbdest.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 500
+  }
 }

--- a/legacy/kbd/kbdfa/kbdfa.keyboard_info
+++ b/legacy/kbd/kbdfa/kbdfa.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:33:13Z",
-  "links": [],
   "packageFilename": "kbdfa.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 501
+  }
 }

--- a/legacy/kbd/kbdfc/kbdfc.keyboard_info
+++ b/legacy/kbd/kbdfc/kbdfc.keyboard_info
@@ -8,7 +8,6 @@
     "fr"
   ],
   "lastModifiedDate": "2009-05-15T14:33:14Z",
-  "links": [],
   "packageFilename": "kbdfc.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 502
+  }
 }

--- a/legacy/kbd/kbdfi/kbdfi.keyboard_info
+++ b/legacy/kbd/kbdfi/kbdfi.keyboard_info
@@ -8,7 +8,6 @@
     "fi"
   ],
   "lastModifiedDate": "2009-05-15T14:33:15Z",
-  "links": [],
   "packageFilename": "kbdfi.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 503
+  }
 }

--- a/legacy/kbd/kbdfi1/kbdfi1.keyboard_info
+++ b/legacy/kbd/kbdfi1/kbdfi1.keyboard_info
@@ -8,7 +8,6 @@
     "se"
   ],
   "lastModifiedDate": "2009-05-15T14:33:16Z",
-  "links": [],
   "packageFilename": "kbdfi1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 504
+  }
 }

--- a/legacy/kbd/kbdfo/kbdfo.keyboard_info
+++ b/legacy/kbd/kbdfo/kbdfo.keyboard_info
@@ -8,7 +8,6 @@
     "fo"
   ],
   "lastModifiedDate": "2009-05-15T14:33:16Z",
-  "links": [],
   "packageFilename": "kbdfo.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 505
+  }
 }

--- a/legacy/kbd/kbdfr/kbdfr.keyboard_info
+++ b/legacy/kbd/kbdfr/kbdfr.keyboard_info
@@ -8,7 +8,6 @@
     "fr"
   ],
   "lastModifiedDate": "2009-05-15T14:33:18Z",
-  "links": [],
   "packageFilename": "kbdfr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 506
+  }
 }

--- a/legacy/kbd/kbdgae/kbdgae.keyboard_info
+++ b/legacy/kbd/kbdgae/kbdgae.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:33:19Z",
-  "links": [],
   "packageFilename": "kbdgae.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 507
+  }
 }

--- a/legacy/kbd/kbdgeo/kbdgeo.keyboard_info
+++ b/legacy/kbd/kbdgeo/kbdgeo.keyboard_info
@@ -8,7 +8,6 @@
     "ka"
   ],
   "lastModifiedDate": "2009-05-15T14:33:19Z",
-  "links": [],
   "packageFilename": "kbdgeo.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 508
+  }
 }

--- a/legacy/kbd/kbdgeoer/kbdgeoer.keyboard_info
+++ b/legacy/kbd/kbdgeoer/kbdgeoer.keyboard_info
@@ -8,7 +8,6 @@
     "ka"
   ],
   "lastModifiedDate": "2009-05-15T14:33:20Z",
-  "links": [],
   "packageFilename": "kbdgeoer.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 509
+  }
 }

--- a/legacy/kbd/kbdgeoqw/kbdgeoqw.keyboard_info
+++ b/legacy/kbd/kbdgeoqw/kbdgeoqw.keyboard_info
@@ -8,7 +8,6 @@
     "ka"
   ],
   "lastModifiedDate": "2009-05-15T14:33:21Z",
-  "links": [],
   "packageFilename": "kbdgeoqw.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 510
+  }
 }

--- a/legacy/kbd/kbdgkl/kbdgkl.keyboard_info
+++ b/legacy/kbd/kbdgkl/kbdgkl.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:22Z",
-  "links": [],
   "packageFilename": "kbdgkl.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 511
+  }
 }

--- a/legacy/kbd/kbdgr/kbdgr.keyboard_info
+++ b/legacy/kbd/kbdgr/kbdgr.keyboard_info
@@ -8,7 +8,6 @@
     "de"
   ],
   "lastModifiedDate": "2009-05-15T14:33:23Z",
-  "links": [],
   "packageFilename": "kbdgr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 512
+  }
 }

--- a/legacy/kbd/kbdgr1/kbdgr1.keyboard_info
+++ b/legacy/kbd/kbdgr1/kbdgr1.keyboard_info
@@ -8,7 +8,6 @@
     "de"
   ],
   "lastModifiedDate": "2009-05-15T14:33:24Z",
-  "links": [],
   "packageFilename": "kbdgr1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 513
+  }
 }

--- a/legacy/kbd/kbdgrlnd/kbdgrlnd.keyboard_info
+++ b/legacy/kbd/kbdgrlnd/kbdgrlnd.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T16:18:37Z",
-  "links": [],
   "packageFilename": "kbdgrlnd.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 514
+  }
 }

--- a/legacy/kbd/kbdhe/kbdhe.keyboard_info
+++ b/legacy/kbd/kbdhe/kbdhe.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:26Z",
-  "links": [],
   "packageFilename": "kbdhe.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 515
+  }
 }

--- a/legacy/kbd/kbdhe220/kbdhe220.keyboard_info
+++ b/legacy/kbd/kbdhe220/kbdhe220.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:27Z",
-  "links": [],
   "packageFilename": "kbdhe220.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 516
+  }
 }

--- a/legacy/kbd/kbdhe319/kbdhe319.keyboard_info
+++ b/legacy/kbd/kbdhe319/kbdhe319.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:28Z",
-  "links": [],
   "packageFilename": "kbdhe319.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 517
+  }
 }

--- a/legacy/kbd/kbdheb/kbdheb.keyboard_info
+++ b/legacy/kbd/kbdheb/kbdheb.keyboard_info
@@ -8,7 +8,6 @@
     "he"
   ],
   "lastModifiedDate": "2009-05-15T14:33:29Z",
-  "links": [],
   "packageFilename": "kbdheb.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 518
+  }
 }

--- a/legacy/kbd/kbdhela2/kbdhela2.keyboard_info
+++ b/legacy/kbd/kbdhela2/kbdhela2.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:30Z",
-  "links": [],
   "packageFilename": "kbdhela2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 519
+  }
 }

--- a/legacy/kbd/kbdhela3/kbdhela3.keyboard_info
+++ b/legacy/kbd/kbdhela3/kbdhela3.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:31Z",
-  "links": [],
   "packageFilename": "kbdhela3.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 520
+  }
 }

--- a/legacy/kbd/kbdhept/kbdhept.keyboard_info
+++ b/legacy/kbd/kbdhept/kbdhept.keyboard_info
@@ -8,7 +8,6 @@
     "el"
   ],
   "lastModifiedDate": "2009-05-15T14:33:32Z",
-  "links": [],
   "packageFilename": "kbdhept.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 521
+  }
 }

--- a/legacy/kbd/kbdhu/kbdhu.keyboard_info
+++ b/legacy/kbd/kbdhu/kbdhu.keyboard_info
@@ -8,7 +8,6 @@
     "hu"
   ],
   "lastModifiedDate": "2009-05-15T14:33:33Z",
-  "links": [],
   "packageFilename": "kbdhu.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 522
+  }
 }

--- a/legacy/kbd/kbdhu1/kbdhu1.keyboard_info
+++ b/legacy/kbd/kbdhu1/kbdhu1.keyboard_info
@@ -8,7 +8,6 @@
     "hu"
   ],
   "lastModifiedDate": "2009-05-15T14:33:34Z",
-  "links": [],
   "packageFilename": "kbdhu1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 523
+  }
 }

--- a/legacy/kbd/kbdic/kbdic.keyboard_info
+++ b/legacy/kbd/kbdic/kbdic.keyboard_info
@@ -8,7 +8,6 @@
     "is"
   ],
   "lastModifiedDate": "2009-05-15T14:33:35Z",
-  "links": [],
   "packageFilename": "kbdic.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 524
+  }
 }

--- a/legacy/kbd/kbdinasa/kbdinasa.keyboard_info
+++ b/legacy/kbd/kbdinasa/kbdinasa.keyboard_info
@@ -8,7 +8,6 @@
     "as"
   ],
   "lastModifiedDate": "2009-05-15T16:18:41Z",
-  "links": [],
   "packageFilename": "kbdinasa.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 525
+  }
 }

--- a/legacy/kbd/kbdinbe1/kbdinbe1.keyboard_info
+++ b/legacy/kbd/kbdinbe1/kbdinbe1.keyboard_info
@@ -8,7 +8,6 @@
     "bn"
   ],
   "lastModifiedDate": "2009-05-15T14:33:37Z",
-  "links": [],
   "packageFilename": "kbdinbe1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 526
+  }
 }

--- a/legacy/kbd/kbdinbe2/kbdinbe2.keyboard_info
+++ b/legacy/kbd/kbdinbe2/kbdinbe2.keyboard_info
@@ -8,7 +8,6 @@
     "bn"
   ],
   "lastModifiedDate": "2009-05-15T14:33:38Z",
-  "links": [],
   "packageFilename": "kbdinbe2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 527
+  }
 }

--- a/legacy/kbd/kbdinben/kbdinben.keyboard_info
+++ b/legacy/kbd/kbdinben/kbdinben.keyboard_info
@@ -8,7 +8,6 @@
     "bn"
   ],
   "lastModifiedDate": "2009-05-15T14:33:39Z",
-  "links": [],
   "packageFilename": "kbdinben.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 528
+  }
 }

--- a/legacy/kbd/kbdindev/kbdindev.keyboard_info
+++ b/legacy/kbd/kbdindev/kbdindev.keyboard_info
@@ -8,7 +8,6 @@
     "hi"
   ],
   "lastModifiedDate": "2009-05-15T14:33:40Z",
-  "links": [],
   "packageFilename": "kbdindev.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 529
+  }
 }

--- a/legacy/kbd/kbdinguj/kbdinguj.keyboard_info
+++ b/legacy/kbd/kbdinguj/kbdinguj.keyboard_info
@@ -8,7 +8,6 @@
     "gu"
   ],
   "lastModifiedDate": "2009-05-15T14:33:40Z",
-  "links": [],
   "packageFilename": "kbdinguj.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 530
+  }
 }

--- a/legacy/kbd/kbdinhin/kbdinhin.keyboard_info
+++ b/legacy/kbd/kbdinhin/kbdinhin.keyboard_info
@@ -8,7 +8,6 @@
     "hi"
   ],
   "lastModifiedDate": "2009-05-15T14:33:41Z",
-  "links": [],
   "packageFilename": "kbdinhin.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 531
+  }
 }

--- a/legacy/kbd/kbdinkan/kbdinkan.keyboard_info
+++ b/legacy/kbd/kbdinkan/kbdinkan.keyboard_info
@@ -8,7 +8,6 @@
     "kn"
   ],
   "lastModifiedDate": "2009-05-15T14:33:42Z",
-  "links": [],
   "packageFilename": "kbdinkan.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 532
+  }
 }

--- a/legacy/kbd/kbdinmal/kbdinmal.keyboard_info
+++ b/legacy/kbd/kbdinmal/kbdinmal.keyboard_info
@@ -8,7 +8,6 @@
     "ml"
   ],
   "lastModifiedDate": "2009-05-15T14:33:43Z",
-  "links": [],
   "packageFilename": "kbdinmal.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 533
+  }
 }

--- a/legacy/kbd/kbdinmar/kbdinmar.keyboard_info
+++ b/legacy/kbd/kbdinmar/kbdinmar.keyboard_info
@@ -8,7 +8,6 @@
     "mr"
   ],
   "lastModifiedDate": "2009-05-15T14:33:44Z",
-  "links": [],
   "packageFilename": "kbdinmar.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 534
+  }
 }

--- a/legacy/kbd/kbdinori/kbdinori.keyboard_info
+++ b/legacy/kbd/kbdinori/kbdinori.keyboard_info
@@ -8,7 +8,6 @@
     "or"
   ],
   "lastModifiedDate": "2009-05-15T16:18:46Z",
-  "links": [],
   "packageFilename": "kbdinori.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 535
+  }
 }

--- a/legacy/kbd/kbdinpun/kbdinpun.keyboard_info
+++ b/legacy/kbd/kbdinpun/kbdinpun.keyboard_info
@@ -8,7 +8,6 @@
     "pa"
   ],
   "lastModifiedDate": "2009-05-15T14:33:46Z",
-  "links": [],
   "packageFilename": "kbdinpun.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 536
+  }
 }

--- a/legacy/kbd/kbdintam/kbdintam.keyboard_info
+++ b/legacy/kbd/kbdintam/kbdintam.keyboard_info
@@ -8,7 +8,6 @@
     "ta"
   ],
   "lastModifiedDate": "2011-09-30T12:03:26Z",
-  "links": [],
   "packageFilename": "kbdintam.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 537,
-  "documentationFilename": "welcome.htm"
+  }
 }

--- a/legacy/kbd/kbdintel/kbdintel.keyboard_info
+++ b/legacy/kbd/kbdintel/kbdintel.keyboard_info
@@ -8,7 +8,6 @@
     "te"
   ],
   "lastModifiedDate": "2009-05-15T14:33:48Z",
-  "links": [],
   "packageFilename": "kbdintel.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 538
+  }
 }

--- a/legacy/kbd/kbdinuk2/kbdinuk2.keyboard_info
+++ b/legacy/kbd/kbdinuk2/kbdinuk2.keyboard_info
@@ -8,7 +8,6 @@
     "ike"
   ],
   "lastModifiedDate": "2009-05-15T16:18:50Z",
-  "links": [],
   "packageFilename": "kbdinuk2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 539
+  }
 }

--- a/legacy/kbd/kbdir/kbdir.keyboard_info
+++ b/legacy/kbd/kbdir/kbdir.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:33:50Z",
-  "links": [],
   "packageFilename": "kbdir.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 540
+  }
 }

--- a/legacy/kbd/kbdit/kbdit.keyboard_info
+++ b/legacy/kbd/kbdit/kbdit.keyboard_info
@@ -8,7 +8,6 @@
     "it"
   ],
   "lastModifiedDate": "2009-05-15T14:33:51Z",
-  "links": [],
   "packageFilename": "kbdit.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 541
+  }
 }

--- a/legacy/kbd/kbdit142/kbdit142.keyboard_info
+++ b/legacy/kbd/kbdit142/kbdit142.keyboard_info
@@ -8,7 +8,6 @@
     "it"
   ],
   "lastModifiedDate": "2009-05-15T14:33:52Z",
-  "links": [],
   "packageFilename": "kbdit142.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 542
+  }
 }

--- a/legacy/kbd/kbdiulat/kbdiulat.keyboard_info
+++ b/legacy/kbd/kbdiulat/kbdiulat.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:33:53Z",
-  "links": [],
   "packageFilename": "kbdiulat.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 543
+  }
 }

--- a/legacy/kbd/kbdkaz/kbdkaz.keyboard_info
+++ b/legacy/kbd/kbdkaz/kbdkaz.keyboard_info
@@ -8,7 +8,6 @@
     "kk"
   ],
   "lastModifiedDate": "2009-05-15T14:33:54Z",
-  "links": [],
   "packageFilename": "kbdkaz.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 544
+  }
 }

--- a/legacy/kbd/kbdkhmr/kbdkhmr.keyboard_info
+++ b/legacy/kbd/kbdkhmr/kbdkhmr.keyboard_info
@@ -8,7 +8,6 @@
     "km"
   ],
   "lastModifiedDate": "2013-02-18T11:24:02Z",
-  "links": [],
   "packageFilename": "kbdkhmr.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 545
+  }
 }

--- a/legacy/kbd/kbdkyr/kbdkyr.keyboard_info
+++ b/legacy/kbd/kbdkyr/kbdkyr.keyboard_info
@@ -8,7 +8,6 @@
     "ky"
   ],
   "lastModifiedDate": "2009-05-15T14:33:55Z",
-  "links": [],
   "packageFilename": "kbdkyr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 546
+  }
 }

--- a/legacy/kbd/kbdla/kbdla.keyboard_info
+++ b/legacy/kbd/kbdla/kbdla.keyboard_info
@@ -8,7 +8,6 @@
     "es"
   ],
   "lastModifiedDate": "2009-05-15T14:33:56Z",
-  "links": [],
   "packageFilename": "kbdla.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 547
+  }
 }

--- a/legacy/kbd/kbdlao/kbdlao.keyboard_info
+++ b/legacy/kbd/kbdlao/kbdlao.keyboard_info
@@ -8,7 +8,6 @@
     "lo"
   ],
   "lastModifiedDate": "2009-05-15T16:18:56Z",
-  "links": [],
   "packageFilename": "kbdlao.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 472
+  }
 }

--- a/legacy/kbd/kbdlt/kbdlt.keyboard_info
+++ b/legacy/kbd/kbdlt/kbdlt.keyboard_info
@@ -8,7 +8,6 @@
     "lt"
   ],
   "lastModifiedDate": "2009-05-15T14:33:57Z",
-  "links": [],
   "packageFilename": "kbdlt.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 548
+  }
 }

--- a/legacy/kbd/kbdlt1/kbdlt1.keyboard_info
+++ b/legacy/kbd/kbdlt1/kbdlt1.keyboard_info
@@ -8,7 +8,6 @@
     "lt"
   ],
   "lastModifiedDate": "2009-05-15T14:33:58Z",
-  "links": [],
   "packageFilename": "kbdlt1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 549
+  }
 }

--- a/legacy/kbd/kbdlt2/kbdlt2.keyboard_info
+++ b/legacy/kbd/kbdlt2/kbdlt2.keyboard_info
@@ -8,7 +8,6 @@
     "lt"
   ],
   "lastModifiedDate": "2009-05-15T14:33:59Z",
-  "links": [],
   "packageFilename": "kbdlt2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 550
+  }
 }

--- a/legacy/kbd/kbdlv/kbdlv.keyboard_info
+++ b/legacy/kbd/kbdlv/kbdlv.keyboard_info
@@ -8,7 +8,6 @@
     "lv"
   ],
   "lastModifiedDate": "2009-05-15T14:34:00Z",
-  "links": [],
   "packageFilename": "kbdlv.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 551
+  }
 }

--- a/legacy/kbd/kbdlv1/kbdlv1.keyboard_info
+++ b/legacy/kbd/kbdlv1/kbdlv1.keyboard_info
@@ -8,7 +8,6 @@
     "lv"
   ],
   "lastModifiedDate": "2009-05-15T14:34:01Z",
-  "links": [],
   "packageFilename": "kbdlv1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 552
+  }
 }

--- a/legacy/kbd/kbdmac/kbdmac.keyboard_info
+++ b/legacy/kbd/kbdmac/kbdmac.keyboard_info
@@ -8,7 +8,6 @@
     "mk"
   ],
   "lastModifiedDate": "2009-05-15T14:34:02Z",
-  "links": [],
   "packageFilename": "kbdmac.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 553
+  }
 }

--- a/legacy/kbd/kbdmacst/kbdmacst.keyboard_info
+++ b/legacy/kbd/kbdmacst/kbdmacst.keyboard_info
@@ -8,7 +8,6 @@
     "mk"
   ],
   "lastModifiedDate": "2009-05-15T14:34:03Z",
-  "links": [],
   "packageFilename": "kbdmacst.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 554
+  }
 }

--- a/legacy/kbd/kbdmaori/kbdmaori.keyboard_info
+++ b/legacy/kbd/kbdmaori/kbdmaori.keyboard_info
@@ -8,7 +8,6 @@
     "mi"
   ],
   "lastModifiedDate": "2009-05-15T14:34:05Z",
-  "links": [],
   "packageFilename": "kbdmaori.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 555
+  }
 }

--- a/legacy/kbd/kbdmlt47/kbdmlt47.keyboard_info
+++ b/legacy/kbd/kbdmlt47/kbdmlt47.keyboard_info
@@ -8,7 +8,6 @@
     "mt"
   ],
   "lastModifiedDate": "2009-05-15T14:34:06Z",
-  "links": [],
   "packageFilename": "kbdmlt47.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 556
+  }
 }

--- a/legacy/kbd/kbdmlt48/kbdmlt48.keyboard_info
+++ b/legacy/kbd/kbdmlt48/kbdmlt48.keyboard_info
@@ -8,7 +8,6 @@
     "mt"
   ],
   "lastModifiedDate": "2009-05-15T14:34:07Z",
-  "links": [],
   "packageFilename": "kbdmlt48.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 557
+  }
 }

--- a/legacy/kbd/kbdmon/kbdmon.keyboard_info
+++ b/legacy/kbd/kbdmon/kbdmon.keyboard_info
@@ -8,7 +8,6 @@
     "khk"
   ],
   "lastModifiedDate": "2009-05-15T16:19:03Z",
-  "links": [],
   "packageFilename": "kbdmon.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 558
+  }
 }

--- a/legacy/kbd/kbdmonmo/kbdmonmo.keyboard_info
+++ b/legacy/kbd/kbdmonmo/kbdmonmo.keyboard_info
@@ -8,7 +8,6 @@
     "mvf"
   ],
   "lastModifiedDate": "2009-05-15T16:19:04Z",
-  "links": [],
   "packageFilename": "kbdmonmo.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 559
+  }
 }

--- a/legacy/kbd/kbdne/kbdne.keyboard_info
+++ b/legacy/kbd/kbdne/kbdne.keyboard_info
@@ -8,7 +8,6 @@
     "nl"
   ],
   "lastModifiedDate": "2009-05-15T14:34:10Z",
-  "links": [],
   "packageFilename": "kbdne.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 560
+  }
 }

--- a/legacy/kbd/kbdnepr/kbdnepr.keyboard_info
+++ b/legacy/kbd/kbdnepr/kbdnepr.keyboard_info
@@ -8,7 +8,6 @@
     "ne"
   ],
   "lastModifiedDate": "2009-05-15T14:34:11Z",
-  "links": [],
   "packageFilename": "kbdnepr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 561
+  }
 }

--- a/legacy/kbd/kbdno/kbdno.keyboard_info
+++ b/legacy/kbd/kbdno/kbdno.keyboard_info
@@ -8,7 +8,6 @@
     "nb"
   ],
   "lastModifiedDate": "2009-05-15T14:34:12Z",
-  "links": [],
   "packageFilename": "kbdno.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 562
+  }
 }

--- a/legacy/kbd/kbdno1/kbdno1.keyboard_info
+++ b/legacy/kbd/kbdno1/kbdno1.keyboard_info
@@ -8,7 +8,6 @@
     "se"
   ],
   "lastModifiedDate": "2009-05-15T14:34:13Z",
-  "links": [],
   "packageFilename": "kbdno1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 563
+  }
 }

--- a/legacy/kbd/kbdpash/kbdpash.keyboard_info
+++ b/legacy/kbd/kbdpash/kbdpash.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:34:14Z",
-  "links": [],
   "packageFilename": "kbdpash.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 564
+  }
 }

--- a/legacy/kbd/kbdpl/kbdpl.keyboard_info
+++ b/legacy/kbd/kbdpl/kbdpl.keyboard_info
@@ -8,7 +8,6 @@
     "pl"
   ],
   "lastModifiedDate": "2009-05-15T14:34:15Z",
-  "links": [],
   "packageFilename": "kbdpl.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 565
+  }
 }

--- a/legacy/kbd/kbdpl1/kbdpl1.keyboard_info
+++ b/legacy/kbd/kbdpl1/kbdpl1.keyboard_info
@@ -8,7 +8,6 @@
     "pl"
   ],
   "lastModifiedDate": "2009-05-15T14:34:16Z",
-  "links": [],
   "packageFilename": "kbdpl1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 566
+  }
 }

--- a/legacy/kbd/kbdpo/kbdpo.keyboard_info
+++ b/legacy/kbd/kbdpo/kbdpo.keyboard_info
@@ -8,7 +8,6 @@
     "pt"
   ],
   "lastModifiedDate": "2009-05-15T14:34:17Z",
-  "links": [],
   "packageFilename": "kbdpo.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 567
+  }
 }

--- a/legacy/kbd/kbdro/kbdro.keyboard_info
+++ b/legacy/kbd/kbdro/kbdro.keyboard_info
@@ -8,7 +8,6 @@
     "ro"
   ],
   "lastModifiedDate": "2009-05-15T14:34:18Z",
-  "links": [],
   "packageFilename": "kbdro.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 568
+  }
 }

--- a/legacy/kbd/kbdropr/kbdropr.keyboard_info
+++ b/legacy/kbd/kbdropr/kbdropr.keyboard_info
@@ -8,7 +8,6 @@
     "ro"
   ],
   "lastModifiedDate": "2009-05-15T14:34:18Z",
-  "links": [],
   "packageFilename": "kbdropr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 569
+  }
 }

--- a/legacy/kbd/kbdrost/kbdrost.keyboard_info
+++ b/legacy/kbd/kbdrost/kbdrost.keyboard_info
@@ -8,7 +8,6 @@
     "ro"
   ],
   "lastModifiedDate": "2009-05-15T14:34:19Z",
-  "links": [],
   "packageFilename": "kbdrost.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 570
+  }
 }

--- a/legacy/kbd/kbdru/kbdru.keyboard_info
+++ b/legacy/kbd/kbdru/kbdru.keyboard_info
@@ -8,7 +8,6 @@
     "ru"
   ],
   "lastModifiedDate": "2009-05-15T14:34:21Z",
-  "links": [],
   "packageFilename": "kbdru.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 571
+  }
 }

--- a/legacy/kbd/kbdru1/kbdru1.keyboard_info
+++ b/legacy/kbd/kbdru1/kbdru1.keyboard_info
@@ -8,7 +8,6 @@
     "ru"
   ],
   "lastModifiedDate": "2009-05-15T14:34:26Z",
-  "links": [],
   "packageFilename": "kbdru1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 572
+  }
 }

--- a/legacy/kbd/kbdsf/kbdsf.keyboard_info
+++ b/legacy/kbd/kbdsf/kbdsf.keyboard_info
@@ -8,7 +8,6 @@
     "lb"
   ],
   "lastModifiedDate": "2009-05-15T14:34:27Z",
-  "links": [],
   "packageFilename": "kbdsf.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 573
+  }
 }

--- a/legacy/kbd/kbdsg/kbdsg.keyboard_info
+++ b/legacy/kbd/kbdsg/kbdsg.keyboard_info
@@ -8,7 +8,6 @@
     "de"
   ],
   "lastModifiedDate": "2009-05-15T14:34:28Z",
-  "links": [],
   "packageFilename": "kbdsg.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 574
+  }
 }

--- a/legacy/kbd/kbdsl/kbdsl.keyboard_info
+++ b/legacy/kbd/kbdsl/kbdsl.keyboard_info
@@ -8,7 +8,6 @@
     "sk"
   ],
   "lastModifiedDate": "2009-05-15T14:34:29Z",
-  "links": [],
   "packageFilename": "kbdsl.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 575
+  }
 }

--- a/legacy/kbd/kbdsl1/kbdsl1.keyboard_info
+++ b/legacy/kbd/kbdsl1/kbdsl1.keyboard_info
@@ -8,7 +8,6 @@
     "sk"
   ],
   "lastModifiedDate": "2009-05-15T14:34:30Z",
-  "links": [],
   "packageFilename": "kbdsl1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 576
+  }
 }

--- a/legacy/kbd/kbdsmsfi/kbdsmsfi.keyboard_info
+++ b/legacy/kbd/kbdsmsfi/kbdsmsfi.keyboard_info
@@ -8,7 +8,6 @@
     "se"
   ],
   "lastModifiedDate": "2009-05-15T14:34:31Z",
-  "links": [],
   "packageFilename": "kbdsmsfi.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 577
+  }
 }

--- a/legacy/kbd/kbdsmsno/kbdsmsno.keyboard_info
+++ b/legacy/kbd/kbdsmsno/kbdsmsno.keyboard_info
@@ -8,7 +8,6 @@
     "se"
   ],
   "lastModifiedDate": "2009-05-15T14:34:33Z",
-  "links": [],
   "packageFilename": "kbdsmsno.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 578
+  }
 }

--- a/legacy/kbd/kbdsorex/kbdsorex.keyboard_info
+++ b/legacy/kbd/kbdsorex/kbdsorex.keyboard_info
@@ -8,7 +8,6 @@
     "hsb"
   ],
   "lastModifiedDate": "2009-05-15T16:19:23Z",
-  "links": [],
   "packageFilename": "kbdsorex.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 580
+  }
 }

--- a/legacy/kbd/kbdsorst/kbdsorst.keyboard_info
+++ b/legacy/kbd/kbdsorst/kbdsorst.keyboard_info
@@ -8,7 +8,6 @@
     "hsb"
   ],
   "lastModifiedDate": "2009-05-15T16:19:24Z",
-  "links": [],
   "packageFilename": "kbdsorst.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 581
+  }
 }

--- a/legacy/kbd/kbdsp/kbdsp.keyboard_info
+++ b/legacy/kbd/kbdsp/kbdsp.keyboard_info
@@ -8,7 +8,6 @@
     "es"
   ],
   "lastModifiedDate": "2009-05-15T14:34:42Z",
-  "links": [],
   "packageFilename": "kbdsp.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 582
+  }
 }

--- a/legacy/kbd/kbdsw/kbdsw.keyboard_info
+++ b/legacy/kbd/kbdsw/kbdsw.keyboard_info
@@ -8,7 +8,6 @@
     "sv"
   ],
   "lastModifiedDate": "2009-05-15T14:34:43Z",
-  "links": [],
   "packageFilename": "kbdsw.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 583
+  }
 }

--- a/legacy/kbd/kbdsw09/kbdsw09.keyboard_info
+++ b/legacy/kbd/kbdsw09/kbdsw09.keyboard_info
@@ -8,7 +8,6 @@
     "si"
   ],
   "lastModifiedDate": "2009-12-22T19:24:18Z",
-  "links": [],
   "packageFilename": "kbdsw09.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 584
+  }
 }

--- a/legacy/kbd/kbdsyr1/kbdsyr1.keyboard_info
+++ b/legacy/kbd/kbdsyr1/kbdsyr1.keyboard_info
@@ -8,7 +8,6 @@
     "syc"
   ],
   "lastModifiedDate": "2009-05-15T14:34:47Z",
-  "links": [],
   "packageFilename": "kbdsyr1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 585
+  }
 }

--- a/legacy/kbd/kbdsyr2/kbdsyr2.keyboard_info
+++ b/legacy/kbd/kbdsyr2/kbdsyr2.keyboard_info
@@ -8,7 +8,6 @@
     "syc"
   ],
   "lastModifiedDate": "2009-05-15T14:34:48Z",
-  "links": [],
   "packageFilename": "kbdsyr2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 586
+  }
 }

--- a/legacy/kbd/kbdtajik/kbdtajik.keyboard_info
+++ b/legacy/kbd/kbdtajik/kbdtajik.keyboard_info
@@ -8,7 +8,6 @@
     "tg"
   ],
   "lastModifiedDate": "2009-05-15T16:19:30Z",
-  "links": [],
   "packageFilename": "kbdtajik.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 587
+  }
 }

--- a/legacy/kbd/kbdtat/kbdtat.keyboard_info
+++ b/legacy/kbd/kbdtat/kbdtat.keyboard_info
@@ -8,7 +8,6 @@
     "tt"
   ],
   "lastModifiedDate": "2009-05-15T14:34:55Z",
-  "links": [],
   "packageFilename": "kbdtat.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 588
+  }
 }

--- a/legacy/kbd/kbdth0/kbdth0.keyboard_info
+++ b/legacy/kbd/kbdth0/kbdth0.keyboard_info
@@ -8,7 +8,6 @@
     "th"
   ],
   "lastModifiedDate": "2009-05-15T14:34:56Z",
-  "links": [],
   "packageFilename": "kbdth0.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 589
+  }
 }

--- a/legacy/kbd/kbdth1/kbdth1.keyboard_info
+++ b/legacy/kbd/kbdth1/kbdth1.keyboard_info
@@ -8,7 +8,6 @@
     "th"
   ],
   "lastModifiedDate": "2009-05-15T14:34:57Z",
-  "links": [],
   "packageFilename": "kbdth1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 590
+  }
 }

--- a/legacy/kbd/kbdth2/kbdth2.keyboard_info
+++ b/legacy/kbd/kbdth2/kbdth2.keyboard_info
@@ -8,7 +8,6 @@
     "th"
   ],
   "lastModifiedDate": "2009-05-15T14:34:58Z",
-  "links": [],
   "packageFilename": "kbdth2.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 591
+  }
 }

--- a/legacy/kbd/kbdth3/kbdth3.keyboard_info
+++ b/legacy/kbd/kbdth3/kbdth3.keyboard_info
@@ -8,7 +8,6 @@
     "th"
   ],
   "lastModifiedDate": "2009-05-15T14:34:59Z",
-  "links": [],
   "packageFilename": "kbdth3.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 592
+  }
 }

--- a/legacy/kbd/kbdtiprc/kbdtiprc.keyboard_info
+++ b/legacy/kbd/kbdtiprc/kbdtiprc.keyboard_info
@@ -8,7 +8,6 @@
     "bo"
   ],
   "lastModifiedDate": "2009-05-15T16:19:36Z",
-  "links": [],
   "packageFilename": "kbdtiprc.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 593
+  }
 }

--- a/legacy/kbd/kbdtuf/kbdtuf.keyboard_info
+++ b/legacy/kbd/kbdtuf/kbdtuf.keyboard_info
@@ -8,7 +8,6 @@
     "tr"
   ],
   "lastModifiedDate": "2009-05-15T14:35:01Z",
-  "links": [],
   "packageFilename": "kbdtuf.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 594
+  }
 }

--- a/legacy/kbd/kbdtuq/kbdtuq.keyboard_info
+++ b/legacy/kbd/kbdtuq/kbdtuq.keyboard_info
@@ -8,7 +8,6 @@
     "tr"
   ],
   "lastModifiedDate": "2014-08-08T16:19:24Z",
-  "links": [],
   "packageFilename": "kbdtuq.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 595
+  }
 }

--- a/legacy/kbd/kbdturme/kbdturme.keyboard_info
+++ b/legacy/kbd/kbdturme/kbdturme.keyboard_info
@@ -8,7 +8,6 @@
     "tk"
   ],
   "lastModifiedDate": "2009-05-15T16:19:40Z",
-  "links": [],
   "packageFilename": "kbdturme.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 596
+  }
 }

--- a/legacy/kbd/kbdughr/kbdughr.keyboard_info
+++ b/legacy/kbd/kbdughr/kbdughr.keyboard_info
@@ -8,7 +8,6 @@
     "ug"
   ],
   "lastModifiedDate": "2009-05-15T16:19:41Z",
-  "links": [],
   "packageFilename": "kbdughr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 597
+  }
 }

--- a/legacy/kbd/kbduk/kbduk.keyboard_info
+++ b/legacy/kbd/kbduk/kbduk.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:04Z",
-  "links": [],
   "packageFilename": "kbduk.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 598
+  }
 }

--- a/legacy/kbd/kbdukx/kbdukx.keyboard_info
+++ b/legacy/kbd/kbdukx/kbdukx.keyboard_info
@@ -8,7 +8,6 @@
     "cy"
   ],
   "lastModifiedDate": "2009-05-15T14:35:04Z",
-  "links": [],
   "packageFilename": "kbdukx.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 599
+  }
 }

--- a/legacy/kbd/kbdur/kbdur.keyboard_info
+++ b/legacy/kbd/kbdur/kbdur.keyboard_info
@@ -8,7 +8,6 @@
     "uk"
   ],
   "lastModifiedDate": "2009-05-15T14:35:05Z",
-  "links": [],
   "packageFilename": "kbdur.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 600
+  }
 }

--- a/legacy/kbd/kbdur1/kbdur1.keyboard_info
+++ b/legacy/kbd/kbdur1/kbdur1.keyboard_info
@@ -8,7 +8,6 @@
     "uk"
   ],
   "lastModifiedDate": "2009-05-15T14:35:06Z",
-  "links": [],
   "packageFilename": "kbdur1.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 601
+  }
 }

--- a/legacy/kbd/kbdurdu/kbdurdu.keyboard_info
+++ b/legacy/kbd/kbdurdu/kbdurdu.keyboard_info
@@ -8,7 +8,6 @@
     "ur"
   ],
   "lastModifiedDate": "2015-01-13T06:20:24Z",
-  "links": [],
   "packageFilename": "kbdurdu.kmp",
   "encodings": [
     "unicode"
@@ -25,6 +24,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 602,
   "jsFilename": "kbdurdu.js"
 }

--- a/legacy/kbd/kbdus/kbdus.keyboard_info
+++ b/legacy/kbd/kbdus/kbdus.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:07Z",
-  "links": [],
   "packageFilename": "kbdus.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 603
+  }
 }

--- a/legacy/kbd/kbdusa/kbdusa.keyboard_info
+++ b/legacy/kbd/kbdusa/kbdusa.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:08Z",
-  "links": [],
   "packageFilename": "kbdusa.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 604
+  }
 }

--- a/legacy/kbd/kbdusl/kbdusl.keyboard_info
+++ b/legacy/kbd/kbdusl/kbdusl.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:09Z",
-  "links": [],
   "packageFilename": "kbdusl.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 605
+  }
 }

--- a/legacy/kbd/kbdusr/kbdusr.keyboard_info
+++ b/legacy/kbd/kbdusr/kbdusr.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:10Z",
-  "links": [],
   "packageFilename": "kbdusr.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 606
+  }
 }

--- a/legacy/kbd/kbdusx/kbdusx.keyboard_info
+++ b/legacy/kbd/kbdusx/kbdusx.keyboard_info
@@ -8,7 +8,6 @@
     "en"
   ],
   "lastModifiedDate": "2009-05-15T14:35:11Z",
-  "links": [],
   "packageFilename": "kbdusx.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 607
+  }
 }

--- a/legacy/kbd/kbduzb/kbduzb.keyboard_info
+++ b/legacy/kbd/kbduzb/kbduzb.keyboard_info
@@ -6,7 +6,6 @@
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2009-05-15T14:35:12Z",
-  "links": [],
   "packageFilename": "kbduzb.kmp",
   "encodings": [
     "unicode"
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 608
+  }
 }

--- a/legacy/kbd/kbdvntc/kbdvntc.keyboard_info
+++ b/legacy/kbd/kbdvntc/kbdvntc.keyboard_info
@@ -8,7 +8,6 @@
     "vi"
   ],
   "lastModifiedDate": "2009-05-15T14:35:12Z",
-  "links": [],
   "packageFilename": "kbdvntc.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 609
+  }
 }

--- a/legacy/kbd/kbdyak/kbdyak.keyboard_info
+++ b/legacy/kbd/kbdyak/kbdyak.keyboard_info
@@ -8,7 +8,6 @@
     "sah"
   ],
   "lastModifiedDate": "2009-05-15T16:19:55Z",
-  "links": [],
   "packageFilename": "kbdyak.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 610
+  }
 }

--- a/legacy/kbd/kbdycc/kbdycc.keyboard_info
+++ b/legacy/kbd/kbdycc/kbdycc.keyboard_info
@@ -8,7 +8,6 @@
     "sr"
   ],
   "lastModifiedDate": "2009-05-15T14:35:14Z",
-  "links": [],
   "packageFilename": "kbdycc.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 611
+  }
 }

--- a/legacy/kbd/kbdycl/kbdycl.keyboard_info
+++ b/legacy/kbd/kbdycl/kbdycl.keyboard_info
@@ -8,7 +8,6 @@
     "sr"
   ],
   "lastModifiedDate": "2009-05-15T14:35:15Z",
-  "links": [],
   "packageFilename": "kbdycl.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 612
+  }
 }

--- a/legacy/l/lao 2008/lao 2008.keyboard_info
+++ b/legacy/l/lao 2008/lao 2008.keyboard_info
@@ -8,7 +8,6 @@
     "lo"
   ],
   "lastModifiedDate": "2009-06-22T17:12:38Z",
-  "links": [],
   "packageFilename": "lao 2008.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 443
+  }
 }

--- a/legacy/l/laounicodebasic_on_thaikbd/laounicodebasic_on_thaikbd.keyboard_info
+++ b/legacy/l/laounicodebasic_on_thaikbd/laounicodebasic_on_thaikbd.keyboard_info
@@ -8,7 +8,6 @@
     "lo"
   ],
   "lastModifiedDate": "2008-03-24T21:17:19Z",
-  "links": [],
   "packageFilename": "laounicodebasic_on_thaikbd.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 431,
-  "documentationFilename": "welcome.pdf"
+  }
 }

--- a/legacy/l/lingfilsemitica/lingfilsemitica.keyboard_info
+++ b/legacy/l/lingfilsemitica/lingfilsemitica.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "lingfilsemitica",
   "name": "LingfilSemitica",
-  "description": "For transcription of Semitic languages and dialects. Also IPA symbols. Adapted primarily for the Swedish national standard (hardware) keyboard",
+  "description": "For transcription of Semitic languages and dialects. Also IPA symbols. Adapted primarily for the Swedish national standard (hardware) keyboard\n<ul>\n  <li><a href='http://www.lingfil.uu.se/afro/semitiska/forskarutbildning/teknikaliteter.html'>Transcribing Semitic Languages</a></li>\n  <li><a href='http://www.anst.uu.se/boisak/lingfilsemitica/welcome.htm'>User's manual</a></li>\n  <li><a href='http://www.anst.uu.se/boisak/lingfilsemitica/readme.htm'>Installation instructions</a></li>\n</ul>\n",
   "authorName": "Bo Isaksson",
   "license": "freeware",
   "languages": [
@@ -24,20 +24,6 @@
     "syc"
   ],
   "lastModifiedDate": "2009-01-09T11:03:27Z",
-  "links": [
-    {
-      "name": "Transcribing Semitic Languages",
-      "url": "http://www.lingfil.uu.se/afro/semitiska/forskarutbildning/teknikaliteter.html"
-    },
-    {
-      "name": "User's manual",
-      "url": "http://www.anst.uu.se/boisak/lingfilsemitica/welcome.htm"
-    },
-    {
-      "name": "Installation instructions",
-      "url": "http://www.anst.uu.se/boisak/lingfilsemitica/readme.htm"
-    }
-  ],
   "packageFilename": "lingfilsemitica.kmp",
   "encodings": [
     "unicode"
@@ -52,7 +38,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 404,
-  "documentationFilename": "welcome.htm"
+  }
 }

--- a/legacy/l/lushootseed/lushootseed.keyboard_info
+++ b/legacy/l/lushootseed/lushootseed.keyboard_info
@@ -8,7 +8,6 @@
     "lut"
   ],
   "lastModifiedDate": "2011-11-11T15:26:19Z",
-  "links": [],
   "packageFilename": "lushootseed.kmp",
   "encodings": [
     "unicode"
@@ -28,7 +27,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 633,
-  "jsFilename": "lushootseed.js",
-  "documentationFilename": "lushootseed unicode keyboard help.pdf"
+  "jsFilename": "lushootseed.js"
 }

--- a/legacy/l/lushootseed_u/lushootseed_u.keyboard_info
+++ b/legacy/l/lushootseed_u/lushootseed_u.keyboard_info
@@ -8,7 +8,6 @@
     "lut"
   ],
   "lastModifiedDate": "2013-04-12T15:45:28Z",
-  "links": [],
   "packageFilename": "lushootseed_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 666,
-  "documentationFilename": "lushootseed - basic usage.pdf"
+  }
 }

--- a/legacy/m/maliazerty/maliazerty.keyboard_info
+++ b/legacy/m/maliazerty/maliazerty.keyboard_info
@@ -33,7 +33,6 @@
     "kao"
   ],
   "lastModifiedDate": "2009-03-20T09:05:29Z",
-  "links": [],
   "packageFilename": "maliazerty.kmp",
   "encodings": [
     "unicode"
@@ -47,7 +46,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 464,
-  "documentationFilename": "tableautouchesazerty22.pdf"
+  }
 }

--- a/legacy/m/malideutsch/malideutsch.keyboard_info
+++ b/legacy/m/malideutsch/malideutsch.keyboard_info
@@ -33,7 +33,6 @@
     "kao"
   ],
   "lastModifiedDate": "2009-01-09T14:38:02Z",
-  "links": [],
   "packageFilename": "malideutsch.kmp",
   "encodings": [
     "unicode"
@@ -47,6 +46,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 466
+  }
 }

--- a/legacy/m/maliqwerty/maliqwerty.keyboard_info
+++ b/legacy/m/maliqwerty/maliqwerty.keyboard_info
@@ -33,7 +33,6 @@
     "kao"
   ],
   "lastModifiedDate": "2009-03-20T09:03:44Z",
-  "links": [],
   "packageFilename": "maliqwerty.kmp",
   "encodings": [
     "unicode"
@@ -47,7 +46,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 465,
-  "documentationFilename": "tableautouchesqwerty22.pdf"
+  }
 }

--- a/legacy/m/malta/malta.keyboard_info
+++ b/legacy/m/malta/malta.keyboard_info
@@ -9,7 +9,6 @@
     "mt"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "malta.kmp",
   "encodings": [
     "ansi"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 334,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/legacy/m/mbsindhi/mbsindhi.keyboard_info
+++ b/legacy/m/mbsindhi/mbsindhi.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "mbsindhi",
   "name": "MBSindhi",
-  "description": "This is Phonetic keyboard for Sindhi based on the keyboard layout as developed by Abdul-Majid Bhurgri in 1988 for Macintosh and later approved by Sindhi Language Authority of Pakistan as standard keyboard for Sindhi language.",
+  "description": "This is Phonetic keyboard for Sindhi based on the keyboard layout as developed by Abdul-Majid Bhurgri in 1988 for Macintosh and later approved by Sindhi Language Authority of Pakistan as standard keyboard for Sindhi language.\n<ul>\n  <li><a href='http://bhurgri.com/bhurgri/sd_index.php'>Bhurgri's Sindhi Website</a></li>\n</ul>\n",
   "authorName": "Majid Bhurgri",
   "license": "freeware",
   "languages": [
     "sd"
   ],
   "lastModifiedDate": "2010-05-21T15:56:24Z",
-  "links": [
-    {
-      "name": "Bhurgri's Sindhi Website",
-      "url": "http://bhurgri.com/bhurgri/sd_index.php"
-    }
-  ],
   "packageFilename": "mbsindhi.kmp",
   "encodings": [
     "unicode"
@@ -26,6 +20,5 @@
     "macos": "full",
     "linux": "full"
   },
-  "legacyId": 336,
   "jsFilename": "mbsindhi.js"
 }

--- a/legacy/m/mextep/mextep.keyboard_info
+++ b/legacy/m/mextep/mextep.keyboard_info
@@ -9,7 +9,6 @@
     "tla"
   ],
   "lastModifiedDate": "2008-06-30T11:06:50Z",
-  "links": [],
   "packageFilename": "mextep.kmp",
   "encodings": [
     "ansi",
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 433
+  }
 }

--- a/legacy/m/mohawk_u/mohawk_u.keyboard_info
+++ b/legacy/m/mohawk_u/mohawk_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "mohawk_u",
   "name": "Mohawk Unicode (obsolete non-Unicode)",
-  "description": "For historical research. Despite the name, this is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/fv_kanienkeha_e'>https://keyman.com/keyboards/fv_kanienkeha_e</a>. (Keyboard layouts for typing Mohawk.)",
+  "description": "For historical research. Despite the name, this is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/fv_kanienkeha_e'>https://keyman.com/keyboards/fv_kanienkeha_e</a>. (Keyboard layouts for typing Mohawk.)\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Mohawk ANSI and Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "moh"
   ],
   "lastModifiedDate": "2012-01-23T17:58:46Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Mohawk ANSI and Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "mohawk_u.kmp",
   "encodings": [
     "ansi"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 337
+  }
 }

--- a/legacy/m/moore/moore.keyboard_info
+++ b/legacy/m/moore/moore.keyboard_info
@@ -8,7 +8,6 @@
     "mos"
   ],
   "lastModifiedDate": "2006-09-18T09:04:58Z",
-  "links": [],
   "packageFilename": "moore.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 394,
-  "documentationFilename": "welcome.htm"
+  }
 }

--- a/legacy/m/mozhi/mozhi.keyboard_info
+++ b/legacy/m/mozhi/mozhi.keyboard_info
@@ -8,7 +8,6 @@
     "ml"
   ],
   "lastModifiedDate": "2012-08-24T09:19:44Z",
-  "links": [],
   "packageFilename": "mozhi.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 654,
-  "documentationFilename": "mozhi malayalam keyboard.pdf"
+  }
 }

--- a/legacy/m/mozhi51/mozhi51.keyboard_info
+++ b/legacy/m/mozhi51/mozhi51.keyboard_info
@@ -8,7 +8,6 @@
     "ml"
   ],
   "lastModifiedDate": "2014-02-06T14:45:29Z",
-  "links": [],
   "packageFilename": "mozhi51.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 678,
-  "documentationFilename": "mozhi malayalam keyboard.pdf"
+  }
 }

--- a/legacy/m/multi pak/multi pak.keyboard_info
+++ b/legacy/m/multi pak/multi pak.keyboard_info
@@ -15,7 +15,6 @@
     "ur"
   ],
   "lastModifiedDate": "2007-12-12T10:56:36Z",
-  "links": [],
   "packageFilename": "multi pak.kmp",
   "encodings": [
     "unicode"
@@ -30,7 +29,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 416,
-  "documentationFilename": "multi language pakistan phonetic keyboard.pdf"
+  }
 }

--- a/legacy/m/myanmar/myanmar.keyboard_info
+++ b/legacy/m/myanmar/myanmar.keyboard_info
@@ -8,7 +8,6 @@
     "my"
   ],
   "lastModifiedDate": "2015-03-06T09:24:42Z",
-  "links": [],
   "packageFilename": "myanmar.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 696
+  }
 }

--- a/legacy/n/naskapi_u/naskapi_u.keyboard_info
+++ b/legacy/n/naskapi_u/naskapi_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "naskapi_u",
   "name": "Naskapi Unicode",
-  "description": "Keyboard layouts for typing Naskapi in Unicode syllabics.  ",
+  "description": "Keyboard layouts for typing Naskapi in Unicode syllabics.  \n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html'>Naskapi Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "nsk"
   ],
   "lastModifiedDate": "2012-01-23T17:59:01Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Naskapi Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/algon/syllabics_keyboards/cr_oj_oc_na.html"
-    }
-  ],
   "packageFilename": "naskapi_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 645
+  }
 }

--- a/legacy/n/naskeysdesktop/naskeysdesktop.keyboard_info
+++ b/legacy/n/naskeysdesktop/naskeysdesktop.keyboard_info
@@ -8,7 +8,6 @@
     "nsk"
   ],
   "lastModifiedDate": "2009-08-21T13:26:03Z",
-  "links": [],
   "packageFilename": "naskeysdesktop.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 618
+  }
 }

--- a/legacy/n/ndailu keyman keyboard/ndailu keyman keyboard.keyboard_info
+++ b/legacy/n/ndailu keyman keyboard/ndailu keyman keyboard.keyboard_info
@@ -8,7 +8,6 @@
     "khb"
   ],
   "lastModifiedDate": "2016-08-26T19:26:10Z",
-  "links": [],
   "packageFilename": "ndailu keyman keyboard.kmp",
   "packageIncludes": [
     "documentation",
@@ -20,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 704
+  }
 }

--- a/legacy/n/nigeria unicode dots/nigeria unicode dots.keyboard_info
+++ b/legacy/n/nigeria unicode dots/nigeria unicode dots.keyboard_info
@@ -16,7 +16,6 @@
     "tan"
   ],
   "lastModifiedDate": "2006-02-13T20:52:39Z",
-  "links": [],
   "packageFilename": "nigeria unicode dots.kmp",
   "encodings": [
     "unicode"
@@ -26,7 +25,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 379,
-  "documentationFilename": "nigeria unicode dot keyboard chart.pdf"
+  }
 }

--- a/legacy/n/nigeria unicode odd vowels/nigeria unicode odd vowels.keyboard_info
+++ b/legacy/n/nigeria unicode odd vowels/nigeria unicode odd vowels.keyboard_info
@@ -16,7 +16,6 @@
     "yer"
   ],
   "lastModifiedDate": "2006-02-13T20:52:50Z",
-  "links": [],
   "packageFilename": "nigeria unicode odd vowels.kmp",
   "encodings": [
     "unicode"
@@ -26,7 +25,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 380,
-  "documentationFilename": "nigeria unicode odd vowels keyboard chart.pdf"
+  }
 }

--- a/legacy/n/nigeria unicode underline/nigeria unicode underline.keyboard_info
+++ b/legacy/n/nigeria unicode underline/nigeria unicode underline.keyboard_info
@@ -20,7 +20,6 @@
     "tvd"
   ],
   "lastModifiedDate": "2006-02-13T20:52:54Z",
-  "links": [],
   "packageFilename": "nigeria unicode underline.kmp",
   "encodings": [
     "unicode"
@@ -30,7 +29,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 381,
-  "documentationFilename": "nigeria unicode underline keyboard chart.pdf"
+  }
 }

--- a/legacy/n/nisgaa_u/nisgaa_u.keyboard_info
+++ b/legacy/n/nisgaa_u/nisgaa_u.keyboard_info
@@ -8,7 +8,6 @@
     "ncg"
   ],
   "lastModifiedDate": "2012-01-23T17:59:07Z",
-  "links": [],
   "packageFilename": "nisgaa_u.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 646
+  }
 }

--- a/legacy/n/nlekepmxcin_u/nlekepmxcin_u.keyboard_info
+++ b/legacy/n/nlekepmxcin_u/nlekepmxcin_u.keyboard_info
@@ -8,7 +8,6 @@
     "thp"
   ],
   "lastModifiedDate": "2013-04-12T15:45:38Z",
-  "links": [],
   "packageFilename": "nlekepmxcin_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 667,
-  "documentationFilename": "nle'kepmxcin - basic usage.pdf"
+  }
 }

--- a/legacy/n/nuer13/nuer13.keyboard_info
+++ b/legacy/n/nuer13/nuer13.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "nuer13",
   "name": "Nuer",
-  "description": "This keyboard provides input mapping for typing Nuer, using Unicode OpenType fonts.",
+  "description": "This keyboard provides input mapping for typing Nuer, using Unicode OpenType fonts.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/african/nuer/nuer13.html'>Author's notes on using the Nuer keyboard</a></li>\n  <li><a href='http://www.openroad.net.au/languages/african/nuer/nuer13.kmp'>Download Keyman 6 keyboard for Nuer</a></li>\n  <li><a href='http://www.openroad.net.au/languages/african/nuer/'>Author's website</a></li>\n</ul>\n",
   "authorName": "Andrew Cunningham",
   "license": "freeware",
   "languages": [
     "nus"
   ],
   "lastModifiedDate": "2006-04-28T10:53:04Z",
-  "links": [
-    {
-      "name": "Author's notes on using the Nuer keyboard",
-      "url": "http://www.openroad.net.au/languages/african/nuer/nuer13.html"
-    },
-    {
-      "name": "Download Keyman 6 keyboard for Nuer",
-      "url": "http://www.openroad.net.au/languages/african/nuer/nuer13.kmp"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.openroad.net.au/languages/african/nuer/"
-    }
-  ],
   "packageFilename": "nuer13.kmp",
   "encodings": [
     "unicode"
@@ -39,7 +25,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 386,
-  "jsFilename": "nuer13.js",
-  "documentationFilename": "nuer13.pdf"
+  "jsFilename": "nuer13.js"
 }

--- a/legacy/n/nuuchahnulth_u/nuuchahnulth_u.keyboard_info
+++ b/legacy/n/nuuchahnulth_u/nuuchahnulth_u.keyboard_info
@@ -9,7 +9,6 @@
     "nuk"
   ],
   "lastModifiedDate": "2013-04-12T15:45:49Z",
-  "links": [],
   "packageFilename": "nuuchahnulth_u.kmp",
   "encodings": [
     "unicode"
@@ -20,7 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 668,
-  "documentationFilename": "nuuchahnulth - basic usage.pdf"
+  }
 }

--- a/legacy/o/okanagan_u/okanagan_u.keyboard_info
+++ b/legacy/o/okanagan_u/okanagan_u.keyboard_info
@@ -8,7 +8,6 @@
     "oka"
   ],
   "lastModifiedDate": "2013-04-12T15:45:59Z",
-  "links": [],
   "packageFilename": "okanagan_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 669,
-  "documentationFilename": "okanagan - basic usage.pdf"
+  }
 }

--- a/legacy/o/okanaganu/okanaganu.keyboard_info
+++ b/legacy/o/okanaganu/okanaganu.keyboard_info
@@ -1,17 +1,11 @@
 {
   "id": "okanaganu",
   "name": "OkanaganU",
-  "description": "This keyboard is designed to enable simple input of the characters needed to type Okanagan Salish.",
+  "description": "This keyboard is designed to enable simple input of the characters needed to type Okanagan Salish.\n<ul>\n  <li><a href='http://www.meltr.org/Resources/Keyboards/Keyboards.htm'>Okanagan-Colville Keyboard</a></li>\n</ul>\n",
   "authorName": "Tony Mattina",
   "license": "freeware",
   "languages": [],
   "lastModifiedDate": "2012-02-23T07:49:34Z",
-  "links": [
-    {
-      "name": "Okanagan-Colville Keyboard",
-      "url": "http://www.meltr.org/Resources/Keyboards/Keyboards.htm"
-    }
-  ],
   "packageFilename": "okanaganu.kmp",
   "encodings": [
     "unicode"
@@ -26,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 627
+  }
 }

--- a/legacy/o/oneida_u/oneida_u.keyboard_info
+++ b/legacy/o/oneida_u/oneida_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "oneida_u",
   "name": "Oneida Unicode",
-  "description": "Keyboard layout for typing Oneida using Unicode fonts.",
+  "description": "Keyboard layout for typing Oneida using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Oneida Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "one"
   ],
   "lastModifiedDate": "2012-01-23T17:59:38Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Oneida Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "oneida_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 342
+  }
 }

--- a/legacy/o/onondaga_u/onondaga_u.keyboard_info
+++ b/legacy/o/onondaga_u/onondaga_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "onondaga_u",
   "name": "Onondaga Unicode",
-  "description": "Keyboard layout for typing Onondaga using Unicode fonts.",
+  "description": "Keyboard layout for typing Onondaga using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Onondaga Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "ono"
   ],
   "lastModifiedDate": "2012-01-23T17:59:49Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Onondaga Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "onondaga_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 343
+  }
 }

--- a/legacy/o/orviet10/orviet10.keyboard_info
+++ b/legacy/o/orviet10/orviet10.keyboard_info
@@ -26,7 +26,6 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 387,
   "jsFilename": "orviet10.js",
   "related": {
     "vietweb11": {

--- a/legacy/o/orvietviqr10/orvietviqr10.keyboard_info
+++ b/legacy/o/orvietviqr10/orvietviqr10.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "orvietviqr10",
   "name": "OR Vietnamese (VIQR)",
-  "description": "Vetnamese Unicode keyboard layout. Uses VIQR convention for typing Vietnamese.",
+  "description": "Vetnamese Unicode keyboard layout. Uses VIQR convention for typing Vietnamese.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/seasian/'>Author's website</a></li>\n</ul>\n",
   "authorName": "Andrew Cunningham",
   "license": "freeware",
   "languages": [
     "vi"
   ],
   "lastModifiedDate": "2006-05-22T17:22:55Z",
-  "links": [
-    {
-      "name": "Author's website",
-      "url": "http://www.openroad.net.au/languages/seasian/"
-    }
-  ],
   "packageFilename": "orvietviqr10.kmp",
   "encodings": [
     "unicode"
@@ -31,6 +25,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 388,
   "jsFilename": "orvietviqr10.js"
 }

--- a/legacy/p/pashai 2/pashai 2.keyboard_info
+++ b/legacy/p/pashai 2/pashai 2.keyboard_info
@@ -8,7 +8,6 @@
     "psi"
   ],
   "lastModifiedDate": "2016-06-09T08:19:55Z",
-  "links": [],
   "packageFilename": "pashai 2.kmp",
   "packageIncludes": [
     "documentation"
@@ -17,7 +16,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 702,
-  "documentationFilename": "pashai keyboard readme 1 revised.pdf"
+  }
 }

--- a/legacy/p/persian11/persian11.keyboard_info
+++ b/legacy/p/persian11/persian11.keyboard_info
@@ -8,7 +8,6 @@
     "pes"
   ],
   "lastModifiedDate": "2007-11-28T08:48:24Z",
-  "links": [],
   "packageFilename": "persian11.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 345
+  }
 }

--- a/legacy/p/phoneticarabic/phoneticarabic.keyboard_info
+++ b/legacy/p/phoneticarabic/phoneticarabic.keyboard_info
@@ -8,7 +8,6 @@
     "arb"
   ],
   "lastModifiedDate": "2009-02-27T11:01:34Z",
-  "links": [],
   "packageFilename": "phoneticarabic.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 468
+  }
 }

--- a/legacy/p/phoneticmalayalam/phoneticmalayalam.keyboard_info
+++ b/legacy/p/phoneticmalayalam/phoneticmalayalam.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "phoneticmalayalam",
   "name": "Phonetic Malayalam",
-  "description": "An easy to use phonetic keyboard for typing Malayalam, and the Malayalam Unicode OpenType font 'AnjaliOldLipi'.\r\n",
+  "description": "An easy to use phonetic keyboard for typing Malayalam, and the Malayalam Unicode OpenType font 'AnjaliOldLipi'.\r\n\n<ul>\n  <li><a href='http://nishad.net'>കൈപ്പള്ളി</a></li>\n</ul>\n",
   "authorName": "Nishad Kaippally",
   "license": "freeware",
   "languages": [
     "ml"
   ],
   "lastModifiedDate": "2012-06-01T15:15:48Z",
-  "links": [
-    {
-      "name": "കൈപ്പള്ളി",
-      "url": "http://nishad.net"
-    }
-  ],
   "packageFilename": "phoneticmalayalam.kmp",
   "encodings": [
     "unicode"
@@ -33,7 +27,5 @@
     "android": "basic",
     "macos": "full"
   },
-  "legacyId": 613,
-  "jsFilename": "phoneticmalayalam.js",
-  "documentationFilename": "phoneticmalayalam.pdf"
+  "jsFilename": "phoneticmalayalam.js"
 }

--- a/legacy/p/phonyrus/phonyrus.keyboard_info
+++ b/legacy/p/phonyrus/phonyrus.keyboard_info
@@ -8,7 +8,6 @@
     "ru"
   ],
   "lastModifiedDate": "2007-10-24T17:27:40Z",
-  "links": [],
   "packageFilename": "phonyrus.kmp",
   "encodings": [
     "unicode",
@@ -24,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 408
+  }
 }

--- a/legacy/p/pinyin/pinyin.keyboard_info
+++ b/legacy/p/pinyin/pinyin.keyboard_info
@@ -8,7 +8,6 @@
     "cmn"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "pinyin.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 346
+  }
 }

--- a/legacy/p/pokhto/pokhto.keyboard_info
+++ b/legacy/p/pokhto/pokhto.keyboard_info
@@ -10,7 +10,6 @@
     "pbt"
   ],
   "lastModifiedDate": "2006-11-13T13:58:17Z",
-  "links": [],
   "packageFilename": "pokhto.kmp",
   "encodings": [
     "unicode"
@@ -26,6 +25,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 399
+  }
 }

--- a/legacy/p/pothana/pothana.keyboard_info
+++ b/legacy/p/pothana/pothana.keyboard_info
@@ -8,7 +8,6 @@
     "te"
   ],
   "lastModifiedDate": "2015-03-12T08:14:16Z",
-  "links": [],
   "packageFilename": "pothana.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 682,
-  "documentationFilename": "manual.pdf"
+  }
 }

--- a/legacy/r/rawangu7/rawangu7.keyboard_info
+++ b/legacy/r/rawangu7/rawangu7.keyboard_info
@@ -8,7 +8,6 @@
     "raw"
   ],
   "lastModifiedDate": "2012-05-03T09:19:25Z",
-  "links": [],
   "packageFilename": "rawangu7.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 414,
-  "documentationFilename": "rawang unicode keyboard.pdf"
+  }
 }

--- a/legacy/r/russian-tajik/russian-tajik.keyboard_info
+++ b/legacy/r/russian-tajik/russian-tajik.keyboard_info
@@ -9,7 +9,6 @@
     "tg"
   ],
   "lastModifiedDate": "2015-02-16T19:44:47Z",
-  "links": [],
   "packageFilename": "russian-tajik.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 312,
-  "documentationFilename": "tajik-alphabet.pdf"
+  }
 }

--- a/legacy/s/sabdalipi assamese/sabdalipi assamese.keyboard_info
+++ b/legacy/s/sabdalipi assamese/sabdalipi assamese.keyboard_info
@@ -8,7 +8,6 @@
     "as"
   ],
   "lastModifiedDate": "2009-10-05T17:36:48Z",
-  "links": [],
   "packageFilename": "sabdalipi assamese.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 619
+  }
 }

--- a/legacy/s/sanskrit csx/sanskrit csx.keyboard_info
+++ b/legacy/s/sanskrit csx/sanskrit csx.keyboard_info
@@ -8,7 +8,6 @@
     "sa"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "sanskrit csx.kmp",
   "encodings": [
     "ansi"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 351
+  }
 }

--- a/legacy/s/sanskrit unicode/sanskrit unicode.keyboard_info
+++ b/legacy/s/sanskrit unicode/sanskrit unicode.keyboard_info
@@ -13,7 +13,6 @@
     }
   },
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "sanskrit unicode.kmp",
   "encodings": [
     "unicode"
@@ -26,6 +25,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 352
+  }
 }

--- a/legacy/s/secwepemctsin_u/secwepemctsin_u.keyboard_info
+++ b/legacy/s/secwepemctsin_u/secwepemctsin_u.keyboard_info
@@ -8,7 +8,6 @@
     "shs"
   ],
   "lastModifiedDate": "2013-04-12T15:46:11Z",
-  "links": [],
   "packageFilename": "secwepemctsin_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 670,
-  "documentationFilename": "secwepemctsin - basic usage.pdf"
+  }
 }

--- a/legacy/s/sencoten_u/sencoten_u.keyboard_info
+++ b/legacy/s/sencoten_u/sencoten_u.keyboard_info
@@ -8,9 +8,7 @@
     "str"
   ],
   "lastModifiedDate": "2013-04-12T15:46:31Z",
-  "links": [],
   "packageFilename": "sencoten_u.kmp",
-  "documentationFilename": "sencoten Unicode - Basic Usage.pdf",
   "encodings": [
     "unicode"
   ],
@@ -20,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 671
+  }
 }

--- a/legacy/s/seneca_u/seneca_u.keyboard_info
+++ b/legacy/s/seneca_u/seneca_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "seneca_u",
   "name": "Seneca Unicode",
-  "description": "Keyboard layout for typing Seneca using Unicode fonts.",
+  "description": "Keyboard layout for typing Seneca using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Seneca Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "see"
   ],
   "lastModifiedDate": "2012-01-23T17:59:58Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Seneca Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "seneca_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 353
+  }
 }

--- a/legacy/s/shashishalhem_u/shashishalhem_u.keyboard_info
+++ b/legacy/s/shashishalhem_u/shashishalhem_u.keyboard_info
@@ -8,7 +8,6 @@
     "sec"
   ],
   "lastModifiedDate": "2013-04-12T15:46:42Z",
-  "links": [],
   "packageFilename": "shashishalhem_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 672,
-  "documentationFilename": "shashishalhem - basic usage.pdf"
+  }
 }

--- a/legacy/s/silethiopicv1.3k7/silethiopicv1.3k7.keyboard_info
+++ b/legacy/s/silethiopicv1.3k7/silethiopicv1.3k7.keyboard_info
@@ -18,7 +18,6 @@
     "ti"
   ],
   "lastModifiedDate": "2014-08-08T16:37:39Z",
-  "links": [],
   "packageFilename": "silethiopicv1.3k7.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +31,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 691,
-  "documentationFilename": "readme.html"
+  }
 }

--- a/legacy/s/silvaiunicodekmn/silvaiunicodekmn.keyboard_info
+++ b/legacy/s/silvaiunicodekmn/silvaiunicodekmn.keyboard_info
@@ -8,7 +8,6 @@
     "vai"
   ],
   "lastModifiedDate": "2014-08-08T16:37:22Z",
-  "links": [],
   "packageFilename": "silvaiunicodekmn.kmp",
   "encodings": [
     "unicode"
@@ -21,7 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 690,
-  "documentationFilename": "vaikbduni.pdf"
+  }
 }

--- a/legacy/s/siouan-unicode/siouan-unicode.keyboard_info
+++ b/legacy/s/siouan-unicode/siouan-unicode.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "siouan-unicode",
   "name": "Siouan Unicode",
-  "description": "A keyboard for typing in Siouan languages.",
+  "description": "A keyboard for typing in Siouan languages.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/siouan/keyboards/si_kbds.html'>Siouan family Unicode keyboard and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -10,20 +10,6 @@
     "sto"
   ],
   "lastModifiedDate": "2012-03-20T12:14:32Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Siouan family Unicode keyboard and information",
-      "url": "http://www.languagegeek.com/siouan/keyboards/si_kbds.html"
-    }
-  ],
   "packageFilename": "siouan-unicode.kmp",
   "encodings": [
     "unicode"
@@ -34,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 356
+  }
 }

--- a/legacy/s/sipon phonetic sinhala/sipon phonetic sinhala.keyboard_info
+++ b/legacy/s/sipon phonetic sinhala/sipon phonetic sinhala.keyboard_info
@@ -8,7 +8,6 @@
     "si"
   ],
   "lastModifiedDate": "2015-02-17T10:00:28Z",
-  "links": [],
   "packageFilename": "sipon phonetic sinhala.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 695,
-  "documentationFilename": "documentation.htm"
+  }
 }

--- a/legacy/s/skwxwumesh_u/skwxwumesh_u.keyboard_info
+++ b/legacy/s/skwxwumesh_u/skwxwumesh_u.keyboard_info
@@ -8,7 +8,6 @@
     "squ"
   ],
   "lastModifiedDate": "2013-04-12T15:46:58Z",
-  "links": [],
   "packageFilename": "skwxwumesh_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 673,
-  "documentationFilename": "skwxwumesh - basic usage.pdf"
+  }
 }

--- a/legacy/s/smalgyax_u/smalgyax_u.keyboard_info
+++ b/legacy/s/smalgyax_u/smalgyax_u.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "smalgyax_u",
   "name": "Tsimshian Unicode",
-  "description": "A keyboard for typing the Tsimshian language (Sm'algyax).   ",
+  "description": "A keyboard for typing the Tsimshian language (Sm'algyax).   \n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/nwc/nwc_keyboards.html'>Tsimshian family Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "tsi"
   ],
   "lastModifiedDate": "2012-01-23T18:00:33Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Tsimshian family Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/nwc/nwc_keyboards.html"
-    }
-  ],
   "packageFilename": "smalgyax_u.kmp",
   "encodings": [
     "unicode"
@@ -32,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 367
+  }
 }

--- a/legacy/s/spantepu/spantepu.keyboard_info
+++ b/legacy/s/spantepu/spantepu.keyboard_info
@@ -9,7 +9,6 @@
     "tla"
   ],
   "lastModifiedDate": "2014-02-07T11:10:21Z",
-  "links": [],
   "packageFilename": "spantepu.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 679
+  }
 }

--- a/legacy/s/statimc_u/statimc_u.keyboard_info
+++ b/legacy/s/statimc_u/statimc_u.keyboard_info
@@ -8,7 +8,6 @@
     "lil"
   ],
   "lastModifiedDate": "2013-04-12T15:47:10Z",
-  "links": [],
   "packageFilename": "statimc_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 674,
-  "documentationFilename": "st'at'imcets - basic usage.pdf"
+  }
 }

--- a/legacy/t/tajik/tajik.keyboard_info
+++ b/legacy/t/tajik/tajik.keyboard_info
@@ -8,7 +8,6 @@
     "tg"
   ],
   "lastModifiedDate": "2008-10-24T08:28:46Z",
-  "links": [],
   "packageFilename": "tajik.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 445
+  }
 }

--- a/legacy/t/tamil - visual media/tamil - visual media.keyboard_info
+++ b/legacy/t/tamil - visual media/tamil - visual media.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "tamil - visual media",
   "name": "Tamil - Visual Media",
-  "description": "This package includes two keyboard layouts: Typewriter and \"Modular\" layout input for Tamil Unicode.",
+  "description": "This package includes two keyboard layouts: Typewriter and \"Modular\" layout input for Tamil Unicode.\n<ul>\n  <li><a href='http://www.tavultesoft.com/tamil/'>Tamil Keyboards</a></li>\n</ul>\n",
   "authorName": "Murali M.S.",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2010-05-21T15:57:30Z",
-  "links": [
-    {
-      "name": "Tamil Keyboards",
-      "url": "http://www.tavultesoft.com/tamil/"
-    }
-  ],
   "packageFilename": "tamil - visual media.kmp",
   "encodings": [
     "unicode"
@@ -28,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 446
+  }
 }

--- a/legacy/t/tchadunicode_with_charis_fonts/tchadunicode_with_charis_fonts.keyboard_info
+++ b/legacy/t/tchadunicode_with_charis_fonts/tchadunicode_with_charis_fonts.keyboard_info
@@ -138,7 +138,6 @@
     "zrn"
   ],
   "lastModifiedDate": "2010-05-07T14:27:52Z",
-  "links": [],
   "packageFilename": "tchadunicode_with_charis_fonts.kmp",
   "encodings": [
     "unicode"
@@ -154,6 +153,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 622
+  }
 }

--- a/legacy/t/tengwar/tengwar.keyboard_info
+++ b/legacy/t/tengwar/tengwar.keyboard_info
@@ -8,7 +8,6 @@
     "qaa"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [],
   "packageFilename": "tengwar.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 360
+  }
 }

--- a/legacy/t/thai-uni/thai-uni.keyboard_info
+++ b/legacy/t/thai-uni/thai-uni.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thai-uni",
   "name": "Thai Unicode",
-  "description": " \tThai-Unicode is a Thai script Unicode keyboard based on the standard Thai Kedmanee layout with included On Screen Keyboard. Efficient input of uncommon Thai symbols is defined. Reordering rules maintain consistent underlying sequence of diacritic vowels and tones, and other rules prevent entry of many illegal vowel and tone sequences and beep to alert the typist.  ",
+  "description": " \tThai-Unicode is a Thai script Unicode keyboard based on the standard Thai Kedmanee layout with included On Screen Keyboard. Efficient input of uncommon Thai symbols is defined. Reordering rules maintain consistent underlying sequence of diacritic vowels and tones, and other rules prevent entry of many illegal vowel and tone sequences and beep to alert the typist.  \n<ul>\n  <li><a href='http://lao-thai.keymankeyboards.com/'>Thai Unicode</a></li>\n</ul>\n",
   "authorName": "Lao & Thai Language Services",
   "license": "freeware",
   "languages": [
     "th"
   ],
   "lastModifiedDate": "2012-06-01T15:15:50Z",
-  "links": [
-    {
-      "name": "Thai Unicode",
-      "url": "http://lao-thai.keymankeyboards.com/"
-    }
-  ],
   "packageFilename": "thai-uni.kmp",
   "encodings": [
     "unicode"
@@ -28,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 430,
-  "documentationFilename": "welcome.pdf"
+  }
 }

--- a/legacy/t/thamizha anjal/thamizha anjal.keyboard_info
+++ b/legacy/t/thamizha anjal/thamizha anjal.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thamizha anjal",
   "name": "Thamizha Anjal",
-  "description": "Tamil keyboard for Unicode fonts using the Anjal (phonetic) layout convention.",
+  "description": "Tamil keyboard for Unicode fonts using the Anjal (phonetic) layout convention.\n<ul>\n  <li><a href='http://www.tavultesoft.com/tamil/'>Tamil Keyboards</a></li>\n</ul>\n",
   "authorName": "Muguntharaj Subramanian",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2010-05-21T15:57:23Z",
-  "links": [
-    {
-      "name": "Tamil Keyboards",
-      "url": "http://www.tavultesoft.com/tamil/"
-    }
-  ],
   "packageFilename": "thamizha anjal.kmp",
   "encodings": [
     "unicode"
@@ -28,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 448
+  }
 }

--- a/legacy/t/thamizha bamini/thamizha bamini.keyboard_info
+++ b/legacy/t/thamizha bamini/thamizha bamini.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thamizha bamini",
   "name": "Thamizha Bamini",
-  "description": "Tamil keyboard for Unicode fonts using the Bamini layout convention.",
+  "description": "Tamil keyboard for Unicode fonts using the Bamini layout convention.\n<ul>\n  <li><a href='http://www.tavultesoft.com/tamil/'>Tamil Keyboards</a></li>\n</ul>\n",
   "authorName": "Muguntharaj Subramanian",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2010-05-21T15:57:15Z",
-  "links": [
-    {
-      "name": "Tamil Keyboards",
-      "url": "http://www.tavultesoft.com/tamil/"
-    }
-  ],
   "packageFilename": "thamizha bamini.kmp",
   "encodings": [
     "unicode"
@@ -28,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 449
+  }
 }

--- a/legacy/t/thamizha tamil99/thamizha tamil99.keyboard_info
+++ b/legacy/t/thamizha tamil99/thamizha tamil99.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thamizha tamil99",
   "name": "Thamizha Tamil99",
-  "description": "Tamil keyboard for Unicode fonts using the Tamil99 layout convention.",
+  "description": "Tamil keyboard for Unicode fonts using the Tamil99 layout convention.\n<ul>\n  <li><a href='http://www.tavultesoft.com/tamil/'>Tamil Keyboards</a></li>\n</ul>\n",
   "authorName": "Muguntharaj Subramanian",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2010-05-21T15:57:01Z",
-  "links": [
-    {
-      "name": "Tamil Keyboards",
-      "url": "http://www.tavultesoft.com/tamil/"
-    }
-  ],
   "packageFilename": "thamizha tamil99.kmp",
   "encodings": [
     "unicode"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 451
+  }
 }

--- a/legacy/t/thamizha typewriter/thamizha typewriter.keyboard_info
+++ b/legacy/t/thamizha typewriter/thamizha typewriter.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thamizha typewriter",
   "name": "Thamizha Typewriter",
-  "description": "Tamil keyboard for Unicode fonts using the New Typewriter layout convention.",
+  "description": "Tamil keyboard for Unicode fonts using the New Typewriter layout convention.\n<ul>\n  <li><a href='http://www.tavultesoft.com/tamil/'>Tamil Keyboards</a></li>\n</ul>\n",
   "authorName": "Muguntharaj Subramanian",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2010-05-21T15:56:54Z",
-  "links": [
-    {
-      "name": "Tamil Keyboards",
-      "url": "http://www.tavultesoft.com/tamil/"
-    }
-  ],
   "packageFilename": "thamizha typewriter.kmp",
   "encodings": [
     "unicode"
@@ -28,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 452
+  }
 }

--- a/legacy/t/thompsonu/thompsonu.keyboard_info
+++ b/legacy/t/thompsonu/thompsonu.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "thompsonu",
   "name": "ThompsonU",
-  "description": "This keyboard is designed to enable simple input of the characters needed to type Thompson River Salish (Nklapmx, Ntlakapamux, Ntlakapmuk).",
+  "description": "This keyboard is designed to enable simple input of the characters needed to type Thompson River Salish (Nklapmx, Ntlakapamux, Ntlakapmuk).\n<ul>\n  <li><a href='http://www.meltr.org/Resources/Keyboards/Keyboards.htm'>ThompsonU Keyboard</a></li>\n</ul>\n",
   "authorName": "Tony Mattina",
   "license": "freeware",
   "languages": [
     "thp"
   ],
   "lastModifiedDate": "2012-03-20T11:24:54Z",
-  "links": [
-    {
-      "name": "ThompsonU Keyboard",
-      "url": "http://www.meltr.org/Resources/Keyboards/Keyboards.htm"
-    }
-  ],
   "packageFilename": "thompsonu.kmp",
   "encodings": [
     "unicode"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 630
+  }
 }

--- a/legacy/t/tibetan unicode direct input/tibetan unicode direct input.keyboard_info
+++ b/legacy/t/tibetan unicode direct input/tibetan unicode direct input.keyboard_info
@@ -38,7 +38,6 @@
     "zau"
   ],
   "lastModifiedDate": "2012-11-08T13:45:35Z",
-  "links": [],
   "packageFilename": "tibetan unicode direct input.kmp",
   "encodings": [
     "unicode"
@@ -54,7 +53,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 364,
-  "documentationFilename": "tibetan unicode direct input help.pdf"
+  }
 }

--- a/legacy/t/tibetan unicode ewts/tibetan unicode ewts.keyboard_info
+++ b/legacy/t/tibetan unicode ewts/tibetan unicode ewts.keyboard_info
@@ -38,7 +38,6 @@
     "zau"
   ],
   "lastModifiedDate": "2014-11-10T19:43:25Z",
-  "links": [],
   "packageFilename": "tibetan unicode ewts.kmp",
   "encodings": [
     "unicode"
@@ -53,7 +52,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 365,
-  "documentationFilename": "tibetan unicode ewts help.pdf"
+  }
 }

--- a/legacy/t/tir-er-uni/tir-er-uni.keyboard_info
+++ b/legacy/t/tir-er-uni/tir-er-uni.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "tir-er-uni",
   "name": "Tigrigna EZ (Eritrea)",
-  "description": "<p>This keyboard implements the SERA EZ phonetic based  input methods for Ethiopic script in the Tigrigna language in Eritrea.</p>    <p>Ge'ez Frontier Foundation have now released and recommend using <a href='http://www.tavultesoft.com/keyman/downloads/keyboards/details.php?KeyboardID=459&FromKeyman=0'>GFF Eritrean-Tigrinya Language Keyboard + Font Power Pack</a> instead of the Tigrigna EZ (Eritrea) keyboard, as it uses GFF standard keyboard conventions and includes many more Ethiopic script fonts.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  ",
+  "description": "<p>This keyboard implements the SERA EZ phonetic based  input methods for Ethiopic script in the Tigrigna language in Eritrea.</p>    <p>Ge'ez Frontier Foundation have now released and recommend using <a href='http://www.tavultesoft.com/keyman/downloads/keyboards/details.php?KeyboardID=459&FromKeyman=0'>GFF Eritrean-Tigrinya Language Keyboard + Font Power Pack</a> instead of the Tigrigna EZ (Eritrea) keyboard, as it uses GFF standard keyboard conventions and includes many more Ethiopic script fonts.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  \n<ul>\n  <li><a href='http://keyman.com/amharic/'>Amharic and Tigrigna Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "ti"
   ],
   "lastModifiedDate": "2014-08-08T16:48:26Z",
-  "links": [
-    {
-      "name": "Amharic and Tigrigna Keyboards Homepage",
-      "url": "http://keyman.com/amharic/"
-    }
-  ],
   "packageFilename": "tir-er-uni.kmp",
   "encodings": [
     "unicode"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 406
+  }
 }

--- a/legacy/t/tir-et-uni/tir-et-uni.keyboard_info
+++ b/legacy/t/tir-et-uni/tir-et-uni.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "tir-et-uni",
   "name": "Tigrigna EZ (Ethiopia)",
-  "description": "<p>This keyboard implements the SERA EZ phonetic based input methods for Ethiopic script in the Tigrigna language in Ethiopia.</p>    <p>Ge'ez Frontier Foundation have now released and recommend using <a href='http://www.tavultesoft.com/keyman/downloads/keyboards/details.php?KeyboardID=461&FromKeyman=0'>GFF Ethiopic-Tigrinya Language Keyboard + Font Power Pack</a> instead of the Tigrinya EZ (Ethiopia) keyboard, as it uses GFF standard keyboard conventions and includes many more Ethiopic script fonts.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>",
+  "description": "<p>This keyboard implements the SERA EZ phonetic based input methods for Ethiopic script in the Tigrigna language in Ethiopia.</p>    <p>Ge'ez Frontier Foundation have now released and recommend using <a href='http://www.tavultesoft.com/keyman/downloads/keyboards/details.php?KeyboardID=461&FromKeyman=0'>GFF Ethiopic-Tigrinya Language Keyboard + Font Power Pack</a> instead of the Tigrinya EZ (Ethiopia) keyboard, as it uses GFF standard keyboard conventions and includes many more Ethiopic script fonts.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>\n<ul>\n  <li><a href='http://keyman.com/amharic/'>Amharic and Tigrigna Keyboards Homepage</a></li>\n</ul>\n",
   "authorName": "Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "ti"
   ],
   "lastModifiedDate": "2014-08-08T16:48:34Z",
-  "links": [
-    {
-      "name": "Amharic and Tigrigna Keyboards Homepage",
-      "url": "http://keyman.com/amharic/"
-    }
-  ],
   "packageFilename": "tir-et-uni.kmp",
   "encodings": [
     "unicode"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 407
+  }
 }

--- a/legacy/t/tlingit_u/tlingit_u.keyboard_info
+++ b/legacy/t/tlingit_u/tlingit_u.keyboard_info
@@ -1,27 +1,13 @@
 {
   "id": "tlingit_u",
   "name": "Tlingit Unicode",
-  "description": "A keyboard for typing Tlingit. See also Tlingit Yukon Unicode. ",
+  "description": "A keyboard for typing Tlingit. See also Tlingit Yukon Unicode. \n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/isolate/tlingit.html'>Tlingit Unicode keyboard information and links</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
     "tli"
   ],
   "lastModifiedDate": "2012-01-23T18:00:16Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Tlingit Unicode keyboard information and links",
-      "url": "http://www.languagegeek.com/isolate/tlingit.html"
-    }
-  ],
   "packageFilename": "tlingit_u.kmp",
   "encodings": [
     "unicode"
@@ -32,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 366
+  }
 }

--- a/legacy/t/tlingit_yukon_u/tlingit_yukon_u.keyboard_info
+++ b/legacy/t/tlingit_yukon_u/tlingit_yukon_u.keyboard_info
@@ -8,7 +8,6 @@
     "tli"
   ],
   "lastModifiedDate": "2012-01-23T18:00:25Z",
-  "links": [],
   "packageFilename": "tlingit_yukon_u.kmp",
   "encodings": [
     "unicode"
@@ -19,6 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 648
+  }
 }

--- a/legacy/t/transazerty/transazerty.keyboard_info
+++ b/legacy/t/transazerty/transazerty.keyboard_info
@@ -27,7 +27,6 @@
     "yo"
   ],
   "lastModifiedDate": "2006-05-18T15:40:05Z",
-  "links": [],
   "packageFilename": "transazerty.kmp",
   "encodings": [
     "unicode"
@@ -40,7 +39,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 385,
-  "documentationFilename": "guide de saisie transazerty.pdf"
+  }
 }

--- a/legacy/t/tsciianjal/tsciianjal.keyboard_info
+++ b/legacy/t/tsciianjal/tsciianjal.keyboard_info
@@ -1,19 +1,13 @@
 {
   "id": "tsciianjal",
   "name": "Tamil - TSCIIANJAL (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/thamizha%20anjal'>https://keyman.com/keyboards/thamizha anjal</a>. (This uses the layout popularly called \"Anjal\" style\r\nkeyboard. This is similar to the English QWERTY keyboard,\r\neg. When A is pressed Tamil 'A' gets displayed.\r\n\r\nTSCII (Tamil Standard code for Information Interchange)\r\nis the most widely followed Encoding standard among the tamils.\r\nThis encoding  standard was formed by open email discussions.\r\nFor More details of TSCII encoding please visit the\r\nTSCII home page: http://www.tamil.net/tscii.)",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/thamizha%20anjal'>https://keyman.com/keyboards/thamizha anjal</a>. (This uses the layout popularly called \"Anjal\" style\r\nkeyboard. This is similar to the English QWERTY keyboard,\r\neg. When A is pressed Tamil 'A' gets displayed.\r\n\r\nTSCII (Tamil Standard code for Information Interchange)\r\nis the most widely followed Encoding standard among the tamils.\r\nThis encoding  standard was formed by open email discussions.\r\nFor More details of TSCII encoding please visit the\r\nTSCII home page: http://www.tamil.net/tscii.)\n<ul>\n  <li><a href='http://www.tamil.net/tscii/'>TSCII home page</a></li>\n</ul>\n",
   "authorName": "S. Muguntharaj",
   "license": "freeware",
   "languages": [
     "ta"
   ],
   "lastModifiedDate": "2006-06-26T15:28:36Z",
-  "links": [
-    {
-      "name": "TSCII home page",
-      "url": "http://www.tamil.net/tscii/"
-    }
-  ],
   "packageFilename": "tsciianjal.kmp",
   "encodings": [
     "ansi"
@@ -23,6 +17,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 359
+  }
 }

--- a/legacy/t/tunisianspokenarabic/tunisianspokenarabic.keyboard_info
+++ b/legacy/t/tunisianspokenarabic/tunisianspokenarabic.keyboard_info
@@ -8,7 +8,6 @@
     "aeb"
   ],
   "lastModifiedDate": "2016-05-13T07:58:05Z",
-  "links": [],
   "packageFilename": "tunisianspokenarabic.kmp",
   "encodings": [
     "unicode"
@@ -23,6 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 701
+  }
 }

--- a/legacy/t/turkmen/turkmen.keyboard_info
+++ b/legacy/t/turkmen/turkmen.keyboard_info
@@ -8,7 +8,6 @@
     "tk"
   ],
   "lastModifiedDate": "2012-03-29T17:29:02Z",
-  "links": [],
   "packageFilename": "turkmen.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 382,
-  "documentationFilename": "user guide (pdf).pdf"
+  }
 }

--- a/legacy/t/tuscarora_u/tuscarora_u.keyboard_info
+++ b/legacy/t/tuscarora_u/tuscarora_u.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "tuscarora_u",
   "name": "Tuscarora Unicode",
-  "description": "Keyboard layout for typing Tuscarora using Unicode fonts.",
+  "description": "Keyboard layout for typing Tuscarora using Unicode fonts.\n<ul>\n  <li><a href='http://www.languagegeek.com/font/fontdownload.html'>Aboriginal Serif Unicode font</a></li>\n  <li><a href='http://www.languagegeek.com/'>Author's website</a></li>\n  <li><a href='http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html'>Tuscarora Unicode keyboards and information</a></li>\n</ul>\n",
   "authorName": "Chris Harvey",
   "license": "freeware",
   "languages": [
@@ -9,20 +9,6 @@
     "tus"
   ],
   "lastModifiedDate": "2012-01-23T18:00:40Z",
-  "links": [
-    {
-      "name": "Aboriginal Serif Unicode font",
-      "url": "http://www.languagegeek.com/font/fontdownload.html"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.languagegeek.com/"
-    },
-    {
-      "name": "Tuscarora Unicode keyboards and information",
-      "url": "http://www.languagegeek.com/rotinonhsonni/keyboards/iro_keyboards.html"
-    }
-  ],
   "packageFilename": "tuscarora_u.kmp",
   "encodings": [
     "unicode"
@@ -33,6 +19,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 368
+  }
 }

--- a/legacy/u/urdu ph - package/urdu ph - package.keyboard_info
+++ b/legacy/u/urdu ph - package/urdu ph - package.keyboard_info
@@ -8,7 +8,6 @@
     "ur"
   ],
   "lastModifiedDate": "2007-12-12T10:56:25Z",
-  "links": [],
   "packageFilename": "urdu ph - package.kmp",
   "encodings": [
     "unicode"
@@ -23,7 +22,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 415,
-  "documentationFilename": "urdu phonetic documentation.pdf"
+  }
 }

--- a/legacy/u/urdu_unicode/urdu_unicode.keyboard_info
+++ b/legacy/u/urdu_unicode/urdu_unicode.keyboard_info
@@ -8,7 +8,6 @@
     "ur"
   ],
   "lastModifiedDate": "2006-05-01T07:56:34Z",
-  "links": [],
   "packageFilename": "urdu_unicode.kmp",
   "encodings": [
     "unicode"
@@ -18,7 +17,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 369,
-  "documentationFilename": "urdu_unicode.pdf"
+  }
 }

--- a/legacy/u/utb unicode/utb unicode.keyboard_info
+++ b/legacy/u/utb unicode/utb unicode.keyboard_info
@@ -12,7 +12,6 @@
     "tlj"
   ],
   "lastModifiedDate": "2010-07-23T08:32:42Z",
-  "links": [],
   "packageFilename": "utb unicode.kmp",
   "encodings": [
     "unicode"
@@ -25,7 +24,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 624,
-  "documentationFilename": "utb unicode keying guide.pdf"
+  }
 }

--- a/legacy/u/uwikala_u/uwikala_u.keyboard_info
+++ b/legacy/u/uwikala_u/uwikala_u.keyboard_info
@@ -8,7 +8,6 @@
     "kwk"
   ],
   "lastModifiedDate": "2013-04-12T15:47:20Z",
-  "links": [],
   "packageFilename": "uwikala_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 675,
-  "documentationFilename": "uwikala - basic usage.pdf"
+  }
 }

--- a/legacy/v/vai1.1/vai1.1.keyboard_info
+++ b/legacy/v/vai1.1/vai1.1.keyboard_info
@@ -8,7 +8,6 @@
     "vai"
   ],
   "lastModifiedDate": "2008-06-12T12:01:03Z",
-  "links": [],
   "packageFilename": "vai1.1.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 432
+  }
 }

--- a/legacy/v/venetian/venetian.keyboard_info
+++ b/legacy/v/venetian/venetian.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "venetian",
   "name": "Venetia et Histria",
-  "description": "Unicode keyboard for entering Venetian and Ladin languages, covering input of all the necessary Latin characters.",
+  "description": "Unicode keyboard for entering Venetian and Ladin languages, covering input of all the necessary Latin characters.\n<ul>\n  <li><a href='http://digilander.libero.it/cssc/arkivio/font-veneti.html'>List of Venetian and Ladin compatible fonts</a></li>\n</ul>\n",
   "authorName": "Tavultesoft Pty Ltd & Fabio Lazarin",
   "license": "freeware",
   "languages": [
@@ -9,12 +9,6 @@
     "vec"
   ],
   "lastModifiedDate": "2007-04-10T12:45:19Z",
-  "links": [
-    {
-      "name": "List of Venetian and Ladin compatible fonts",
-      "url": "http://digilander.libero.it/cssc/arkivio/font-veneti.html"
-    }
-  ],
   "packageFilename": "venetian.kmp",
   "encodings": [
     "unicode"
@@ -32,7 +26,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 403,
-  "jsFilename": "venetian.js",
-  "documentationFilename": "tastveneta.pdf"
+  "jsFilename": "venetian.js"
 }

--- a/legacy/w/waiwai/waiwai.keyboard_info
+++ b/legacy/w/waiwai/waiwai.keyboard_info
@@ -8,7 +8,6 @@
     "waw"
   ],
   "lastModifiedDate": "2012-11-16T12:14:35Z",
-  "links": [],
   "packageFilename": "waiwai.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 657,
-  "documentationFilename": "wai wai keyboard help.pdf"
+  }
 }

--- a/legacy/w/winmacdene/winmacdene.keyboard_info
+++ b/legacy/w/winmacdene/winmacdene.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "winmacdene",
   "name": "WinMac Dene Fonts (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/deneunicode'>https://keyman.com/keyboards/deneunicode</a>. (A set of fonts and keyboards for typing in the Chipewyan Dene, Gwich'in, North Slavey, South Slavey, and Tlicho (Dogrib) Languages of Canada's Northwest Territories.)",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. An appropriate Unicode keyboard that is based on the same keyboard layout is: <a href='https://keyman.com/keyboards/deneunicode'>https://keyman.com/keyboards/deneunicode</a>. (A set of fonts and keyboards for typing in the Chipewyan Dene, Gwich'in, North Slavey, South Slavey, and Tlicho (Dogrib) Languages of Canada's Northwest Territories.)\n<ul>\n  <li><a href='http://denefont.tripod.com'>Author's website</a></li>\n</ul>\n",
   "authorName": "Jim Stauffer",
   "license": "freeware",
   "languages": [
@@ -12,12 +12,6 @@
     "xsl"
   ],
   "lastModifiedDate": "2006-12-04T14:53:44Z",
-  "links": [
-    {
-      "name": "Author's website",
-      "url": "http://denefont.tripod.com"
-    }
-  ],
   "packageFilename": "winmacdene.kmp",
   "encodings": [
     "ansi"
@@ -29,6 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 400
+  }
 }

--- a/legacy/w/wiwa/wiwa.keyboard_info
+++ b/legacy/w/wiwa/wiwa.keyboard_info
@@ -8,7 +8,6 @@
     "mbp"
   ],
   "lastModifiedDate": "2012-07-06T11:41:40Z",
-  "links": [],
   "packageFilename": "wiwa.kmp",
   "encodings": [
     "unicode"
@@ -22,6 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 655
+  }
 }

--- a/legacy/y/yi/yi.keyboard_info
+++ b/legacy/y/yi/yi.keyboard_info
@@ -8,7 +8,6 @@
     "ii"
   ],
   "lastModifiedDate": "2014-08-08T16:19:06Z",
-  "links": [],
   "packageFilename": "yi.kmp",
   "encodings": [
     "unicode"
@@ -22,7 +21,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 689,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/legacy/y/yidish2k/yidish2k.keyboard_info
+++ b/legacy/y/yidish2k/yidish2k.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "yidish2k",
   "name": "Yiddish Pasekh",
-  "description": "Type Yiddish by transliteration. Updated 18 December 2009 with automatic configuration for Windows and Office, On Screen Keyboard and updated documentation for Keyman Desktop 7.",
+  "description": "Type Yiddish by transliteration. Updated 18 December 2009 with automatic configuration for Windows and Office, On Screen Keyboard and updated documentation for Keyman Desktop 7.\n<ul>\n  <li><a href='http://zsigri.tripod.com/fontboard/yiddish.html'>Author's Home Page</a></li>\n</ul>\n",
   "authorName": "Zsigri Gyula",
   "license": "freeware",
   "languages": [
@@ -9,12 +9,6 @@
     "yih"
   ],
   "lastModifiedDate": "2010-05-21T15:56:40Z",
-  "links": [
-    {
-      "name": "Author's Home Page",
-      "url": "http://zsigri.tripod.com/fontboard/yiddish.html"
-    }
-  ],
   "packageFilename": "yidish2k.kmp",
   "encodings": [
     "unicode"
@@ -31,6 +25,5 @@
     "desktopWeb": "full",
     "macos": "full"
   },
-  "legacyId": 371,
   "jsFilename": "yidish2k.js"
 }

--- a/legacy/y/yolngu20/yolngu20.keyboard_info
+++ b/legacy/y/yolngu20/yolngu20.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "yolngu20",
   "name": "Yolngu",
-  "description": "Type Yolngu and other Australian aboriginal languages using standard \nUnicode fonts.  Other layouts are also available from the author's website.",
+  "description": "Type Yolngu and other Australian aboriginal languages using standard \nUnicode fonts.  Other layouts are also available from the author's website.\n<ul>\n  <li><a href='http://www.openroad.net.au/languages/files/yolngu20.html'>Author's notes on using revised Yolngu keyboard</a></li>\n  <li><a href='http://www.openroad.net.au/languages/files/yolngu_unicode.html'>Author's notes on using Yolngu keyboard</a></li>\n  <li><a href='http://www.openroad.net.au/languages/files/yolngu20.zip'>Download revised Yolngu keyboard for Keyman 6</a></li>\n  <li><a href='http://www.openroad.net.au/languages/files/yolngu_unicode.zip'>Download Yolngu keyboard for Keyman 5/6</a></li>\n  <li><a href='http://www.openroad.net.au/languages/'>Author's website</a></li>\n</ul>\n",
   "authorName": "Andrew Cunningham",
   "license": "freeware",
   "languages": [
@@ -18,28 +18,6 @@
     "rit"
   ],
   "lastModifiedDate": "2007-02-22T17:57:01Z",
-  "links": [
-    {
-      "name": "Author's notes on using revised Yolngu keyboard",
-      "url": "http://www.openroad.net.au/languages/files/yolngu20.html"
-    },
-    {
-      "name": "Author's notes on using Yolngu keyboard",
-      "url": "http://www.openroad.net.au/languages/files/yolngu_unicode.html"
-    },
-    {
-      "name": "Download revised Yolngu keyboard for Keyman 6",
-      "url": "http://www.openroad.net.au/languages/files/yolngu20.zip"
-    },
-    {
-      "name": "Download Yolngu keyboard for Keyman 5/6",
-      "url": "http://www.openroad.net.au/languages/files/yolngu_unicode.zip"
-    },
-    {
-      "name": "Author's website",
-      "url": "http://www.openroad.net.au/languages/"
-    }
-  ],
   "packageFilename": "yolngu20.kmp",
   "encodings": [
     "unicode"
@@ -50,6 +28,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 372
+  }
 }

--- a/legacy/y/yoruba1_u/yoruba1_u.keyboard_info
+++ b/legacy/y/yoruba1_u/yoruba1_u.keyboard_info
@@ -8,7 +8,6 @@
     "yo"
   ],
   "lastModifiedDate": "2013-04-12T15:47:35Z",
-  "links": [],
   "packageFilename": "yoruba1_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 676,
-  "documentationFilename": "yoruba 1 - basic usage.pdf"
+  }
 }

--- a/legacy/y/yoruba2_u/yoruba2_u.keyboard_info
+++ b/legacy/y/yoruba2_u/yoruba2_u.keyboard_info
@@ -8,7 +8,6 @@
     "yo"
   ],
   "lastModifiedDate": "2013-04-12T15:47:43Z",
-  "links": [],
   "packageFilename": "yoruba2_u.kmp",
   "encodings": [
     "unicode"
@@ -19,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 677,
-  "documentationFilename": "yoruba 2 - basic usage.pdf"
+  }
 }

--- a/legacy/y/yoruba8/yoruba8.keyboard_info
+++ b/legacy/y/yoruba8/yoruba8.keyboard_info
@@ -8,7 +8,6 @@
     "yo"
   ],
   "lastModifiedDate": "2012-11-08T12:07:37Z",
-  "links": [],
   "packageFilename": "yoruba8.kmp",
   "encodings": [
     "unicode"
@@ -24,7 +23,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 656,
-  "documentationFilename": "welcome.pdf"
+  }
 }

--- a/legacy/y/yorubaok/yorubaok.keyboard_info
+++ b/legacy/y/yorubaok/yorubaok.keyboard_info
@@ -1,7 +1,7 @@
 {
   "id": "yorubaok",
   "name": "Yoruba (obsolete non-Unicode)",
-  "description": "For historical research. This is a non-Unicode compliant keyboard. (Type Yoruba using <b>YorubaOK.ttf</b> or similarly coded fonts.)",
+  "description": "For historical research. This is a non-Unicode compliant keyboard. (Type Yoruba using <b>YorubaOK.ttf</b> or similarly coded fonts.)\n<ul>\n  <li><a href='http://www.learnyoruba.com/'>Author's website</a></li>\n</ul>\n",
   "authorName": "Adebusola Onayemi",
   "license": "freeware",
   "languages": [
@@ -9,12 +9,6 @@
     "yo"
   ],
   "lastModifiedDate": "2005-12-13T15:54:18Z",
-  "links": [
-    {
-      "name": "Author's website",
-      "url": "http://www.learnyoruba.com/"
-    }
-  ],
   "packageFilename": "yorubaok.kmp",
   "encodings": [
     "ansi"
@@ -24,7 +18,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 373,
-  "documentationFilename": "readme.txt"
+  }
 }

--- a/release/a/arabic_izza/arabic_izza.keyboard_info
+++ b/release/a/arabic_izza/arabic_izza.keyboard_info
@@ -7,6 +7,5 @@
   "languages": [
     "ar-DZ"
   ],
-  "legacyId": 714,
   "jsFilename": "arabic_izza.js"
 }

--- a/release/e/esperuni/esperuni.keyboard_info
+++ b/release/e/esperuni/esperuni.keyboard_info
@@ -4,6 +4,5 @@
   "license": "mit",
   "languages": [
     "eo"
-  ],
-  "legacyId": 317
+  ]
 }

--- a/release/g/gandhari/gandhari.keyboard_info
+++ b/release/g/gandhari/gandhari.keyboard_info
@@ -1,16 +1,10 @@
 {
-  "description": "Gandhari Sanskrit keyboard developed for Latin transliteration of Gāndhārī language written in the Kharoṣṭhī script.  Gandhari font recommended (see link below).",
+  "description": "Gandhari Sanskrit keyboard developed for Latin transliteration of Gāndhārī language written in the Kharoṣṭhī script.  Gandhari font recommended (see link below).\n<ul>\n  <li><a href='https://github.com/gandhariunicode/gandhari_unicode_font'>Gandhari font</a></li>\n</ul>\n",
   "authorName": "Andrew Glass",
   "license": "mit",
   "languages": [
     "sa-Latn",
     "pgd-Latn"
-  ],
-  "links": [
-    {
-      "name": "Gandhari font",
-      "url": "https://github.com/gandhariunicode/gandhari_unicode_font"
-    }
   ],
   "related": {
     "gandhari-keyboard-2.7": {

--- a/release/g/ghana/ghana.keyboard_info
+++ b/release/g/ghana/ghana.keyboard_info
@@ -9,6 +9,5 @@
     "hag-Latn",
     "nzi-Latn",
     "xsm-Latn"
-  ],
-  "legacyId": 712
+  ]
 }

--- a/release/g/greekclassical/greekclassical.keyboard_info
+++ b/release/g/greekclassical/greekclassical.keyboard_info
@@ -9,6 +9,5 @@
     "pnt-Grek",
     "tsd-Grek",
     "yej-Grek"
-  ],
-  "legacyId": 309
+  ]
 }

--- a/release/h/hieroglyphic/hieroglyphic.keyboard_info
+++ b/release/h/hieroglyphic/hieroglyphic.keyboard_info
@@ -10,6 +10,5 @@
       }
     }
   },
-  "legacyId": 651,
   "description": "This keyboard provides a quick and easy way to enter Ancient Egyptian hieroglyphs and transliteration as Unicode text."
 }

--- a/release/k/kbdsn1/kbdsn1.keyboard_info
+++ b/release/k/kbdsn1/kbdsn1.keyboard_info
@@ -8,7 +8,6 @@
     "si"
   ],
   "lastModifiedDate": "2009-05-15T16:19:22Z",
-  "links": [],
   "packageFilename": "kbdsn1.kmp",
   "encodings": [
     "unicode"
@@ -21,6 +20,5 @@
   "platformSupport": {
     "windows": "full",
     "macos": "full"
-  },
-  "legacyId": 579
+  }
 }

--- a/release/l/lahu/lahu.keyboard_info
+++ b/release/l/lahu/lahu.keyboard_info
@@ -6,6 +6,5 @@
   "license": "mit",
   "languages": [
     "lhu-Latn"
-  ],
-  "legacyId": 623
+  ]
 }

--- a/release/m/malar_malayalam/malar_malayalam.keyboard_info
+++ b/release/m/malar_malayalam/malar_malayalam.keyboard_info
@@ -9,11 +9,5 @@
       }
     }
   },
-  "description": "<p><b>Malar Malayalam</b> Keyboard is a transliteration based Malayalam input method. This keyboard supports all Malayalam characters encoded as per the Unicode Standard, Version 15.0.</p>",
-  "links": [
-    {
-      "name": "Keyboard Demo",
-      "url": "https://malarproject.gitlab.io/ml/"
-    }
-  ]
+  "description": "<p><b>Malar Malayalam</b> Keyboard is a transliteration based Malayalam input method. This keyboard supports all Malayalam characters encoded as per the Unicode Standard, Version 15.0.</p>\n<ul>\n  <li><a href='https://malarproject.gitlab.io/ml/'>Keyboard Demo</a></li>\n</ul>\n"
 }

--- a/release/m/malar_malayalam_inscript/malar_malayalam_inscript.keyboard_info
+++ b/release/m/malar_malayalam_inscript/malar_malayalam_inscript.keyboard_info
@@ -9,13 +9,7 @@
       }
     }
   },
-  "description": "<p><b>Malar Malayalam Inscript</b> Keyboard is a customized version of the Malayalam Inscript keyboard. This keyboard supports all Malayalam characters encoded as per the Unicode Standard, Version 14.0.</p>",
-  "links": [
-    {
-      "name": "Keyboard Demo",
-      "url": "https://malarproject.gitlab.io/ml-inscript/"
-    }
-  ],
+  "description": "<p><b>Malar Malayalam Inscript</b> Keyboard is a customized version of the Malayalam Inscript keyboard. This keyboard supports all Malayalam characters encoded as per the Unicode Standard, Version 14.0.</p>\n<ul>\n  <li><a href='https://malarproject.gitlab.io/ml-inscript/'>Keyboard Demo</a></li>\n</ul>\n",
   "related": {
     "malayalam_kab": {
       "deprecates": true

--- a/release/m/malar_tirhuta/malar_tirhuta.keyboard_info
+++ b/release/m/malar_tirhuta/malar_tirhuta.keyboard_info
@@ -24,11 +24,5 @@
       }
     }
   },
-  "description": "<p><b>Malar Tirhuta</b> is a transliteration based Unicode input method for Tirhuta script.</p>",
-  "links": [
-    {
-      "name": "Keyboard Demo",
-      "url": "https://malarproject.gitlab.io/tirhuta"
-    }
-  ]
+  "description": "<p><b>Malar Tirhuta</b> is a transliteration based Unicode input method for Tirhuta script.</p>\n<ul>\n  <li><a href='https://malarproject.gitlab.io/tirhuta'>Keyboard Demo</a></li>\n</ul>\n"
 }

--- a/release/m/maltese/maltese.keyboard_info
+++ b/release/m/maltese/maltese.keyboard_info
@@ -5,6 +5,5 @@
   "license": "mit",
   "languages": [
     "mt"
-  ],
-  "legacyId": 333
+  ]
 }

--- a/release/n/nko/nko.keyboard_info
+++ b/release/n/nko/nko.keyboard_info
@@ -8,6 +8,5 @@
     "man-Nkoo",
     "bm-Nkoo",
     "dyu-Nkoo"
-  ],
-  "legacyId": 653
+  ]
 }

--- a/release/n/nw_iranian_latin/nw_iranian_latin.keyboard_info
+++ b/release/n/nw_iranian_latin/nw_iranian_latin.keyboard_info
@@ -7,6 +7,5 @@
   "languages": [
     "glk-Latn"
   ],
-  "legacyId": 716,
   "jsFilename": "nw_iranian_latin.js"
 }

--- a/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.keyboard_info
+++ b/release/p/postmodern_english_uk_dualstroke/postmodern_english_uk_dualstroke.keyboard_info
@@ -3,11 +3,5 @@
   "languages": [
     "en-QP"
   ],
-  "links": [
-    {
-      "name": "Postmodern English Website",
-      "url": "http://www.postmodernenglish.org"
-    }
-  ],
-  "description": "This is a British English keyboard designed for typing in Postmodern English, in the DualStroke layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
+  "description": "This is a British English keyboard designed for typing in Postmodern English, in the DualStroke layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below.\n<ul>\n  <li><a href='http://www.postmodernenglish.org'>Postmodern English Website</a></li>\n</ul>\n"
 }

--- a/release/p/postmodern_english_uk_natural/postmodern_english_uk_natural.keyboard_info
+++ b/release/p/postmodern_english_uk_natural/postmodern_english_uk_natural.keyboard_info
@@ -3,11 +3,5 @@
   "languages": [
     "en-QP"
   ],
-  "links": [
-    {
-      "name": "Postmodern English Website",
-      "url": "http://www.postmodernenglish.org"
-    }
-  ],
-  "description": "This is a British English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
+  "description": "This is a British English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below.\n<ul>\n  <li><a href='http://www.postmodernenglish.org'>Postmodern English Website</a></li>\n</ul>\n"
 }

--- a/release/p/postmodern_english_us_dualstroke/postmodern_english_us_dualstroke.keyboard_info
+++ b/release/p/postmodern_english_us_dualstroke/postmodern_english_us_dualstroke.keyboard_info
@@ -3,11 +3,5 @@
   "languages": [
     "en-QP"
   ],
-  "links": [
-    {
-      "name": "Postmodern English Website",
-      "url": "http://www.postmodernenglish.org"
-    }
-  ],
-  "description": "This is an American English keyboard designed for typing in Postmodern English, in the DualStroke layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
+  "description": "This is an American English keyboard designed for typing in Postmodern English, in the DualStroke layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below.\n<ul>\n  <li><a href='http://www.postmodernenglish.org'>Postmodern English Website</a></li>\n</ul>\n"
 }

--- a/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
+++ b/release/p/postmodern_english_us_natural/postmodern_english_us_natural.keyboard_info
@@ -3,11 +3,5 @@
   "languages": [
     "en-QP"
   ],
-  "links": [
-    {
-      "name": "Postmodern English Website",
-      "url": "http://www.postmodernenglish.org"
-    }
-  ],
-  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below."
+  "description": "This is an American English keyboard designed for typing in Postmodern English, in the Natural layout style. The Postmodern English Project is an open source, community led effort to create dictionaries of Postmodern English words from around the world. Postmodern English in itself is a refactor of how English writing functions, which focuses on making it as phonetic, consistent, and condensed as possible. For more information, please visit the Postmodern English website linked below.\n<ul>\n  <li><a href='http://www.postmodernenglish.org'>Postmodern English Website</a></li>\n</ul>\n"
 }

--- a/release/packages/gff_amh_powerpack_7/gff_amh_powerpack_7.keyboard_info
+++ b/release/packages/gff_amh_powerpack_7/gff_amh_powerpack_7.keyboard_info
@@ -1,16 +1,10 @@
 {
   "name": "GFF Amharic Language Keyboard + Font Power Pack",
-  "description": "<p>An intuitive, easy to use, keyboard for entering Amharic with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  ",
+  "description": "<p>An intuitive, easy to use, keyboard for entering Amharic with standard English keyboards according to the GFF convention for Ethiopic script languages.</p>    <p><a href='http://ethiopic.keymankeyboards.com/' onclick=\"if(typeof pageTracker == 'undefined') return true; pageTracker._link(this.href); return false;\">Compare different Ethiopic keyboards online</a> now with KeymanWeb (no download required).</p>  \n<ul>\n  <li><a href='http://keyboards.ethiopic.org/specification/'>Principles and Specification for Mnemonic Ethiopic Keyboards</a></li>\n</ul>\n",
   "authorName": "The Ge'ez Frontier Foundation",
   "license": "freeware",
   "languages": [
     "am"
-  ],
-  "links": [
-    {
-      "name": "Principles and Specification for Mnemonic Ethiopic Keyboards",
-      "url": "http://keyboards.ethiopic.org/specification/"
-    }
   ],
   "packageFilename": "gff_amh_powerpack_7.kmp",
   "encodings": [
@@ -26,7 +20,6 @@
     "windows": "full",
     "macos": "full"
   },
-  "legacyId": 455,
   "related": {
     "gff-amh-powerpack-7": {
       "deprecates": true

--- a/release/rac/rac_yidgha/rac_yidgha.keyboard_info
+++ b/release/rac/rac_yidgha/rac_yidgha.keyboard_info
@@ -12,6 +12,5 @@
   },
   "description": "This keyboard was developed for keyboarding the Yidgha language in the Arabic Script. You can use this keyboard with any extended Arabic script Unicode font.\r\n\r\nIf you have problems using the RAChitrali-Yidgha Keyman keyboard, please contact:\r\n\r\nRehmat Aziz Chitrali\r\nE-mail: rachitrali@yahoo.com",
   "authorName": "Rehmat Aziz Chitrali",
-  "license": "mit",
-  "legacyId": 715
+  "license": "mit"
 }

--- a/release/s/shan/shan.keyboard_info
+++ b/release/s/shan/shan.keyboard_info
@@ -1,16 +1,9 @@
 {
-  "description": "A Unicode keyboard for the Shan language (shn).",
+  "description": "A Unicode keyboard for the Shan language (shn).\n<ul>\n  <li><a href='http://www.surehope.net'>www.surehope.net</a></li>\n</ul>\n",
   "authorName": "Sai Ai Wong",
   "license": "mit",
   "languages": [
     "my",
     "shn"
-  ],
-  "links": [
-    {
-      "name": "www.surehope.net",
-      "url": "http://www.surehope.net"
-    }
-  ],
-  "legacyId": 709
+  ]
 }

--- a/release/sil/sil_cheyenne/sil_cheyenne.keyboard_info
+++ b/release/sil/sil_cheyenne/sil_cheyenne.keyboard_info
@@ -1,17 +1,11 @@
 {
   "id": "sil_cheyenne",
   "name": "Cheyenne",
-  "description": "This keyboard allows you to type all the letters and special symbols used in the Cheyenne alphabet.",
+  "description": "This keyboard allows you to type all the letters and special symbols used in the Cheyenne alphabet.\n<ul>\n  <li><a href='http://www.cheyennelanguage.org/'>Cheyenne language website</a></li>\n</ul>\n",
   "authorName": "Phil Leckrone",
   "license": "mit",
   "languages": [
     "chy-Latn"
-  ],
-  "links": [
-    {
-      "name": "Cheyenne language website",
-      "url": "http://www.cheyennelanguage.org/"
-    }
   ],
   "related": {
     "chey-unicode": {

--- a/release/sil/sil_ethiopic/sil_ethiopic.keyboard_info
+++ b/release/sil/sil_ethiopic/sil_ethiopic.keyboard_info
@@ -22,6 +22,5 @@
     "tig-Ethi",
     "zay-Ethi",
     "mul-Ethi"
-  ],
-  "legacyId": 711
+  ]
 }

--- a/release/sil/sil_ethiopic_power_g/sil_ethiopic_power_g.keyboard_info
+++ b/release/sil/sil_ethiopic_power_g/sil_ethiopic_power_g.keyboard_info
@@ -17,6 +17,5 @@
     "tig-Ethi",
     "zay-Ethi",
     "mul-Ethi"
-  ],
-  "legacyId": 706
+  ]
 }

--- a/release/sil/sil_nubian/sil_nubian.keyboard_info
+++ b/release/sil/sil_nubian/sil_nubian.keyboard_info
@@ -6,6 +6,5 @@
     "fia-Copt",
     "dgl-Copt",
     "xnz-Copt"
-  ],
-  "legacyId": 707
+  ]
 }

--- a/release/sil/sil_torwali/sil_torwali.keyboard_info
+++ b/release/sil/sil_torwali/sil_torwali.keyboard_info
@@ -1,7 +1,6 @@
 {
   "license": "mit",
   "description": "This keyboard was developed for keyboarding the Torwali language in the Arabic Script. The Torwali keyboard is designed to work with the Scheherazade font. However, you can use this keyboard with any extended Arabic script Unicode font.",
-  "legacyId": 708,
   "languages": {
     "trw-Arab": {
       "font": {

--- a/release/t/tainua/tainua.keyboard_info
+++ b/release/t/tainua/tainua.keyboard_info
@@ -6,6 +6,5 @@
   "license": "mit",
   "languages": [
     "tdd-Tale"
-  ],
-  "legacyId": 705
+  ]
 }

--- a/release/t/tem_kdh/tem_kdh.keyboard_info
+++ b/release/t/tem_kdh/tem_kdh.keyboard_info
@@ -8,7 +8,6 @@
     "kdh-Arab"
   ],
   "lastModifiedDate": "2017-06-29T13:53:22Z",
-  "links": [],
   "packageFilename": "tem_kdh.kmp",
   "encodings": [
     "unicode"
@@ -24,6 +23,5 @@
     "ios": "basic",
     "android": "basic",
     "macos": "full"
-  },
-  "legacyId": 717
+  }
 }


### PR DESCRIPTION
Relates to keymanapp/keyman#9351.

Removes:
* links --> details moved into description field
* legacyId --> from old Tavultesoft infrastructure, very much obsolete at this point
* documentationFilename, documentationFileSize --> essentially unused, never referenced by websites
* related[].note --> only ever used by one keyboard