### PR TITLE
chore: move related keyboard data to kps

### DIFF
--- a/release/a/anii/source/anii.kps
+++ b/release/a/anii/source/anii.kps
@@ -135,4 +135,7 @@ landscape and portraid mode).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="anii_2015_fr_pack2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/a/aramaic_hebrew/source/aramaic_hebrew.kps
+++ b/release/a/aramaic_hebrew/source/aramaic_hebrew.kps
@@ -320,4 +320,7 @@ Mardutho: The Syriac Institute](http://www.BethMardutho.org/).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="aramaic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/athinkra/athinkra_vai/source/athinkra_vai.kps
+++ b/release/athinkra/athinkra_vai/source/athinkra_vai.kps
@@ -127,4 +127,7 @@ at Athinkra, LLC.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="vai1.1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/b/bangla_joy/source/bangla_joy.kps
+++ b/release/b/bangla_joy/source/bangla_joy.kps
@@ -98,4 +98,7 @@ Windows fonts. This is the most popular layout in Bangladesh.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bangla_joy_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/b/bangla_munir/source/bangla_munir.kps
+++ b/release/b/bangla_munir/source/bangla_munir.kps
@@ -91,4 +91,7 @@ Windows fonts. This is a layout widely used in Bangladesh.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bangla_munir_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/b/bangla_probhat/source/bangla_probhat.kps
+++ b/release/b/bangla_probhat/source/bangla_probhat.kps
@@ -97,4 +97,7 @@ Windows fonts. This is a popular layout used in Bangladesh.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bangla_probhat_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/b/bu_phonetic/source/bu_phonetic.kps
+++ b/release/b/bu_phonetic/source/bu_phonetic.kps
@@ -70,4 +70,7 @@ for Latin-based scripts in Unicode (www.unicode.org).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bu" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbda1/source/basic_kbda1.kps
+++ b/release/basic/basic_kbda1/source/basic_kbda1.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="arabic_101" Relationship="deprecates" />
+    <RelatedPackage ID="kbda1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbda2/source/basic_kbda2.kps
+++ b/release/basic/basic_kbda2/source/basic_kbda2.kps
@@ -102,4 +102,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="arabic_102" Relationship="deprecates" />
+    <RelatedPackage ID="kbda2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbda3/source/basic_kbda3.kps
+++ b/release/basic/basic_kbda3/source/basic_kbda3.kps
@@ -101,4 +101,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="arabic_102_azerty" Relationship="deprecates" />
+    <RelatedPackage ID="kbda3" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdal/source/basic_kbdal.kps
+++ b/release/basic/basic_kbdal/source/basic_kbdal.kps
@@ -93,4 +93,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="albanian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdal" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdarme/source/basic_kbdarme.kps
+++ b/release/basic/basic_kbdarme/source/basic_kbdarme.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="armenian_east" Relationship="deprecates" />
+    <RelatedPackage ID="kbdarme" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdarmw/source/basic_kbdarmw.kps
+++ b/release/basic/basic_kbdarmw/source/basic_kbdarmw.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="armenian_west" Relationship="deprecates" />
+    <RelatedPackage ID="kbdarmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdaze/source/basic_kbdaze.kps
+++ b/release/basic/basic_kbdaze/source/basic_kbdaze.kps
@@ -91,4 +91,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="azeri_cyrillic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdaze" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdazel/source/basic_kbdazel.kps
+++ b/release/basic/basic_kbdazel/source/basic_kbdazel.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="azeri_latin" Relationship="deprecates" />
+    <RelatedPackage ID="kbdazel" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbash/source/basic_kbdbash.kps
+++ b/release/basic/basic_kbdbash/source/basic_kbdbash.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdbash" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbe/source/basic_kbdbe.kps
+++ b/release/basic/basic_kbdbe/source/basic_kbdbe.kps
@@ -93,4 +93,9 @@ following Windows 10 input methods: Belgian French and Belgian (Period).</Descri
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="belgian_period" Relationship="deprecates" />
+    <RelatedPackage ID="belgian_french" Relationship="deprecates" />
+    <RelatedPackage ID="kbdbe" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbene/source/basic_kbdbene.kps
+++ b/release/basic/basic_kbdbene/source/basic_kbdbene.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="belgian_comma" Relationship="deprecates" />
+    <RelatedPackage ID="kbdbene" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbgph/source/basic_kbdbgph.kps
+++ b/release/basic/basic_kbdbgph/source/basic_kbdbgph.kps
@@ -83,4 +83,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdbgph" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbhc/source/basic_kbdbhc.kps
+++ b/release/basic/basic_kbdbhc/source/basic_kbdbhc.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdbhc" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdblr/source/basic_kbdblr.kps
+++ b/release/basic/basic_kbdblr/source/basic_kbdblr.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="belarusian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdblr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbr/source/basic_kbdbr.kps
+++ b/release/basic/basic_kbdbr/source/basic_kbdbr.kps
@@ -92,4 +92,10 @@ and Portuguese (Brazil ABNT2).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="portuguese_abnt" Relationship="deprecates" />
+    <RelatedPackage ID="portuguese_abnt2" Relationship="deprecates" />
+    <RelatedPackage ID="brazilian_portuguese" Relationship="deprecates" />
+    <RelatedPackage ID="kbdbr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbu/source/basic_kbdbu.kps
+++ b/release/basic/basic_kbdbu/source/basic_kbdbu.kps
@@ -83,4 +83,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdbu" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdbulg/source/basic_kbdbulg.kps
+++ b/release/basic/basic_kbdbulg/source/basic_kbdbulg.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bulgarian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdbulg" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdca/source/basic_kbdca.kps
+++ b/release/basic/basic_kbdca/source/basic_kbdca.kps
@@ -92,4 +92,10 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="canadian_french" Relationship="deprecates" />
+    <RelatedPackage ID="canadian_french_legacy" Relationship="deprecates" />
+    <RelatedPackage ID="kbdfc" Relationship="deprecates" />
+    <RelatedPackage ID="kbdca" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdcan/source/basic_kbdcan.kps
+++ b/release/basic/basic_kbdcan/source/basic_kbdcan.kps
@@ -107,4 +107,7 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="canadian_ms" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdcr/source/basic_kbdcr.kps
+++ b/release/basic/basic_kbdcr/source/basic_kbdcr.kps
@@ -95,4 +95,10 @@ the following Windows 10 input methods: Croatian and Slovenian.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="slovenian" Relationship="deprecates" />
+    <RelatedPackage ID="croatian" Relationship="deprecates" />
+    <RelatedPackage ID="bosnian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdcr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdcz/source/basic_kbdcz.kps
+++ b/release/basic/basic_kbdcz/source/basic_kbdcz.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="czech" Relationship="deprecates" />
+    <RelatedPackage ID="kbdcz" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdcz1/source/basic_kbdcz1.kps
+++ b/release/basic/basic_kbdcz1/source/basic_kbdcz1.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="czech_qwerty" Relationship="deprecates" />
+    <RelatedPackage ID="kbdcz1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdcz2/source/basic_kbdcz2.kps
+++ b/release/basic/basic_kbdcz2/source/basic_kbdcz2.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="czech_prog" Relationship="deprecates" />
+    <RelatedPackage ID="kbdcz2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdda/source/basic_kbdda.kps
+++ b/release/basic/basic_kbdda/source/basic_kbdda.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="danish" Relationship="deprecates" />
+    <RelatedPackage ID="kbdda" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbddiv1/source/basic_kbddiv1.kps
+++ b/release/basic/basic_kbddiv1/source/basic_kbddiv1.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="divehi_phon" Relationship="deprecates" />
+    <RelatedPackage ID="kbddiv1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbddiv2/source/basic_kbddiv2.kps
+++ b/release/basic/basic_kbddiv2/source/basic_kbddiv2.kps
@@ -90,4 +90,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="divehi_type" Relationship="deprecates" />
+    <RelatedPackage ID="kbddiv2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbddv/source/basic_kbddv.kps
+++ b/release/basic/basic_kbddv/source/basic_kbddv.kps
@@ -86,4 +86,9 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dvorak" Relationship="deprecates" />
+    <RelatedPackage ID="us_dvorak" Relationship="deprecates" />
+    <RelatedPackage ID="kbddv" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdes/source/basic_kbdes.kps
+++ b/release/basic/basic_kbdes/source/basic_kbdes.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="spanish_var" Relationship="deprecates" />
+    <RelatedPackage ID="kbdes" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdest/source/basic_kbdest.kps
+++ b/release/basic/basic_kbdest/source/basic_kbdest.kps
@@ -101,4 +101,8 @@ the Windows 10 Estonian layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="estonian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdest" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdfa/source/basic_kbdfa.kps
+++ b/release/basic/basic_kbdfa/source/basic_kbdfa.kps
@@ -96,4 +96,9 @@ Inscript Farsi layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="farsi_kab" Relationship="deprecates" />
+    <RelatedPackage ID="farsi" Relationship="deprecates" />
+    <RelatedPackage ID="kbdfa" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdfi/source/basic_kbdfi.kps
+++ b/release/basic/basic_kbdfi/source/basic_kbdfi.kps
@@ -95,4 +95,8 @@ the Windows 10 Finnish layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="finnish" Relationship="deprecates" />
+    <RelatedPackage ID="kbdfi" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdfi1/source/basic_kbdfi1.kps
+++ b/release/basic/basic_kbdfi1/source/basic_kbdfi1.kps
@@ -102,4 +102,9 @@ Finnish with Sami.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdfi1" Relationship="deprecates" />
+    <RelatedPackage ID="finnish_sami" Relationship="deprecates" />
+    <RelatedPackage ID="swedish_sami" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdfo/source/basic_kbdfo.kps
+++ b/release/basic/basic_kbdfo/source/basic_kbdfo.kps
@@ -92,4 +92,9 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="faeroese" Relationship="deprecates" />
+    <RelatedPackage ID="faroese" Relationship="deprecates" />
+    <RelatedPackage ID="kbdfo" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdfr/source/basic_kbdfr.kps
+++ b/release/basic/basic_kbdfr/source/basic_kbdfr.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="french" Relationship="deprecates" />
+    <RelatedPackage ID="kbdfr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgae/source/basic_kbdgae.kps
+++ b/release/basic/basic_kbdgae/source/basic_kbdgae.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gaelic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgae" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgeo/source/basic_kbdgeo.kps
+++ b/release/basic/basic_kbdgeo/source/basic_kbdgeo.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="georgian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgeo" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgeoer/source/basic_kbdgeoer.kps
+++ b/release/basic/basic_kbdgeoer/source/basic_kbdgeoer.kps
@@ -95,4 +95,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdgeoer" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgeoqw/source/basic_kbdgeoqw.kps
+++ b/release/basic/basic_kbdgeoqw/source/basic_kbdgeoqw.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdgeoqw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgkl/source/basic_kbdgkl.kps
+++ b/release/basic/basic_kbdgkl/source/basic_kbdgkl.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_latin" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgkl" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgr/source/basic_kbdgr.kps
+++ b/release/basic/basic_kbdgr/source/basic_kbdgr.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="german" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgr1/source/basic_kbdgr1.kps
+++ b/release/basic/basic_kbdgr1/source/basic_kbdgr1.kps
@@ -101,4 +101,8 @@ the Windows 10 German (IBM) layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="german_ibm" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgr1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdgrlnd/source/basic_kbdgrlnd.kps
+++ b/release/basic/basic_kbdgrlnd/source/basic_kbdgrlnd.kps
@@ -98,4 +98,8 @@ the Windows 10 Greenlandic layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greenlandic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdgrlnd" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhe/source/basic_kbdhe.kps
+++ b/release/basic/basic_kbdhe/source/basic_kbdhe.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhe" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhe220/source/basic_kbdhe220.kps
+++ b/release/basic/basic_kbdhe220/source/basic_kbdhe220.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_220" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhe220" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhe319/source/basic_kbdhe319.kps
+++ b/release/basic/basic_kbdhe319/source/basic_kbdhe319.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_319" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhe319" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdheb/source/basic_kbdheb.kps
+++ b/release/basic/basic_kbdheb/source/basic_kbdheb.kps
@@ -101,4 +101,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hebrew" Relationship="deprecates" />
+    <RelatedPackage ID="kbdheb" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhela2/source/basic_kbdhela2.kps
+++ b/release/basic/basic_kbdhela2/source/basic_kbdhela2.kps
@@ -92,4 +92,8 @@ the Windows 10 Greek (220) Latin layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_220_latin" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhela2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhela3/source/basic_kbdhela3.kps
+++ b/release/basic/basic_kbdhela3/source/basic_kbdhela3.kps
@@ -92,4 +92,8 @@ the Windows 10 Greek (319) Latin layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_319_latin" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhela3" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhept/source/basic_kbdhept.kps
+++ b/release/basic/basic_kbdhept/source/basic_kbdhept.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="greek_polytonic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhept" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhu/source/basic_kbdhu.kps
+++ b/release/basic/basic_kbdhu/source/basic_kbdhu.kps
@@ -95,4 +95,8 @@ the Windows 10 Hungarian layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hungarian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhu" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdhu1/source/basic_kbdhu1.kps
+++ b/release/basic/basic_kbdhu1/source/basic_kbdhu1.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hungarian_101" Relationship="deprecates" />
+    <RelatedPackage ID="kbdhu1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdic/source/basic_kbdic.kps
+++ b/release/basic/basic_kbdic/source/basic_kbdic.kps
@@ -95,4 +95,8 @@ the Windows 10 Icelandic layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="icelandic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinasa/source/basic_kbdinasa.kps
+++ b/release/basic/basic_kbdinasa/source/basic_kbdinasa.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdinasa" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinbe2/source/basic_kbdinbe2.kps
+++ b/release/basic/basic_kbdinbe2/source/basic_kbdinbe2.kps
@@ -92,4 +92,10 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bengali_inscript" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinbe1" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinbe2" Relationship="deprecates" />
+    <RelatedPackage ID="bengali_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinben/source/basic_kbdinben.kps
+++ b/release/basic/basic_kbdinben/source/basic_kbdinben.kps
@@ -110,4 +110,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="bengali" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinben" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdindev/source/basic_kbdindev.kps
+++ b/release/basic/basic_kbdindev/source/basic_kbdindev.kps
@@ -104,4 +104,9 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dev_inscript" Relationship="deprecates" />
+    <RelatedPackage ID="devanagari_inscript" Relationship="deprecates" />
+    <RelatedPackage ID="kbdindev" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinguj/source/basic_kbdinguj.kps
+++ b/release/basic/basic_kbdinguj/source/basic_kbdinguj.kps
@@ -105,4 +105,9 @@ Inscript layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gujarati_kab" Relationship="deprecates" />
+    <RelatedPackage ID="gujarati" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinguj" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinhin/source/basic_kbdinhin.kps
+++ b/release/basic/basic_kbdinhin/source/basic_kbdinhin.kps
@@ -104,4 +104,9 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hindi_traditional_kab" Relationship="deprecates" />
+    <RelatedPackage ID="hindi_trad" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinhin" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinkan/source/basic_kbdinkan.kps
+++ b/release/basic/basic_kbdinkan/source/basic_kbdinkan.kps
@@ -105,4 +105,9 @@ Inscript layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kannada_kab" Relationship="deprecates" />
+    <RelatedPackage ID="kannada" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinkan" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinmal/source/basic_kbdinmal.kps
+++ b/release/basic/basic_kbdinmal/source/basic_kbdinmal.kps
@@ -104,4 +104,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="malayalam" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinmal" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinmar/source/basic_kbdinmar.kps
+++ b/release/basic/basic_kbdinmar/source/basic_kbdinmar.kps
@@ -105,4 +105,9 @@ this keyboard are based on the Inscript layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdinmar" Relationship="deprecates" />
+    <RelatedPackage ID="marathi" Relationship="deprecates" />
+    <RelatedPackage ID="marathi_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinori/source/basic_kbdinori.kps
+++ b/release/basic/basic_kbdinori/source/basic_kbdinori.kps
@@ -101,4 +101,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdinori" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinpun/source/basic_kbdinpun.kps
+++ b/release/basic/basic_kbdinpun/source/basic_kbdinpun.kps
@@ -105,4 +105,9 @@ Inscript layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="punjabi_kab" Relationship="deprecates" />
+    <RelatedPackage ID="punjabi" Relationship="deprecates" />
+    <RelatedPackage ID="kbdinpun" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdintam/source/basic_kbdintam.kps
+++ b/release/basic/basic_kbdintam/source/basic_kbdintam.kps
@@ -99,4 +99,9 @@ Inscript Layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tamil_kab" Relationship="deprecates" />
+    <RelatedPackage ID="tamil" Relationship="deprecates" />
+    <RelatedPackage ID="kbdintam" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdintel/source/basic_kbdintel.kps
+++ b/release/basic/basic_kbdintel/source/basic_kbdintel.kps
@@ -105,4 +105,9 @@ layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="telegu_kab" Relationship="deprecates" />
+    <RelatedPackage ID="telugu" Relationship="deprecates" />
+    <RelatedPackage ID="kbdintel" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdinuk2/source/basic_kbdinuk2.kps
+++ b/release/basic/basic_kbdinuk2/source/basic_kbdinuk2.kps
@@ -94,4 +94,7 @@ layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdinuk2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdir/source/basic_kbdir.kps
+++ b/release/basic/basic_kbdir/source/basic_kbdir.kps
@@ -101,4 +101,8 @@ the Windows 10 Irish layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="irish" Relationship="deprecates" />
+    <RelatedPackage ID="kbdir" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdit/source/basic_kbdit.kps
+++ b/release/basic/basic_kbdit/source/basic_kbdit.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="italian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdit" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdit142/source/basic_kbdit142.kps
+++ b/release/basic/basic_kbdit142/source/basic_kbdit142.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="italian_142" Relationship="deprecates" />
+    <RelatedPackage ID="kbdit142" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdiulat/source/basic_kbdiulat.kps
+++ b/release/basic/basic_kbdiulat/source/basic_kbdiulat.kps
@@ -94,4 +94,7 @@ layout follows the Windows 10 Inuktitut - Latin layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdiulat" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdkaz/source/basic_kbdkaz.kps
+++ b/release/basic/basic_kbdkaz/source/basic_kbdkaz.kps
@@ -83,4 +83,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kazakh" Relationship="deprecates" />
+    <RelatedPackage ID="kbdkaz" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdkhmr/source/basic_kbdkhmr.kps
+++ b/release/basic/basic_kbdkhmr/source/basic_kbdkhmr.kps
@@ -98,4 +98,7 @@ the Windows 10 Khmer layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdkhmr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdkyr/source/basic_kbdkyr.kps
+++ b/release/basic/basic_kbdkyr/source/basic_kbdkyr.kps
@@ -95,4 +95,9 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kyrgyz_cyrillic" Relationship="deprecates" />
+    <RelatedPackage ID="kyrghyz" Relationship="deprecates" />
+    <RelatedPackage ID="kbdkyr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdla/source/basic_kbdla.kps
+++ b/release/basic/basic_kbdla/source/basic_kbdla.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="latin_american" Relationship="deprecates" />
+    <RelatedPackage ID="kbdla" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlao/source/basic_kbdlao.kps
+++ b/release/basic/basic_kbdlao/source/basic_kbdlao.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdlao" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlt/source/basic_kbdlt.kps
+++ b/release/basic/basic_kbdlt/source/basic_kbdlt.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="lithuanian_ibm" Relationship="deprecates" />
+    <RelatedPackage ID="kbdlt" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlt1/source/basic_kbdlt1.kps
+++ b/release/basic/basic_kbdlt1/source/basic_kbdlt1.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="lithuanian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdlt1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlt2/source/basic_kbdlt2.kps
+++ b/release/basic/basic_kbdlt2/source/basic_kbdlt2.kps
@@ -86,4 +86,7 @@ the Windows 10 Lithuanian Standard layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdlt2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlv/source/basic_kbdlv.kps
+++ b/release/basic/basic_kbdlv/source/basic_kbdlv.kps
@@ -101,4 +101,8 @@ the Windows 10 Latvian layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="latvian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdlv" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdlv1/source/basic_kbdlv1.kps
+++ b/release/basic/basic_kbdlv1/source/basic_kbdlv1.kps
@@ -101,4 +101,8 @@ the Windows 10 Latvian (QWERTY) layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="latvian_qwerty" Relationship="deprecates" />
+    <RelatedPackage ID="kbdlv1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmac/source/basic_kbdmac.kps
+++ b/release/basic/basic_kbdmac/source/basic_kbdmac.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="macedonian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmac" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmacst/source/basic_kbdmacst.kps
+++ b/release/basic/basic_kbdmacst/source/basic_kbdmacst.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="macedonian_fyro" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmacst" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmaori/source/basic_kbdmaori.kps
+++ b/release/basic/basic_kbdmaori/source/basic_kbdmaori.kps
@@ -86,4 +86,8 @@ the Windows 10 Maori layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="maori" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmaori" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmlt47/source/basic_kbdmlt47.kps
+++ b/release/basic/basic_kbdmlt47/source/basic_kbdmlt47.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="maltese_47" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmlt47" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmlt48/source/basic_kbdmlt48.kps
+++ b/release/basic/basic_kbdmlt48/source/basic_kbdmlt48.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="maltese_48" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmlt48" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmon/source/basic_kbdmon.kps
+++ b/release/basic/basic_kbdmon/source/basic_kbdmon.kps
@@ -83,4 +83,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="mongolian_cyrillic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdmon" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdmonmo/source/basic_kbdmonmo.kps
+++ b/release/basic/basic_kbdmonmo/source/basic_kbdmonmo.kps
@@ -84,4 +84,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdmonmo" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdne/source/basic_kbdne.kps
+++ b/release/basic/basic_kbdne/source/basic_kbdne.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dutch" Relationship="deprecates" />
+    <RelatedPackage ID="kbdne" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdnepr/source/basic_kbdnepr.kps
+++ b/release/basic/basic_kbdnepr/source/basic_kbdnepr.kps
@@ -95,4 +95,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdnepr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdno/source/basic_kbdno.kps
+++ b/release/basic/basic_kbdno/source/basic_kbdno.kps
@@ -92,4 +92,8 @@ follows the Windows 10 Norwegian layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="norwegian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdno" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdno1/source/basic_kbdno1.kps
+++ b/release/basic/basic_kbdno1/source/basic_kbdno1.kps
@@ -98,4 +98,8 @@ the Windows 10 Norwegian with Sami layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="norwegian_sami" Relationship="deprecates" />
+    <RelatedPackage ID="kbdno1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdpash/source/basic_kbdpash.kps
+++ b/release/basic/basic_kbdpash/source/basic_kbdpash.kps
@@ -90,4 +90,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="pashtokeyboard" Relationship="deprecates" />
+    <RelatedPackage ID="kbdpash" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdpl/source/basic_kbdpl.kps
+++ b/release/basic/basic_kbdpl/source/basic_kbdpl.kps
@@ -92,4 +92,9 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="polish" Relationship="deprecates" />
+    <RelatedPackage ID="polish_214" Relationship="deprecates" />
+    <RelatedPackage ID="kbdpl" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdpl1/source/basic_kbdpl1.kps
+++ b/release/basic/basic_kbdpl1/source/basic_kbdpl1.kps
@@ -101,4 +101,8 @@ the Windows 10 Polish (Programmers) layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="polish_prog" Relationship="deprecates" />
+    <RelatedPackage ID="kbdpl1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdpo/source/basic_kbdpo.kps
+++ b/release/basic/basic_kbdpo/source/basic_kbdpo.kps
@@ -92,4 +92,8 @@ the Windows 10 Portuguese layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="portuguese" Relationship="deprecates" />
+    <RelatedPackage ID="kbdpo" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdropr/source/basic_kbdropr.kps
+++ b/release/basic/basic_kbdropr/source/basic_kbdropr.kps
@@ -98,4 +98,7 @@ the Windows 10 Romanian (Programmers) layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdropr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdrost/source/basic_kbdrost.kps
+++ b/release/basic/basic_kbdrost/source/basic_kbdrost.kps
@@ -95,4 +95,9 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="romanian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdrost" Relationship="deprecates" />
+    <RelatedPackage ID="kbdro" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdru/source/basic_kbdru.kps
+++ b/release/basic/basic_kbdru/source/basic_kbdru.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="russian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdru" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdru1/source/basic_kbdru1.kps
+++ b/release/basic/basic_kbdru1/source/basic_kbdru1.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="russian_type" Relationship="deprecates" />
+    <RelatedPackage ID="kbdru1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsf/source/basic_kbdsf.kps
+++ b/release/basic/basic_kbdsf/source/basic_kbdsf.kps
@@ -96,4 +96,8 @@ following Windows 10 input methods: Luxembourgish and Swiss French.</Description
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdsf" Relationship="deprecates" />
+    <RelatedPackage ID="swiss_french" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsg/source/basic_kbdsg.kps
+++ b/release/basic/basic_kbdsg/source/basic_kbdsg.kps
@@ -95,4 +95,8 @@ the Windows 10 Swiss German layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="swiss_german" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsg" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsl/source/basic_kbdsl.kps
+++ b/release/basic/basic_kbdsl/source/basic_kbdsl.kps
@@ -92,4 +92,8 @@ the Windows 10 Slovak layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="slovak" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsl" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsl1/source/basic_kbdsl1.kps
+++ b/release/basic/basic_kbdsl1/source/basic_kbdsl1.kps
@@ -92,4 +92,8 @@ the Windows 10 Slovak (QWERTY) layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="slovak_qwerty" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsl1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsmsfi/source/basic_kbdsmsfi.kps
+++ b/release/basic/basic_kbdsmsfi/source/basic_kbdsmsfi.kps
@@ -99,4 +99,8 @@ the Windows 10 Sami Extended Finland-Sweden layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sami_finland_sweden" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsmsfi" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsmsno/source/basic_kbdsmsno.kps
+++ b/release/basic/basic_kbdsmsno/source/basic_kbdsmsno.kps
@@ -98,4 +98,8 @@ the Windows 10 Sami Extended Norway layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sami_norway" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsmsno" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsn1/source/basic_kbdsn1.kps
+++ b/release/basic/basic_kbdsn1/source/basic_kbdsn1.kps
@@ -93,4 +93,7 @@ the Windows 10 Sinhala layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdsn1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsorex/source/basic_kbdsorex.kps
+++ b/release/basic/basic_kbdsorex/source/basic_kbdsorex.kps
@@ -92,4 +92,7 @@ the Windows 10 Sorbian Extended layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdsorex" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsors1/source/basic_kbdsors1.kps
+++ b/release/basic/basic_kbdsors1/source/basic_kbdsors1.kps
@@ -87,4 +87,7 @@ the Windows 10 Sorbian Standard layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdsorst" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsp/source/basic_kbdsp.kps
+++ b/release/basic/basic_kbdsp/source/basic_kbdsp.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="spanish" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsp" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsw/source/basic_kbdsw.kps
+++ b/release/basic/basic_kbdsw/source/basic_kbdsw.kps
@@ -92,4 +92,8 @@ the Windows 10 Swedish layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="swedish" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsw09/source/basic_kbdsw09.kps
+++ b/release/basic/basic_kbdsw09/source/basic_kbdsw09.kps
@@ -92,4 +92,7 @@ the Windows 10 Sinhala - wij 9 layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdsw09" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsyr1/source/basic_kbdsyr1.kps
+++ b/release/basic/basic_kbdsyr1/source/basic_kbdsyr1.kps
@@ -93,4 +93,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="syriac" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsyr1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdsyr2/source/basic_kbdsyr2.kps
+++ b/release/basic/basic_kbdsyr2/source/basic_kbdsyr2.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="syriac_phon" Relationship="deprecates" />
+    <RelatedPackage ID="kbdsyr2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtajik/source/basic_kbdtajik.kps
+++ b/release/basic/basic_kbdtajik/source/basic_kbdtajik.kps
@@ -83,4 +83,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tajik" Relationship="deprecates" />
+    <RelatedPackage ID="kbdtajik" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtam99/source/basic_kbdtam99.kps
+++ b/release/basic/basic_kbdtam99/source/basic_kbdtam99.kps
@@ -101,4 +101,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tamil99m" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdth0/source/basic_kbdth0.kps
+++ b/release/basic/basic_kbdth0/source/basic_kbdth0.kps
@@ -92,4 +92,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="thai_kedmanee" Relationship="deprecates" />
+    <RelatedPackage ID="kbdth0" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdth1/source/basic_kbdth1.kps
+++ b/release/basic/basic_kbdth1/source/basic_kbdth1.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="thai_pattachote" Relationship="deprecates" />
+    <RelatedPackage ID="kbdth1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdth2/source/basic_kbdth2.kps
+++ b/release/basic/basic_kbdth2/source/basic_kbdth2.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="thai_kedmanee_nsl" Relationship="deprecates" />
+    <RelatedPackage ID="kbdth2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdth3/source/basic_kbdth3.kps
+++ b/release/basic/basic_kbdth3/source/basic_kbdth3.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="thai_pattachote_nsl" Relationship="deprecates" />
+    <RelatedPackage ID="kbdth3" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtiprd/source/basic_kbdtiprd.kps
+++ b/release/basic/basic_kbdtiprd/source/basic_kbdtiprd.kps
@@ -112,4 +112,7 @@ Unicode Tibetan font DDC Uchen.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdtiprc" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtt102/source/basic_kbdtt102.kps
+++ b/release/basic/basic_kbdtt102/source/basic_kbdtt102.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tatar" Relationship="deprecates" />
+    <RelatedPackage ID="kbdtat" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtuf/source/basic_kbdtuf.kps
+++ b/release/basic/basic_kbdtuf/source/basic_kbdtuf.kps
@@ -98,4 +98,8 @@ the Windows 10 Turkish F layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="turkish_f" Relationship="deprecates" />
+    <RelatedPackage ID="kbdtuf" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdtuq/source/basic_kbdtuq.kps
+++ b/release/basic/basic_kbdtuq/source/basic_kbdtuq.kps
@@ -98,4 +98,8 @@ the Windows 10 Turkish Q layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="turkish_q" Relationship="deprecates" />
+    <RelatedPackage ID="kbdtuq" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdturme/source/basic_kbdturme.kps
+++ b/release/basic/basic_kbdturme/source/basic_kbdturme.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tkmluncd" Relationship="deprecates" />
+    <RelatedPackage ID="kbdturme" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdughr1/source/basic_kbdughr1.kps
+++ b/release/basic/basic_kbdughr1/source/basic_kbdughr1.kps
@@ -83,4 +83,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdughr" Relationship="deprecates" />
+    <RelatedPackage ID="basic_kbdughr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbduk/source/basic_kbduk.kps
+++ b/release/basic/basic_kbduk/source/basic_kbduk.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="uk" Relationship="deprecates" />
+    <RelatedPackage ID="kbduk" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdukx/source/basic_kbdukx.kps
+++ b/release/basic/basic_kbdukx/source/basic_kbdukx.kps
@@ -98,4 +98,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="uk_extended" Relationship="deprecates" />
+    <RelatedPackage ID="kbdukx" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdur/source/basic_kbdur.kps
+++ b/release/basic/basic_kbdur/source/basic_kbdur.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ukrainian" Relationship="deprecates" />
+    <RelatedPackage ID="kbdur" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdur1/source/basic_kbdur1.kps
+++ b/release/basic/basic_kbdur1/source/basic_kbdur1.kps
@@ -95,4 +95,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdur1" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdurdu/source/basic_kbdurdu.kps
+++ b/release/basic/basic_kbdurdu/source/basic_kbdurdu.kps
@@ -95,4 +95,9 @@ the Windows 10 Urdu layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="urdu_kab" Relationship="deprecates" />
+    <RelatedPackage ID="urdu" Relationship="deprecates" />
+    <RelatedPackage ID="kbdurdu" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdus/source/basic_kbdus.kps
+++ b/release/basic/basic_kbdus/source/basic_kbdus.kps
@@ -112,4 +112,8 @@ Hong Kong S.A.R.) - US, Chinese (Simplified, Singapore) - US, Chinese
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdus" Relationship="deprecates" />
+    <RelatedPackage ID="us" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdusa/source/basic_kbdusa.kps
+++ b/release/basic/basic_kbdusa/source/basic_kbdusa.kps
@@ -83,4 +83,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdusa" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdusl/source/basic_kbdusl.kps
+++ b/release/basic/basic_kbdusl/source/basic_kbdusl.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="us_dvorak_lh" Relationship="deprecates" />
+    <RelatedPackage ID="kbdusl" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdusr/source/basic_kbdusr.kps
+++ b/release/basic/basic_kbdusr/source/basic_kbdusr.kps
@@ -86,4 +86,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="us_dvorak_rh" Relationship="deprecates" />
+    <RelatedPackage ID="kbdusr" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdusx/source/basic_kbdusx.kps
+++ b/release/basic/basic_kbdusx/source/basic_kbdusx.kps
@@ -101,4 +101,8 @@ the Windows 10 United States-International layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="us_int" Relationship="deprecates" />
+    <RelatedPackage ID="kbdusx" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbduzb/source/basic_kbduzb.kps
+++ b/release/basic/basic_kbduzb/source/basic_kbduzb.kps
@@ -83,4 +83,9 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="uzbek_cyrillic" Relationship="deprecates" />
+    <RelatedPackage ID="uzbek" Relationship="deprecates" />
+    <RelatedPackage ID="kbduzb" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdvntc/source/basic_kbdvntc.kps
+++ b/release/basic/basic_kbdvntc/source/basic_kbdvntc.kps
@@ -95,4 +95,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="vietnamese" Relationship="deprecates" />
+    <RelatedPackage ID="kbdvntc" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdyak/source/basic_kbdyak.kps
+++ b/release/basic/basic_kbdyak/source/basic_kbdyak.kps
@@ -89,4 +89,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kbdyak" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdycc/source/basic_kbdycc.kps
+++ b/release/basic/basic_kbdycc/source/basic_kbdycc.kps
@@ -91,4 +91,8 @@ layout from Windows 10.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="serbian_cyrillic" Relationship="deprecates" />
+    <RelatedPackage ID="kbdycc" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/basic/basic_kbdycl/source/basic_kbdycl.kps
+++ b/release/basic/basic_kbdycl/source/basic_kbdycl.kps
@@ -89,4 +89,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="serbian_latin" Relationship="deprecates" />
+    <RelatedPackage ID="kbdycl" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/bj/bj_cree_east_james_bay/source/bj_cree_east_james_bay.kps
+++ b/release/bj/bj_cree_east_james_bay/source/bj_cree_east_james_bay.kps
@@ -81,4 +81,7 @@ character). It uses Unified Canadian Aboriginal Syllabics.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="creekeysdesktop3" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kps
+++ b/release/bj/bj_naskapi_classic/source/bj_naskapi_classic.kps
@@ -82,4 +82,7 @@ Syllabics.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="naskeysdesktop" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/bj/bj_naskapi_common/source/bj_naskapi_common.kps
+++ b/release/bj/bj_naskapi_common/source/bj_naskapi_common.kps
@@ -87,4 +87,7 @@ it sounds) layout. It uses Unified Canadian Aboriginal Syllabics.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="naskeysdesktop" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/c/clavbur9/source/clavbur9.kps
+++ b/release/c/clavbur9/source/clavbur9.kps
@@ -114,4 +114,7 @@ AZERTY ou le clavier QWERTY.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="clavier du burkina" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/c/coptic_greek/source/coptic_greek.kps
+++ b/release/c/coptic_greek/source/coptic_greek.kps
@@ -105,4 +105,7 @@ supports a touch layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="coptic_qwerty" />
+  </RelatedPackages>
 </Package>

--- a/release/d/dene/source/dene.kps
+++ b/release/d/dene/source/dene.kps
@@ -88,4 +88,7 @@ south Slavy, and Gwich\'in languages of Canada.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="deneunicode" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/e/easy_chakma/source/easy_chakma.kps
+++ b/release/e/easy_chakma/source/easy_chakma.kps
@@ -88,4 +88,7 @@ to input any Chakma complex words even any Chakma spell-bound.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="easy chakma new" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/e/ekwtamil99uni/source/ekwtamil99uni.kps
+++ b/release/e/ekwtamil99uni/source/ekwtamil99uni.kps
@@ -212,4 +212,7 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="Thamizha Tamil99" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_dari_clra/source/el_dari_clra.kps
+++ b/release/el/el_dari_clra/source/el_dari_clra.kps
@@ -91,4 +91,7 @@ and other regions in South Asia.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dari_clra" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_dinka/source/el_dinka.kps
+++ b/release/el/el_dinka/source/el_dinka.kps
@@ -111,4 +111,8 @@
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dinkaweb11" Relationship="deprecates" />
+    <RelatedPackage ID="dlia25bas" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_harari_latin/source/el_harari_latin.kps
+++ b/release/el/el_harari_latin/source/el_harari_latin.kps
@@ -143,4 +143,8 @@ Harari children their own language.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="har10" Relationship="deprecates" />
+    <RelatedPackage ID="harlatn" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_naija/source/el_naija.kps
+++ b/release/el/el_naija/source/el_naija.kps
@@ -117,4 +117,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="naijanfd10" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_nuer/source/el_nuer.kps
+++ b/release/el/el_nuer/source/el_nuer.kps
@@ -97,4 +97,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nuer13" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_osmanya/source/el_osmanya.kps
+++ b/release/el/el_osmanya/source/el_osmanya.kps
@@ -104,4 +104,7 @@ language of the Horn region of Africa.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="osmanya10" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_pan_sahelian/source/el_pan_sahelian.kps
+++ b/release/el/el_pan_sahelian/source/el_pan_sahelian.kps
@@ -79,4 +79,7 @@ Central Africa.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ps32" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_pasifika/source/el_pasifika.kps
+++ b/release/el/el_pasifika/source/el_pasifika.kps
@@ -104,4 +104,7 @@ Hawaiian, Maori, Niuean, Samoan, Tahitian, and Tongan.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="pasifika20" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/el/el_yolngu/source/el_yolngu.kps
+++ b/release/el/el_yolngu/source/el_yolngu.kps
@@ -77,4 +77,8 @@ website.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yolngu20" Relationship="deprecates" />
+    <RelatedPackage ID="yolngu21" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_anicinapemi8in/source/fv_anicinapemi8in.kps
+++ b/release/fv/fv_anicinapemi8in/source/fv_anicinapemi8in.kps
@@ -55,4 +55,7 @@ set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_anicinapemi8in_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_anishinaabemowin/source/fv_anishinaabemowin.kps
+++ b/release/fv/fv_anishinaabemowin/source/fv_anishinaabemowin.kps
@@ -55,4 +55,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_anishinaabemowin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_atikamekw/source/fv_atikamekw.kps
+++ b/release/fv/fv_atikamekw/source/fv_atikamekw.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_atikamekw_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_australian/source/fv_australian.kps
+++ b/release/fv/fv_australian/source/fv_australian.kps
@@ -58,4 +58,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_australian_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_blackfoot/source/fv_blackfoot.kps
+++ b/release/fv/fv_blackfoot/source/fv_blackfoot.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_blackfoot_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_bodewadminwen/source/fv_bodewadminwen.kps
+++ b/release/fv/fv_bodewadminwen/source/fv_bodewadminwen.kps
@@ -55,4 +55,7 @@ of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_bodewadminwen_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_cree_latin/source/fv_cree_latin.kps
+++ b/release/fv/fv_cree_latin/source/fv_cree_latin.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_cree_latin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dakelh/source/fv_dakelh.kps
+++ b/release/fv/fv_dakelh/source/fv_dakelh.kps
@@ -152,4 +152,10 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dakelh" Relationship="deprecates" />
+    <RelatedPackage ID="dakelh1_u" Relationship="deprecates" />
+    <RelatedPackage ID="dakelh2_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_dakelh_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dakota_mb/source/fv_dakota_mb.kps
+++ b/release/fv/fv_dakota_mb/source/fv_dakota_mb.kps
@@ -54,4 +54,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dakota_mb_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dakota_sk/source/fv_dakota_sk.kps
+++ b/release/fv/fv_dakota_sk/source/fv_dakota_sk.kps
@@ -54,4 +54,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dakota_sk_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dane_zaa_zaage/source/fv_dane_zaa_zaage.kps
+++ b/release/fv/fv_dane_zaa_zaage/source/fv_dane_zaa_zaage.kps
@@ -86,4 +86,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dane_zaa_zaage_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dene_dzage/source/fv_dene_dzage.kps
+++ b/release/fv/fv_dene_dzage/source/fv_dene_dzage.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dene_dzage_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dene_mb/source/fv_dene_mb.kps
+++ b/release/fv/fv_dene_mb/source/fv_dene_mb.kps
@@ -63,4 +63,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dene_mb_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dene_nt/source/fv_dene_nt.kps
+++ b/release/fv/fv_dene_nt/source/fv_dene_nt.kps
@@ -69,4 +69,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dene_nt_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dene_zhatie/source/fv_dene_zhatie.kps
+++ b/release/fv/fv_dene_zhatie/source/fv_dene_zhatie.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dene_zhatie_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_denesuline/source/fv_denesuline.kps
+++ b/release/fv/fv_denesuline/source/fv_denesuline.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_denesuline_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_denesuline_epsilon/source/fv_denesuline_epsilon.kps
+++ b/release/fv/fv_denesuline_epsilon/source/fv_denesuline_epsilon.kps
@@ -153,4 +153,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_denesuline_epsilon_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dexwlesucid/source/fv_dexwlesucid.kps
+++ b/release/fv/fv_dexwlesucid/source/fv_dexwlesucid.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dexwlesucid_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_diitiidatx/source/fv_diitiidatx.kps
+++ b/release/fv/fv_diitiidatx/source/fv_diitiidatx.kps
@@ -146,4 +146,9 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="diitiidatx_u " Relationship="deprecates" />
+    <RelatedPackage ID="nootka " Relationship="deprecates" />
+    <RelatedPackage ID="fv_diitiidatx_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_dine_bizaad/source/fv_dine_bizaad.kps
+++ b/release/fv/fv_dine_bizaad/source/fv_dine_bizaad.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_dine_bizaad_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kps
+++ b/release/fv/fv_eastern_canadian_inuktitut/source/fv_eastern_canadian_inuktitut.kps
@@ -62,4 +62,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_eastern_canadian_inuktitut_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_gitsenimx/source/fv_gitsenimx.kps
+++ b/release/fv/fv_gitsenimx/source/fv_gitsenimx.kps
@@ -145,4 +145,9 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gitsenimx_u" Relationship="deprecates" />
+    <RelatedPackage ID="gitxsan" Relationship="deprecates" />
+    <RelatedPackage ID="fv_gitsenimx_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_goyogohono/source/fv_goyogohono.kps
+++ b/release/fv/fv_goyogohono/source/fv_goyogohono.kps
@@ -55,4 +55,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_goyogohono_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_gwichin/source/fv_gwichin.kps
+++ b/release/fv/fv_gwichin/source/fv_gwichin.kps
@@ -130,4 +130,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_gwichin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kps
+++ b/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kps
@@ -78,4 +78,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_hailzaqvla_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_halqemeylem/source/fv_halqemeylem.kps
+++ b/release/fv/fv_halqemeylem/source/fv_halqemeylem.kps
@@ -140,4 +140,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="halqemeylem_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_halqemeylem_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_han/source/fv_han.kps
+++ b/release/fv/fv_han/source/fv_han.kps
@@ -139,4 +139,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_han_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_henqeminem/source/fv_henqeminem.kps
+++ b/release/fv/fv_henqeminem/source/fv_henqeminem.kps
@@ -144,4 +144,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="henqeminem_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_henqeminem_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_hlgaagilda_xaayda_kil/source/fv_hlgaagilda_xaayda_kil.kps
+++ b/release/fv/fv_hlgaagilda_xaayda_kil/source/fv_hlgaagilda_xaayda_kil.kps
@@ -147,4 +147,9 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="haida" Relationship="deprecates" />
+    <RelatedPackage ID="xaadkil" Relationship="deprecates" />
+    <RelatedPackage ID="fv_hlgaagilda_xaayda_kil_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_hulquminum/source/fv_hulquminum.kps
+++ b/release/fv/fv_hulquminum/source/fv_hulquminum.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_hulquminum_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_hulquminum_combine/source/fv_hulquminum_combine.kps
+++ b/release/fv/fv_hulquminum_combine/source/fv_hulquminum_combine.kps
@@ -57,4 +57,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_hulquminum" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_ilnu_innu_aimun/source/fv_ilnu_innu_aimun.kps
+++ b/release/fv/fv_ilnu_innu_aimun/source/fv_ilnu_innu_aimun.kps
@@ -55,4 +55,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_ilnu_innu_aimun_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_inuvialuktun/source/fv_inuvialuktun.kps
+++ b/release/fv/fv_inuvialuktun/source/fv_inuvialuktun.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_inuvialuktun_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_isga_iabi/source/fv_isga_iabi.kps
+++ b/release/fv/fv_isga_iabi/source/fv_isga_iabi.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_isga_iabi_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_kanienkeha_e/source/fv_kanienkeha_e.kps
+++ b/release/fv/fv_kanienkeha_e/source/fv_kanienkeha_e.kps
@@ -145,4 +145,7 @@ of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_kanienkeha_e_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_kashogotine_yati/source/fv_kashogotine_yati.kps
+++ b/release/fv/fv_kashogotine_yati/source/fv_kashogotine_yati.kps
@@ -55,4 +55,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_kashogotine_yati_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_klahoose/source/fv_klahoose.kps
+++ b/release/fv/fv_klahoose/source/fv_klahoose.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_klahoose_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_ktunaxa/source/fv_ktunaxa.kps
+++ b/release/fv/fv_ktunaxa/source/fv_ktunaxa.kps
@@ -144,4 +144,9 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ktunaxa" Relationship="deprecates" />
+    <RelatedPackage ID="kutenai" Relationship="deprecates" />
+    <RelatedPackage ID="fv_ktunaxa_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_kwakwala/source/fv_kwakwala.kps
+++ b/release/fv/fv_kwakwala/source/fv_kwakwala.kps
@@ -145,4 +145,10 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kwakwala_u" Relationship="deprecates" />
+    <RelatedPackage ID="kwakiutl" Relationship="deprecates" />
+    <RelatedPackage ID="uwikala_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_kwakwala_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_kwakwala_liqwala/source/fv_kwakwala_liqwala.kps
+++ b/release/fv/fv_kwakwala_liqwala/source/fv_kwakwala_liqwala.kps
@@ -146,4 +146,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_kwakwala_liqwala_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_lakota/source/fv_lakota.kps
+++ b/release/fv/fv_lakota/source/fv_lakota.kps
@@ -54,4 +54,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_lakota_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_lunaapeewi_huluniixsuwaakan/source/fv_lunaapeewi_huluniixsuwaakan.kps
+++ b/release/fv/fv_lunaapeewi_huluniixsuwaakan/source/fv_lunaapeewi_huluniixsuwaakan.kps
@@ -55,4 +55,7 @@ set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_lunaapeewi_huluniixsuwaakan_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_maori/source/fv_maori.kps
+++ b/release/fv/fv_maori/source/fv_maori.kps
@@ -54,4 +54,7 @@ of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_maori_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_migmaq/source/fv_migmaq.kps
+++ b/release/fv/fv_migmaq/source/fv_migmaq.kps
@@ -146,4 +146,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_migmaq_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_moose_cree/source/fv_moose_cree.kps
+++ b/release/fv/fv_moose_cree/source/fv_moose_cree.kps
@@ -63,4 +63,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_moose_cree_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nakoda/source/fv_nakoda.kps
+++ b/release/fv/fv_nakoda/source/fv_nakoda.kps
@@ -54,4 +54,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_nakoda_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_naskapi/source/fv_naskapi.kps
+++ b/release/fv/fv_naskapi/source/fv_naskapi.kps
@@ -62,4 +62,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_naskapi_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_natwits/source/fv_natwits.kps
+++ b/release/fv/fv_natwits/source/fv_natwits.kps
@@ -146,4 +146,8 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="natooten" Relationship="deprecates" />
+    <RelatedPackage ID="fv_natwits_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_neeaandeg/source/fv_neeaandeg.kps
+++ b/release/fv/fv_neeaandeg/source/fv_neeaandeg.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_neeaandeg_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_neeaaneegn/source/fv_neeaaneegn.kps
+++ b/release/fv/fv_neeaaneegn/source/fv_neeaaneegn.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_neeaaneegn_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nexwslayemucen/source/fv_nexwslayemucen.kps
+++ b/release/fv/fv_nexwslayemucen/source/fv_nexwslayemucen.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_nexwslayemucen_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nisgaa/source/fv_nisgaa.kps
+++ b/release/fv/fv_nisgaa/source/fv_nisgaa.kps
@@ -146,4 +146,9 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nisgaa_u" Relationship="deprecates" />
+    <RelatedPackage ID="nisgaa" Relationship="deprecates" />
+    <RelatedPackage ID="fv_nisgaa_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nlekepmxcin/source/fv_nlekepmxcin.kps
+++ b/release/fv/fv_nlekepmxcin/source/fv_nlekepmxcin.kps
@@ -147,4 +147,9 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nlekepmxcin_u" Relationship="deprecates" />
+    <RelatedPackage ID="nlakapamux" Relationship="deprecates" />
+    <RelatedPackage ID="fv_nlekepmxcin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nlha7kapmxtsin/source/fv_nlha7kapmxtsin.kps
+++ b/release/fv/fv_nlha7kapmxtsin/source/fv_nlha7kapmxtsin.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_nlha7kapmxtsin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kps
+++ b/release/fv/fv_northern_east_cree/source/fv_northern_east_cree.kps
@@ -63,4 +63,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_northern_east_cree_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kps
+++ b/release/fv/fv_northern_tutchone/source/fv_northern_tutchone.kps
@@ -142,4 +142,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_northern_tutchone_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nsilxcen/source/fv_nsilxcen.kps
+++ b/release/fv/fv_nsilxcen/source/fv_nsilxcen.kps
@@ -148,4 +148,8 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="okanagan_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_nsilxcen_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nuucaanul/source/fv_nuucaanul.kps
+++ b/release/fv/fv_nuucaanul/source/fv_nuucaanul.kps
@@ -146,4 +146,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nuuchahnulth_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_nuucaanul_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_nuxalk/source/fv_nuxalk.kps
+++ b/release/fv/fv_nuxalk/source/fv_nuxalk.kps
@@ -54,4 +54,7 @@ of Canada. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_nuxalk_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_ojibwa/source/fv_ojibwa.kps
+++ b/release/fv/fv_ojibwa/source/fv_ojibwa.kps
@@ -63,4 +63,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_ojibwa_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_onayotaaka/source/fv_onayotaaka.kps
+++ b/release/fv/fv_onayotaaka/source/fv_onayotaaka.kps
@@ -55,4 +55,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_onayotaaka_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_onodagega_onondagega/source/fv_onodagega_onondagega.kps
+++ b/release/fv/fv_onodagega_onondagega/source/fv_onodagega_onondagega.kps
@@ -55,4 +55,7 @@ set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_onodagega_onondagega_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_onodowaga/source/fv_onodowaga.kps
+++ b/release/fv/fv_onodowaga/source/fv_onodowaga.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_onodowaga_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_plains_cree/source/fv_plains_cree.kps
+++ b/release/fv/fv_plains_cree/source/fv_plains_cree.kps
@@ -63,4 +63,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_plains_cree_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_sahugotine_yati/source/fv_sahugotine_yati.kps
+++ b/release/fv/fv_sahugotine_yati/source/fv_sahugotine_yati.kps
@@ -55,4 +55,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_sahugotine_yati_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_secwepemctsin/source/fv_secwepemctsin.kps
+++ b/release/fv/fv_secwepemctsin/source/fv_secwepemctsin.kps
@@ -146,4 +146,8 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="secwepemctsin_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_secwepemctsin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_sencoten/source/fv_sencoten.kps
+++ b/release/fv/fv_sencoten/source/fv_sencoten.kps
@@ -153,4 +153,9 @@ This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sencoten_u" Relationship="deprecates" />
+    <RelatedPackage ID="salish" Relationship="deprecates" />
+    <RelatedPackage ID="fv_sencoten_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kps
+++ b/release/fv/fv_severn_ojibwa/source/fv_severn_ojibwa.kps
@@ -63,4 +63,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_severn_ojibwa_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_shashishalhem/source/fv_shashishalhem.kps
+++ b/release/fv/fv_shashishalhem/source/fv_shashishalhem.kps
@@ -146,4 +146,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="shashishalhem_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_shashishalhem_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_shihgotine_yati/source/fv_shihgotine_yati.kps
+++ b/release/fv/fv_shihgotine_yati/source/fv_shihgotine_yati.kps
@@ -55,4 +55,7 @@ from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_shihgotine_yati_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_skaru_re/source/fv_skaru_re.kps
+++ b/release/fv/fv_skaru_re/source/fv_skaru_re.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_skaru_re_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_skicinuwatuwewakon/source/fv_skicinuwatuwewakon.kps
+++ b/release/fv/fv_skicinuwatuwewakon/source/fv_skicinuwatuwewakon.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_skicinuwatuwewakon_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_skwxwumesh_snichim/source/fv_skwxwumesh_snichim.kps
+++ b/release/fv/fv_skwxwumesh_snichim/source/fv_skwxwumesh_snichim.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_skwxwumesh_snichim_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_smalgyax/source/fv_smalgyax.kps
+++ b/release/fv/fv_smalgyax/source/fv_smalgyax.kps
@@ -146,4 +146,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="smalgyax_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_smalgyax_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_southern_carrier/source/fv_southern_carrier.kps
+++ b/release/fv/fv_southern_carrier/source/fv_southern_carrier.kps
@@ -62,4 +62,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_southern_carrier_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
+++ b/release/fv/fv_southern_tutchone/source/fv_southern_tutchone.kps
@@ -141,4 +141,7 @@ the region. This is part of a set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_southern_tutchone_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_statimcets/source/fv_statimcets.kps
+++ b/release/fv/fv_statimcets/source/fv_statimcets.kps
@@ -146,4 +146,9 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="statimcets" Relationship="deprecates" />
+    <RelatedPackage ID="statimc_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_statimcets_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_stlatlimxec/source/fv_stlatlimxec.kps
+++ b/release/fv/fv_stlatlimxec/source/fv_stlatlimxec.kps
@@ -146,4 +146,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="stlatlimxec" Relationship="deprecates" />
+    <RelatedPackage ID="fv_stlatlimxec_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_swampy_cree/source/fv_swampy_cree.kps
+++ b/release/fv/fv_swampy_cree/source/fv_swampy_cree.kps
@@ -62,4 +62,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_swampy_cree_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kps
+++ b/release/fv/fv_tagizi_dene/source/fv_tagizi_dene.kps
@@ -141,4 +141,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_tagizi_dene_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_taltan/source/fv_taltan.kps
+++ b/release/fv/fv_taltan/source/fv_taltan.kps
@@ -145,4 +145,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_taltan_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tlicho_yatii/source/fv_tlicho_yatii.kps
+++ b/release/fv/fv_tlicho_yatii/source/fv_tlicho_yatii.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_tlicho_yatii_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tlingit/source/fv_tlingit.kps
+++ b/release/fv/fv_tlingit/source/fv_tlingit.kps
@@ -79,4 +79,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_tlingit_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tsekehne/source/fv_tsekehne.kps
+++ b/release/fv/fv_tsekehne/source/fv_tsekehne.kps
@@ -145,4 +145,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_tsekehne_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kps
+++ b/release/fv/fv_tsilhqotin/source/fv_tsilhqotin.kps
@@ -140,4 +140,8 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="chilcotin" Relationship="deprecates" />
+    <RelatedPackage ID="fv_tsilhqotin_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_tsuutina/source/fv_tsuutina.kps
+++ b/release/fv/fv_tsuutina/source/fv_tsuutina.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_tsuutina_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_uummarmiutun/source/fv_uummarmiutun.kps
+++ b/release/fv/fv_uummarmiutun/source/fv_uummarmiutun.kps
@@ -54,4 +54,7 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_uummarmiutun_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_uwikala/source/fv_uwikala.kps
+++ b/release/fv/fv_uwikala/source/fv_uwikala.kps
@@ -152,4 +152,8 @@ region of Canada. This is part of a set of keyboards from FirstVoices.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="heiltsuk" Relationship="deprecates" />
+    <RelatedPackage ID="fv_uwikala_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_wendat/source/fv_wendat.kps
+++ b/release/fv/fv_wendat/source/fv_wendat.kps
@@ -55,4 +55,7 @@ FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_wendat_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_wobanakiodwawogan/source/fv_wobanakiodwawogan.kps
+++ b/release/fv/fv_wobanakiodwawogan/source/fv_wobanakiodwawogan.kps
@@ -55,4 +55,7 @@ keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="fv_wobanakiodwawogan_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/fv/fv_xaislakala/source/fv_xaislakala.kps
+++ b/release/fv/fv_xaislakala/source/fv_xaislakala.kps
@@ -146,4 +146,8 @@ set of keyboards from FirstVoices.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="haisla_u" Relationship="deprecates" />
+    <RelatedPackage ID="fv_xaislakala_kmw" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/g/galaxie_greek_mnemonic/source/galaxie_greek_mnemonic.kps
+++ b/release/g/galaxie_greek_mnemonic/source/galaxie_greek_mnemonic.kps
@@ -82,4 +82,7 @@ order of the keys on your hardware layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiebiblescriptmnemonic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/g/galaxie_greek_positional/source/galaxie_greek_positional.kps
+++ b/release/g/galaxie_greek_positional/source/galaxie_greek_positional.kps
@@ -91,4 +91,8 @@ Septuagint Scriptures.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiegreekandhebrew" Relationship="deprecates" />
+    <RelatedPackage ID="galaxiegreekkm6" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kps
+++ b/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kps
@@ -75,4 +75,7 @@ layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiebiblescriptmnemonic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kps
+++ b/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kps
@@ -75,4 +75,8 @@ ancient Near East and the language of the Hebrew Bible</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiegreekandhebrew" Relationship="deprecates" />
+    <RelatedPackage ID="galaxiehebrewkm6" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/g/gandhari/source/gandhari.kps
+++ b/release/g/gandhari/source/gandhari.kps
@@ -78,4 +78,7 @@ font](https://github.com/gandhariunicode/gandhari_unicode_font)</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gandhari-keyboard-2.7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_amh_7/source/gff_amh_7.kps
+++ b/release/gff/gff_amh_7/source/gff_amh_7.kps
@@ -224,4 +224,7 @@ standard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff-amh-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_amharic/source/gff_amharic.kps
+++ b/release/gff/gff_amharic/source/gff_amharic.kps
@@ -252,4 +252,8 @@ standard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_amh_powerpack_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_amh_7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_amharic_classic/source/gff_amharic_classic.kps
+++ b/release/gff/gff_amharic_classic/source/gff_amharic_classic.kps
@@ -233,4 +233,7 @@ platforms based on a US-QWERTY layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_amharic" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_awngi_xamtanga/source/gff_awngi_xamtanga.kps
+++ b/release/gff/gff_awngi_xamtanga/source/gff_awngi_xamtanga.kps
@@ -218,4 +218,8 @@ convention for Ethiopic script languages.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_awn_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-awn-powerpack-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_blin/source/gff_blin.kps
+++ b/release/gff/gff_blin/source/gff_blin.kps
@@ -214,4 +214,8 @@ script languages.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff-byn-powerpack-7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_byn_7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_ethiopic/source/gff_ethiopic.kps
+++ b/release/gff/gff_ethiopic/source/gff_ethiopic.kps
@@ -245,4 +245,11 @@ convention for Ethiopic script languages.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_ethiopic_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_bcq_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-bcq-powerpack-7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_mym_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-mym-powerpack-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_geez/source/gff_geez.kps
+++ b/release/gff/gff_geez/source/gff_geez.kps
@@ -157,4 +157,9 @@ a Geʾez language document.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_gez_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-gez-7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-gez-powerpack-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_gurage/source/gff_gurage.kps
+++ b/release/gff/gff_gurage/source/gff_gurage.kps
@@ -183,4 +183,8 @@ with \"Gurage\" are included with this package.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_gurage_legacy" />
+    <RelatedPackage ID="gff_sgw_7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_gurage_legacy/source/gff_gurage_legacy.kps
+++ b/release/gff/gff_gurage_legacy/source/gff_gurage_legacy.kps
@@ -151,4 +151,8 @@ standard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff_sgw_7" Relationship="deprecates" />
+    <RelatedPackage ID="gff-sgw-powerpack-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
+++ b/release/gff/gff_tigrinya_eritrea/source/gff_tigrinya_eritrea.kps
@@ -257,4 +257,10 @@ script languages.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff-tir-er-powerpack-7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_tir_er_7" Relationship="deprecates" />
+    <RelatedPackage ID="tir_er_uni_ez" Relationship="deprecates" />
+    <RelatedPackage ID="tir-er-uni" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
@@ -257,4 +257,10 @@ script languages.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff-tir-et-powerpack-7" Relationship="deprecates" />
+    <RelatedPackage ID="gff_tir_et_7" Relationship="deprecates" />
+    <RelatedPackage ID="tir_et_uni_ez" Relationship="deprecates" />
+    <RelatedPackage ID="tir-et-uni" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/h/hindi_modular/source/hindi_modular.kps
+++ b/release/h/hindi_modular/source/hindi_modular.kps
@@ -100,4 +100,7 @@ professional DTP work.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hindi_modular_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/k/khmer_angkor/source/khmer_angkor.kps
+++ b/release/k/khmer_angkor/source/khmer_angkor.kps
@@ -158,4 +158,7 @@ Automatically corrects many common keying errors.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="khmer10" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/k/kmhmu_2008/source/kmhmu_2008.kps
+++ b/release/k/kmhmu_2008/source/kmhmu_2008.kps
@@ -109,4 +109,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kmhmu" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/l/lao_2008_basic/source/lao_2008_basic.kps
+++ b/release/l/lao_2008_basic/source/lao_2008_basic.kps
@@ -119,4 +119,7 @@ re-ordering and no break insertion.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="lao 2008" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/l/lao_2008_rapid/source/lao_2008_rapid.kps
+++ b/release/l/lao_2008_rapid/source/lao_2008_rapid.kps
@@ -110,4 +110,7 @@ automatically inserts (hidden) break characters at syllable boundaries.</Descrip
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="lao 2008" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/m/malar_malayalam_inscript/source/malar_malayalam_inscript.kps
+++ b/release/m/malar_malayalam_inscript/source/malar_malayalam_inscript.kps
@@ -128,4 +128,7 @@ characters encoded as per the Unicode Standard, Version 14.0.
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="malayalam_kab" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/m/mozhi_malayalam/source/mozhi_malayalam.kps
+++ b/release/m/mozhi_malayalam/source/mozhi_malayalam.kps
@@ -104,4 +104,10 @@ information.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="mozhi" Relationship="deprecates" />
+    <RelatedPackage ID="mozhi_1_1_0" Relationship="deprecates" />
+    <RelatedPackage ID="mozhi_5_1" Relationship="deprecates" />
+    <RelatedPackage ID="mozhi51" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/m/multi_pak_phonetic/source/multi_pak_phonetic.kps
+++ b/release/m/multi_pak_phonetic/source/multi_pak_phonetic.kps
@@ -129,4 +129,7 @@ Kashmiri, Memoni, Panjabi, Pashto, Seraiki, Sindhi and Urdu.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="multi pak" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/n/ntl_onekey/source/ntl_onekey.kps
+++ b/release/n/ntl_onekey/source/ntl_onekey.kps
@@ -104,4 +104,7 @@ in Xishuangbanna Prefecture in Yunnan, China.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ndailu keyman keyboard" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/nlci/nlci_ipa/source/nlci_ipa.kps
+++ b/release/nlci/nlci_ipa/source/nlci_ipa.kps
@@ -71,4 +71,7 @@ of occurance, yet tried to follow a phonetic based keyboarding system.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sil_ipa" />
+  </RelatedPackages>
 </Package>

--- a/release/o/osage_nation_new/source/osage_nation_new.kps
+++ b/release/o/osage_nation_new/source/osage_nation_new.kps
@@ -96,4 +96,7 @@ carried since the last Osage keyboard was developed.)</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="osage_nation" />
+  </RelatedPackages>
 </Package>

--- a/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
@@ -106,4 +106,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiebiblescriptmnemonic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
+++ b/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
@@ -118,4 +118,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="galaxiegreekandhebrew" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/packages/gff_amh_powerpack_7/source/gff_amh_powerpack_7.kps
+++ b/release/packages/gff_amh_powerpack_7/source/gff_amh_powerpack_7.kps
@@ -245,4 +245,7 @@ Keyboards](http://keyboards.ethiopic.org/specification/)</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="gff-amh-powerpack-7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/packages/syriac_aramaic/source/syriac_aramaic.kps
+++ b/release/packages/syriac_aramaic/source/syriac_aramaic.kps
@@ -434,4 +434,7 @@ Mardutho: The Syriac Institute](http://www.BethMardutho.org/).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="aramaic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/packages/vm_tamil/source/vm_tamil.kps
+++ b/release/packages/vm_tamil/source/vm_tamil.kps
@@ -128,4 +128,7 @@ layout input for Tamil Unicode.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tamil - visual media" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/r/rawang/source/rawang.kps
+++ b/release/r/rawang/source/rawang.kps
@@ -90,4 +90,8 @@ The keyboard is designed to be used with a standard (QWERTY) keyboard.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="rawangu" Relationship="deprecates" />
+    <RelatedPackage ID="rawangu7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/rac/rac_kashmir_shina/source/rac_kashmir_shina.kps
+++ b/release/rac/rac_kashmir_shina/source/rac_kashmir_shina.kps
@@ -143,4 +143,7 @@ encoded in Unicode.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="rac_shina" />
+  </RelatedPackages>
 </Package>

--- a/release/rac/rac_khowar/source/rac_khowar.kps
+++ b/release/rac/rac_khowar/source/rac_khowar.kps
@@ -123,4 +123,7 @@ the Khowar language.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="khowar" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/s/sabdalipi_assamese/source/sabdalipi_assamese.kps
+++ b/release/s/sabdalipi_assamese/source/sabdalipi_assamese.kps
@@ -100,4 +100,8 @@ letters of the English keyboard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sabdalipiunicode" Relationship="deprecates" />
+    <RelatedPackage ID="sabdalipi assamese" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/s/syriac_arabic/source/syriac_arabic.kps
+++ b/release/s/syriac_arabic/source/syriac_arabic.kps
@@ -322,4 +322,7 @@ Mardutho: The Syriac Institute](http://www.BethMardutho.org/).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="aramaic" />
+  </RelatedPackages>
 </Package>

--- a/release/s/syriac_phonetic/source/syriac_phonetic.kps
+++ b/release/s/syriac_phonetic/source/syriac_phonetic.kps
@@ -321,4 +321,7 @@ Mardutho: The Syriac Institute](http://www.BethMardutho.org/).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="aramaic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_arabic_phonetic/source/sil_arabic_phonetic.kps
+++ b/release/sil/sil_arabic_phonetic/source/sil_arabic_phonetic.kps
@@ -108,4 +108,7 @@ using a standard English keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="phoneticarabic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_bengali_phonetic/source/sil_bengali_phonetic.kps
+++ b/release/sil/sil_bengali_phonetic/source/sil_bengali_phonetic.kps
@@ -85,4 +85,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="benasm" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_buang/source/sil_buang.kps
+++ b/release/sil/sil_buang/source/sil_buang.kps
@@ -62,4 +62,7 @@ Doulos SIL or Charis SIL fonts.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="buang" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_busa/source/sil_busa.kps
+++ b/release/sil/sil_busa/source/sil_busa.kps
@@ -150,4 +150,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="busau" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kps
+++ b/release/sil/sil_cameroon_azerty/source/sil_cameroon_azerty.kps
@@ -449,4 +449,7 @@ an AZERTY (French) Keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="cameroon azerty unicode" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_cameroon_qwerty/source/sil_cameroon_qwerty.kps
+++ b/release/sil/sil_cameroon_qwerty/source/sil_cameroon_qwerty.kps
@@ -462,4 +462,7 @@ Languages for a QWERTY (US Keyboard)</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="cameroonqwertyunicode50" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_cherokee_nation/source/sil_cherokee_nation.kps
+++ b/release/sil/sil_cherokee_nation/source/sil_cherokee_nation.kps
@@ -111,4 +111,7 @@ layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="cherokee_nation" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_cheyenne/source/sil_cheyenne.kps
+++ b/release/sil/sil_cheyenne/source/sil_cheyenne.kps
@@ -160,4 +160,7 @@ used in the Cheyenne alphabet.
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="chey-unicode" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_dzongkha/source/sil_dzongkha.kps
+++ b/release/sil/sil_dzongkha/source/sil_dzongkha.kps
@@ -76,4 +76,7 @@ Development Authority of the Government of Bhutan.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="dzongkha" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_eastern_congo/source/sil_eastern_congo.kps
+++ b/release/sil/sil_eastern_congo/source/sil_eastern_congo.kps
@@ -234,4 +234,7 @@ Congo.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ecgunicode" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_ethiopic/source/sil_ethiopic.kps
+++ b/release/sil/sil_ethiopic/source/sil_ethiopic.kps
@@ -92,4 +92,7 @@ scripts.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="silethiopicv1.3k7" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_euro_latin/source/sil_euro_latin.kps
+++ b/release/sil/sil_euro_latin/source/sil_euro_latin.kps
@@ -538,4 +538,8 @@ The EuroLatin keyboard is ideal for:
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="european" Relationship="deprecates" />
+    <RelatedPackage ID="european2" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.kps
+++ b/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.kps
@@ -86,4 +86,7 @@ characters.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="grkpolycompv103" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_hawaiian/source/sil_hawaiian.kps
+++ b/release/sil/sil_hawaiian/source/sil_hawaiian.kps
@@ -139,4 +139,7 @@ with permission from Hale Kuamo\'o.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hi-keyboard" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_hebr_grek_trans/source/sil_hebr_grek_trans.kps
+++ b/release/sil/sil_hebr_grek_trans/source/sil_hebr_grek_trans.kps
@@ -93,4 +93,7 @@ Unicode Windows fonts.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="hebgrktransuni" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_hebrew/source/sil_hebrew.kps
+++ b/release/sil/sil_hebrew/source/sil_hebrew.kps
@@ -135,4 +135,7 @@ official Biblical Hebrew keyboard from SIL.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ezrasil251" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_hebrew_legacy/source/sil_hebrew_legacy.kps
+++ b/release/sil/sil_hebrew_legacy/source/sil_hebrew_legacy.kps
@@ -136,4 +136,7 @@ Hebrew (SIL) keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sil_hebrew" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_indic_roman/source/sil_indic_roman.kps
+++ b/release/sil/sil_indic_roman/source/sil_indic_roman.kps
@@ -118,4 +118,7 @@ accents or diacritics.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="indic roman transliteration" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_ipa/source/sil_ipa.kps
+++ b/release/sil/sil_ipa/source/sil_ipa.kps
@@ -126,4 +126,9 @@ as sequences of an appropriate key.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ipauni11" Relationship="deprecates" />
+    <RelatedPackage ID="ipauni111" Relationship="deprecates" />
+    <RelatedPackage ID="ipa93_km5" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_kmhmu/source/sil_kmhmu.kps
+++ b/release/sil/sil_kmhmu/source/sil_kmhmu.kps
@@ -128,4 +128,8 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="kmhmu" Relationship="deprecates" />
+    <RelatedPackage ID="kmhmu_2008" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_korda_jamo/source/sil_korda_jamo.kps
+++ b/release/sil/sil_korda_jamo/source/sil_korda_jamo.kps
@@ -94,4 +94,8 @@ Latin-Korean transliteration easy, accurate, and computerizable.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="korda" Relationship="deprecates" />
+    <RelatedPackage ID="sil_korda_latin" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_korda_latin/source/sil_korda_latin.kps
+++ b/release/sil/sil_korda_latin/source/sil_korda_latin.kps
@@ -94,4 +94,8 @@ Latin-Korean transliteration easy, accurate, and computerizable.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="korda" Relationship="deprecates" />
+    <RelatedPackage ID="sil_korda_jamo" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_korean_morse/source/sil_korean_morse.kps
+++ b/release/sil/sil_korean_morse/source/sil_korean_morse.kps
@@ -94,4 +94,7 @@ Korean pronunciation, use the Korean KORDA keyboards.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="korean_morse" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_mali_azerty/source/sil_mali_azerty.kps
+++ b/release/sil/sil_mali_azerty/source/sil_mali_azerty.kps
@@ -160,4 +160,7 @@ keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="maliazerty" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_mali_qwerty/source/sil_mali_qwerty.kps
+++ b/release/sil/sil_mali_qwerty/source/sil_mali_qwerty.kps
@@ -186,4 +186,7 @@ of the \_Other Important Symbols\_ are supported.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="maliqwerty" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_mali_qwertz/source/sil_mali_qwertz.kps
+++ b/release/sil/sil_mali_qwertz/source/sil_mali_qwertz.kps
@@ -162,4 +162,7 @@ correctement sur le clavier d'un ordinateur français !</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="malideutsch" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_moore/source/sil_moore.kps
+++ b/release/sil/sil_moore/source/sil_moore.kps
@@ -136,4 +136,7 @@ on the French keyboard as used in Burkina Faso.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="moore" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_myanmar_my3/source/sil_myanmar_my3.kps
+++ b/release/sil/sil_myanmar_my3/source/sil_myanmar_my3.kps
@@ -165,4 +165,8 @@ keyboard layout originally developed by Myanmar NLP on MSKLC software.</Descript
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="myanmar" Relationship="deprecates" />
+    <RelatedPackage ID="burmese02" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kps
+++ b/release/sil/sil_myanmar_mywinext/source/sil_myanmar_mywinext.kps
@@ -118,4 +118,7 @@ as a result.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="myanmar" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_nigeria_dot/source/sil_nigeria_dot.kps
+++ b/release/sil/sil_nigeria_dot/source/sil_nigeria_dot.kps
@@ -94,4 +94,7 @@ nasality, tone, and the Naira sign.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nigeria unicode dots" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_nigeria_odd_vowels/source/sil_nigeria_odd_vowels.kps
+++ b/release/sil/sil_nigeria_odd_vowels/source/sil_nigeria_odd_vowels.kps
@@ -94,4 +94,7 @@ nasality, tone, and the Naira sign.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nigeria unicode odd vowels" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_nigeria_underline/source/sil_nigeria_underline.kps
+++ b/release/sil/sil_nigeria_underline/source/sil_nigeria_underline.kps
@@ -91,4 +91,7 @@ nasality, tone, and the Naira sign.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="nigeria unicode underline" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_pan_africa_mnemonic/source/sil_pan_africa_mnemonic.kps
+++ b/release/sil/sil_pan_africa_mnemonic/source/sil_pan_africa_mnemonic.kps
@@ -112,4 +112,7 @@ for this particular layout.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="africadeadkey" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_pan_africa_positional/source/sil_pan_africa_positional.kps
+++ b/release/sil/sil_pan_africa_positional/source/sil_pan_africa_positional.kps
@@ -115,4 +115,7 @@ cases, use the alternate keystroke (in this case \'\[O\' ).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="africaus" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_tchad/source/sil_tchad.kps
+++ b/release/sil/sil_tchad/source/sil_tchad.kps
@@ -248,4 +248,7 @@ Chadian National Alphabet.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tchadunicode_with_charis_fonts" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_tepehuan/source/sil_tepehuan.kps
+++ b/release/sil/sil_tepehuan/source/sil_tepehuan.kps
@@ -113,4 +113,8 @@ includes the Unicode code points for glottal stops U+A78B and U+A78C.</Descripti
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="spantepu" Relationship="deprecates" />
+    <RelatedPackage ID="mextep" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_tunisian/source/sil_tunisian.kps
+++ b/release/sil/sil_tunisian/source/sil_tunisian.kps
@@ -91,4 +91,7 @@ description.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tunisianspokenarabic" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_uganda_tanzania/source/sil_uganda_tanzania.kps
+++ b/release/sil/sil_uganda_tanzania/source/sil_uganda_tanzania.kps
@@ -188,4 +188,7 @@ and Tanzania.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="utb unicode" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_vai/source/sil_vai.kps
+++ b/release/sil/sil_vai/source/sil_vai.kps
@@ -62,4 +62,7 @@ keyboard (U+A610..U+A62B).</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="silvaiunicodekmn" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_yi/source/sil_yi.kps
+++ b/release/sil/sil_yi/source/sil_yi.kps
@@ -104,4 +104,7 @@ characters and basic full-width punctuation.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yi" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_yoruba8/source/sil_yoruba8.kps
+++ b/release/sil/sil_yoruba8/source/sil_yoruba8.kps
@@ -95,4 +95,7 @@ letters ẹ, ọ and ṣ.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yoruba8" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_yoruba_bar/source/sil_yoruba_bar.kps
+++ b/release/sil/sil_yoruba_bar/source/sil_yoruba_bar.kps
@@ -99,4 +99,7 @@ using the traditional bar under the letters e̩, o̩, and s̩.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yorubabar" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_yoruba_dot/source/sil_yoruba_dot.kps
+++ b/release/sil/sil_yoruba_dot/source/sil_yoruba_dot.kps
@@ -109,4 +109,7 @@ using the modern dot under the letters ẹ, ọ, and ṣ.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yorubadot" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/sil/sil_yupik_cyrillic_ru/source/sil_yupik_cyrillic_ru.kps
+++ b/release/sil/sil_yupik_cyrillic_ru/source/sil_yupik_cyrillic_ru.kps
@@ -240,4 +240,7 @@
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="sil_yupik_cyrillic" />
+  </RelatedPackages>
 </Package>

--- a/release/t/thamizha_anjal_paangu/source/thamizha_anjal_paangu.kps
+++ b/release/t/thamizha_anjal_paangu/source/thamizha_anjal_paangu.kps
@@ -200,4 +200,8 @@ normal QWERTY (English) keyboard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ekwunitamil" Relationship="deprecates" />
+    <RelatedPackage ID="thamizha anjal" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/thamizha_bamini/source/thamizha_bamini.kps
+++ b/release/t/thamizha_bamini/source/thamizha_bamini.kps
@@ -116,4 +116,8 @@ use with a normal QWERTY (English) keyboard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ekwbamuni" Relationship="deprecates" />
+    <RelatedPackage ID="thamizha bamini" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/thamizha_new_typewriter/source/thamizha_new_typewriter.kps
+++ b/release/t/thamizha_new_typewriter/source/thamizha_new_typewriter.kps
@@ -111,4 +111,8 @@ use with a normal QWERTY (English) keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ekwnewtwuni" Relationship="deprecates" />
+    <RelatedPackage ID="thamizha typewriter" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/thamizha_tamil99_ext/source/thamizha_tamil99_ext.kps
+++ b/release/t/thamizha_tamil99_ext/source/thamizha_tamil99_ext.kps
@@ -198,4 +198,7 @@ with a normal QWERTY (English) keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="ekwtamil99uniext" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/tibetan_direct_input/source/tibetan_direct_input.kps
+++ b/release/t/tibetan_direct_input/source/tibetan_direct_input.kps
@@ -150,4 +150,9 @@ layout.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tibetan_unicode_direct_input" Relationship="deprecates" />
+    <RelatedPackage ID="tibetan_direct_unicode" Relationship="deprecates" />
+    <RelatedPackage ID="tibetan unicode direct input" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/tibetan_ewts/source/tibetan_ewts.kps
+++ b/release/t/tibetan_ewts/source/tibetan_ewts.kps
@@ -153,4 +153,9 @@ menus for Tibetan symbols.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tibetan_ewts_to_unicode" Relationship="deprecates" />
+    <RelatedPackage ID="tibetan_unicode_ewts" Relationship="deprecates" />
+    <RelatedPackage ID="tibetan unicode ewts" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/t/turkmen_cyrl/source/turkmen_cyrl.kps
+++ b/release/t/turkmen_cyrl/source/turkmen_cyrl.kps
@@ -85,4 +85,8 @@ words.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="tkmcaus3" Relationship="deprecates" />
+    <RelatedPackage ID="turkmen" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/u/urdu_phonetic/source/urdu_phonetic.kps
+++ b/release/u/urdu_phonetic/source/urdu_phonetic.kps
@@ -115,4 +115,7 @@ font Pak Nastaleeq optimised for use with Urdu.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="urdu ph - package" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/v/venetia_et_histria/source/venetia_et_histria.kps
+++ b/release/v/venetia_et_histria/source/venetia_et_histria.kps
@@ -98,4 +98,7 @@ input of all the necessary Latin characters.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="venetian" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/v/vietnamese_telex/source/vietnamese_telex.kps
+++ b/release/v/vietnamese_telex/source/vietnamese_telex.kps
@@ -157,4 +157,7 @@ Vietnam as part of TCVN 5712.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="vietnamese_telex_legacy" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/v/vm_tamil_modular/source/vm_tamil_modular.kps
+++ b/release/v/vm_tamil_modular/source/vm_tamil_modular.kps
@@ -96,4 +96,7 @@ is intended for use with a normal QWERTY (English) keyboard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="visual_media_tamil_modular" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/v/vm_tamil_typewriter/source/vm_tamil_typewriter.kps
+++ b/release/v/vm_tamil_typewriter/source/vm_tamil_typewriter.kps
@@ -96,4 +96,7 @@ a normal QWERTY (English) keyboard.</Description>
   </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="visual_media_tamil_typewriter" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>

--- a/release/y/yiddish_pasekh/source/yiddish_pasekh.kps
+++ b/release/y/yiddish_pasekh/source/yiddish_pasekh.kps
@@ -86,4 +86,7 @@ This keyboard layout works best with a QWERTY (English) keyboard.</Description>
     </Keyboard>
   </Keyboards>
   <Strings/>
+  <RelatedPackages>
+    <RelatedPackage ID="yidish2k" Relationship="deprecates" />
+  </RelatedPackages>
 </Package>


### PR DESCRIPTION
Based on a generated report:
[related.txt](https://github.com/keymanapp/keyboards/files/13019192/related.txt)
