### PR TITLE
chore: Fix longpress commas on touch layout

### DIFF
--- a/release/sil/sil_euro_latin/HISTORY.md
+++ b/release/sil/sil_euro_latin/HISTORY.md
@@ -1,5 +1,7 @@
 # EuroLatin (SIL) Keyboard Change History
 
+## 2.0.4 (29 Sep 2023)
+* Fix longpress commas on touch layout
 ## 2.0.3 (30 Jan 2023)
 * Fix duplicated language codes (`ik`, `ff`, `gn`, `qu`)
 ## 2.0.2 (30 Jan 2023)

--- a/release/sil/sil_euro_latin/LICENSE.md
+++ b/release/sil/sil_euro_latin/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 1994-2022 SIL International
+Copyright (c) 1994-2023 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.keyman-touch-layout
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.keyman-touch-layout
@@ -914,8 +914,8 @@
                 "text": ".",
                 "sk": [
                   {
-                    "id": "K_COMMA",
-                    "text": ","
+                    "text": ",",
+                    "id": "U_002C"
                   },
                   {
                     "id": "U_0021"
@@ -1867,7 +1867,7 @@
                 "sk": [
                   {
                     "text": ",",
-                    "id": "K_COMMA"
+                    "id": "U_002C"
                   },
                   {
                     "text": "!",
@@ -2241,7 +2241,7 @@
                 "sk": [
                   {
                     "text": ",",
-                    "id": "K_COMMA",
+                    "id": "U_002C",
                     "nextlayer": "numeric"
                   },
                   {

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.kmn
@@ -14,7 +14,7 @@ c KeymanWeb-specific header statements
 store(&KMW_HELPFILE) 'sil_euro_latin.html'
 store(&KMW_EMBEDJS) 'sil_euro_latin_js.txt'
 store(&LAYOUTFILE) 'sil_euro_latin.keyman-touch-layout'
-store(&KEYBOARDVERSION) '2.0.3'
+store(&KEYBOARDVERSION) '2.0.4'
 store(&TARGETS) 'any'
 
 begin Unicode > use(Main)


### PR DESCRIPTION
Fixes #2375 

On the shift layer, longpress on the comma <kbd>,</kbd> was outputting `<` because the KeymanWeb engine processes the keystroke as <kbd>shift</kbd>+<kbd>,</kbd>.

Converting from K_COMMA to U_002C should fix this.