### PR TITLE
chore: remove legacy fonts from .keyboard_info

### DIFF
--- a/legacy/b/burmese02/burmese02.keyboard_info
+++ b/legacy/b/burmese02/burmese02.keyboard_info
@@ -14,16 +14,13 @@
       "font": {
         "family": "MyanmarWeb",
         "source": [
-          "Padauk.ttf",
-          "PADAUK0.eot",
-          "Padauk.mobileconfig"
+          "Padauk.ttf"
         ]
       },
       "oskFont": {
         "family": "MyanmarWebOsk",
         "source": [
-          "Padauk.ttf",
-          "Padauk.svg#PadaukRegular"
+          "Padauk.ttf"
         ]
       },
       "example": {

--- a/legacy/c/cherokee_nation/cherokee_nation.keyboard_info
+++ b/legacy/c/cherokee_nation/cherokee_nation.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "cherokee_web_osk",
         "source": [
-          "digohweli_1_7.ttf",
-          "digohweli_1_7.svg#Digohweli"
+          "digohweli_1_7.ttf"
         ]
       }
     }

--- a/legacy/d/dinkaweb11/dinkaweb11.keyboard_info
+++ b/legacy/d/dinkaweb11/dinkaweb11.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {

--- a/legacy/d/divehi_phon/divehi_phon.keyboard_info
+++ b/legacy/d/divehi_phon/divehi_phon.keyboard_info
@@ -21,8 +21,7 @@
       "oskFont": {
         "family": "DivehiWebOSK",
         "source": [
-          "NotoSansThaana-Regular.ttf",
-          "NotoSansThaana-Regular-Add.svg#NotoSansThaana"
+          "NotoSansThaana-Regular.ttf"
         ]
       }
     }

--- a/legacy/d/divehi_type/divehi_type.keyboard_info
+++ b/legacy/d/divehi_type/divehi_type.keyboard_info
@@ -14,15 +14,13 @@
       "font": {
         "family": "DivehiWeb",
         "source": [
-          "NotoSansThaana-Regular.mobileconfig",
           "NotoSansThaana-Regular.ttf"
         ]
       },
       "oskFont": {
         "family": "DivehiWebOSK",
         "source": [
-          "NotoSansThaana-Regular.ttf",
-          "NotoSansThaana-Regular-Add.svg#NotoSansThaana"
+          "NotoSansThaana-Regular.ttf"
         ]
       }
     }

--- a/legacy/e/ekwbamuni/ekwbamuni.keyboard_info
+++ b/legacy/e/ekwbamuni/ekwbamuni.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/legacy/e/ekwnewtwuni/ekwnewtwuni.keyboard_info
+++ b/legacy/e/ekwnewtwuni/ekwnewtwuni.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       }
     }

--- a/legacy/e/ekwtamil99uniext/ekwtamil99uniext.keyboard_info
+++ b/legacy/e/ekwtamil99uniext/ekwtamil99uniext.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       }
     }

--- a/legacy/e/ekwunitamil/ekwunitamil.keyboard_info
+++ b/legacy/e/ekwunitamil/ekwunitamil.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/legacy/e/european2/european2.keyboard_info
+++ b/legacy/e/european2/european2.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +22,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +30,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +38,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +46,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +54,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +62,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -77,8 +70,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -86,8 +78,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -95,8 +86,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -104,8 +94,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -113,8 +102,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -122,8 +110,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -131,8 +118,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -140,8 +126,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -149,8 +134,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -158,8 +142,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -167,8 +150,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -176,8 +158,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -185,8 +166,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -194,8 +174,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -203,8 +182,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -212,8 +190,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -221,8 +198,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -230,8 +206,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -239,8 +214,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -248,8 +222,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -257,8 +230,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -266,8 +238,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -275,8 +246,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -284,8 +254,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -293,8 +262,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -302,8 +270,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -311,8 +278,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -320,8 +286,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -329,8 +294,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -338,8 +302,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -347,8 +310,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -356,8 +318,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -365,8 +326,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -374,8 +334,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -383,8 +342,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -392,8 +350,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -401,8 +358,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -410,8 +366,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -419,8 +374,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -428,8 +382,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -437,8 +390,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -446,8 +398,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -455,8 +406,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -464,8 +414,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -473,8 +422,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -482,8 +430,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -491,8 +438,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -500,8 +446,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -509,8 +454,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -518,8 +462,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -527,8 +470,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -536,8 +478,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -545,8 +486,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -554,8 +494,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -563,8 +502,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -572,8 +510,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -581,8 +518,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -590,8 +526,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -599,8 +534,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -608,8 +542,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -617,8 +550,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -626,8 +558,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -635,8 +566,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -644,8 +574,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -653,8 +582,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -662,8 +590,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -671,8 +598,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -680,8 +606,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -689,8 +614,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -698,8 +622,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -707,8 +630,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -716,8 +638,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -725,8 +646,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -734,8 +654,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -743,8 +662,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -752,8 +670,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -761,8 +678,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -770,8 +686,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -779,8 +694,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -788,8 +702,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -797,8 +710,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -806,8 +718,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -815,8 +726,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -824,8 +734,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -833,8 +742,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -842,8 +750,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -851,8 +758,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -860,8 +766,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -869,8 +774,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -878,8 +782,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -887,8 +790,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -896,8 +798,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -905,8 +806,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -914,8 +814,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -923,8 +822,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -932,8 +830,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -941,8 +838,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -950,8 +846,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -959,8 +854,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -968,8 +862,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -977,8 +870,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -986,8 +878,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -995,8 +886,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1004,8 +894,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1013,8 +902,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1022,8 +910,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1031,8 +918,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1040,8 +926,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1049,8 +934,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1058,8 +942,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1067,8 +950,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1076,8 +958,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1085,8 +966,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1094,8 +974,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1103,8 +982,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1112,8 +990,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1121,8 +998,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1130,8 +1006,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1139,8 +1014,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1148,8 +1022,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1157,8 +1030,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1166,8 +1038,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1175,8 +1046,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1184,8 +1054,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_awn_7/gff_awn_7.keyboard_info
+++ b/legacy/gff/gff_awn_7/gff_awn_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_bcq_7/gff_bcq_7.keyboard_info
+++ b/legacy/gff/gff_bcq_7/gff_bcq_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_byn_7/gff_byn_7.keyboard_info
+++ b/legacy/gff/gff_byn_7/gff_byn_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       },
       "example": {

--- a/legacy/gff/gff_gez_7/gff_gez_7.keyboard_info
+++ b/legacy/gff/gff_gez_7/gff_gez_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_mym_7/gff_mym_7.keyboard_info
+++ b/legacy/gff/gff_mym_7/gff_mym_7.keyboard_info
@@ -15,9 +15,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     },
@@ -25,9 +23,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     },
@@ -35,9 +31,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     },
@@ -45,9 +39,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_sgw_7/gff_sgw_7.keyboard_info
+++ b/legacy/gff/gff_sgw_7/gff_sgw_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/gff/gff_tir_er_7/gff_tir_er_7.keyboard_info
+++ b/legacy/gff/gff_tir_er_7/gff_tir_er_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       },
       "example": {

--- a/legacy/gff/gff_tir_et_7/gff_tir_et_7.keyboard_info
+++ b/legacy/gff/gff_tir_et_7/gff_tir_et_7.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       },
       "example": {

--- a/legacy/m/malayalam/malayalam.keyboard_info
+++ b/legacy/m/malayalam/malayalam.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "MalayalamWebOsk",
         "source": [
-          "AnjaliNewLipi.ttf",
-          "AnjaliNewLipi-webfont.svg#anjalinewlipiregular"
+          "AnjaliNewLipi.ttf"
         ]
       },
       "example": {

--- a/legacy/m/malayalam_kab/malayalam_kab.keyboard_info
+++ b/legacy/m/malayalam_kab/malayalam_kab.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "MalayalamWebOsk",
         "source": [
-          "AnjaliNewLipi.ttf",
-          "AnjaliNewLipi-webfont.svg#anjalinewlipiregular"
+          "AnjaliNewLipi.ttf"
         ]
       }
     }

--- a/legacy/m/mozhi_1_1_0/mozhi_1_1_0.keyboard_info
+++ b/legacy/m/mozhi_1_1_0/mozhi_1_1_0.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "MalayalamWebOsk",
         "source": [
-          "AnjaliNewLipi.ttf",
-          "AnjaliNewLipi-webfont.svg#anjalinewlipiregular"
+          "AnjaliNewLipi.ttf"
         ]
       },
       "example": {

--- a/legacy/m/mozhi_5_1/mozhi_5_1.keyboard_info
+++ b/legacy/m/mozhi_5_1/mozhi_5_1.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "MalayalamWebOsk",
         "source": [
-          "AnjaliNewLipi.ttf",
-          "AnjaliNewLipi-webfont.svg#anjalinewlipiregular"
+          "AnjaliNewLipi.ttf"
         ]
       }
     }

--- a/legacy/n/naijanfd10/naijanfd10.keyboard_info
+++ b/legacy/n/naijanfd10/naijanfd10.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +22,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +30,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +38,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +46,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +54,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +62,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -77,8 +70,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -86,8 +78,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -95,8 +86,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -104,8 +94,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -113,8 +102,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -122,8 +110,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -131,8 +118,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -140,8 +126,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -149,8 +134,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -158,8 +142,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -167,8 +150,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -176,8 +158,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -185,8 +166,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -194,8 +174,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -203,8 +182,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -212,8 +190,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -221,8 +198,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -230,8 +206,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -239,8 +214,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -248,8 +222,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -257,8 +230,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -266,8 +238,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -275,8 +246,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -284,8 +254,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -293,8 +262,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -302,8 +270,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -311,8 +278,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -320,8 +286,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -329,8 +294,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -338,8 +302,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -347,8 +310,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -356,8 +318,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -365,8 +326,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -374,8 +334,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -383,8 +342,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -392,8 +350,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -401,8 +358,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -410,8 +366,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -419,8 +374,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -428,8 +382,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -437,8 +390,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -446,8 +398,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -455,8 +406,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -464,8 +414,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -473,8 +422,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/legacy/p/pasifika20/pasifika20.keyboard_info
+++ b/legacy/p/pasifika20/pasifika20.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +22,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +30,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +38,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +46,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +54,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +62,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/legacy/p/ps32/ps32.keyboard_info
+++ b/legacy/p/ps32/ps32.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/legacy/s/serbian_latin/serbian_latin.keyboard_info
+++ b/legacy/s/serbian_latin/serbian_latin.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/legacy/s/syriac/syriac.keyboard_info
+++ b/legacy/s/syriac/syriac.keyboard_info
@@ -15,16 +15,14 @@
         "family": "SyriacWeb",
         "size": "12",
         "source": [
-          "NotoSansSyriacEastern-Regular.ttf",
-          "NotoSansSyriacEastern-Regular.mobileconfig"
+          "NotoSansSyriacEastern-Regular.ttf"
         ]
       },
       "oskFont": {
         "family": "SyriacWebOsk",
         "size": "12",
         "source": [
-          "NotoSansSyriacEastern-Regular.ttf",
-          "NotoSansSyriacWestern-Regular.svg#NotoSansSyriacWestern"
+          "NotoSansSyriacEastern-Regular.ttf"
         ]
       },
       "example": {

--- a/legacy/s/syriac_phon/syriac_phon.keyboard_info
+++ b/legacy/s/syriac_phon/syriac_phon.keyboard_info
@@ -15,16 +15,14 @@
         "family": "SyriacWeb",
         "size": "12",
         "source": [
-          "NotoSansSyriacEastern-Regular.ttf",
-          "NotoSansSyriacEastern-Regular.mobileconfig"
+          "NotoSansSyriacEastern-Regular.ttf"
         ]
       },
       "oskFont": {
         "family": "SyriacWebOsk",
         "size": "12",
         "source": [
-          "NotoSansSyriacEastern-Regular.ttf",
-          "NotoSansSyriacWestern-Regular.svg#NotoSansSyriacWestern"
+          "NotoSansSyriacEastern-Regular.ttf"
         ]
       },
       "example": {

--- a/legacy/t/tamil99m/tamil99m.keyboard_info
+++ b/legacy/t/tamil99m/tamil99m.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       }
     }

--- a/legacy/t/tibetan_direct_unicode/tibetan_direct_unicode.keyboard_info
+++ b/legacy/t/tibetan_direct_unicode/tibetan_direct_unicode.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -36,8 +35,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {

--- a/legacy/t/tibetan_ewts_to_unicode/tibetan_ewts_to_unicode.keyboard_info
+++ b/legacy/t/tibetan_ewts_to_unicode/tibetan_ewts_to_unicode.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "TibetanWeb",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen.mobileconfig"
+          "DDC_Uchen.ttf"
         ]
       }
     }

--- a/legacy/t/tibetan_unicode_direct_input/tibetan_unicode_direct_input.keyboard_info
+++ b/legacy/t/tibetan_unicode_direct_input/tibetan_unicode_direct_input.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -31,8 +30,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -44,8 +42,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -57,8 +54,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -70,8 +66,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -83,8 +78,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -96,8 +90,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -109,8 +102,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -122,8 +114,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -135,8 +126,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -148,8 +138,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -161,8 +150,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -174,8 +162,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -187,8 +174,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -200,8 +186,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -213,8 +198,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -226,8 +210,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -239,8 +222,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -252,8 +234,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -265,8 +246,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -278,8 +258,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -291,8 +270,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -304,8 +282,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -317,8 +294,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -330,8 +306,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -348,8 +323,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -361,8 +335,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -374,8 +347,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -387,8 +359,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -400,8 +371,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     }

--- a/legacy/t/tibetan_unicode_ewts/tibetan_unicode_ewts.keyboard_info
+++ b/legacy/t/tibetan_unicode_ewts/tibetan_unicode_ewts.keyboard_info
@@ -18,8 +18,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -31,8 +30,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -44,8 +42,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -57,8 +54,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -70,8 +66,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -83,8 +78,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -96,8 +90,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -109,8 +102,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -122,8 +114,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -135,8 +126,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -148,8 +138,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -161,8 +150,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -174,8 +162,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -187,8 +174,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -200,8 +186,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -213,8 +198,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -226,8 +210,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -239,8 +222,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -252,8 +234,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -265,8 +246,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -278,8 +258,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -291,8 +270,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -304,8 +282,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -317,8 +294,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -330,8 +306,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -348,8 +323,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -361,8 +335,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -374,8 +347,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -387,8 +359,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -400,8 +371,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     }

--- a/legacy/t/tir_er_uni_ez/tir_er_uni_ez.keyboard_info
+++ b/legacy/t/tir_er_uni_ez/tir_er_uni_ez.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/t/tir_et_uni_ez/tir_et_uni_ez.keyboard_info
+++ b/legacy/t/tir_et_uni_ez/tir_et_uni_ez.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "GeezWeb",
         "source": [
-          "wookianos.ttf",
-          "ETHIOPI0.eot",
-          "wookianos.mobileconfig"
+          "wookianos.ttf"
         ]
       }
     }

--- a/legacy/v/visual_media_tamil_modular/visual_media_tamil_modular.keyboard_info
+++ b/legacy/v/visual_media_tamil_modular/visual_media_tamil_modular.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/legacy/v/visual_media_tamil_typewriter/visual_media_tamil_typewriter.keyboard_info
+++ b/legacy/v/visual_media_tamil_typewriter/visual_media_tamil_typewriter.keyboard_info
@@ -14,9 +14,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/legacy/y/yolngu21/yolngu21.keyboard_info
+++ b/legacy/y/yolngu21/yolngu21.keyboard_info
@@ -14,8 +14,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +22,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +30,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +38,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +46,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +54,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +62,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -77,8 +70,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -86,8 +78,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -95,8 +86,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -104,8 +94,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/release/e/ekwtamil99uni/ekwtamil99uni.keyboard_info
+++ b/release/e/ekwtamil99uni/ekwtamil99uni.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/release/el/el_dinka/el_dinka.keyboard_info
+++ b/release/el/el_dinka/el_dinka.keyboard_info
@@ -5,8 +5,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {
@@ -19,8 +18,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {
@@ -33,8 +31,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {
@@ -47,8 +44,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {
@@ -61,8 +57,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {
@@ -75,8 +70,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       },
       "example": {

--- a/release/el/el_naija/el_naija.keyboard_info
+++ b/release/el/el_naija/el_naija.keyboard_info
@@ -5,8 +5,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -14,8 +13,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +21,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +29,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +37,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +45,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +53,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +61,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -77,8 +69,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -86,8 +77,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -95,8 +85,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -104,8 +93,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -113,8 +101,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -122,8 +109,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -131,8 +117,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -140,8 +125,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -149,8 +133,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -158,8 +141,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -167,8 +149,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -176,8 +157,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -185,8 +165,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -194,8 +173,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -203,8 +181,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -212,8 +189,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -221,8 +197,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -230,8 +205,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -239,8 +213,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -248,8 +221,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -257,8 +229,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -266,8 +237,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -275,8 +245,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -284,8 +253,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -293,8 +261,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -302,8 +269,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -311,8 +277,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -320,8 +285,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -329,8 +293,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -338,8 +301,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -347,8 +309,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -356,8 +317,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -365,8 +325,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -374,8 +333,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -383,8 +341,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -392,8 +349,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -401,8 +357,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -410,8 +365,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -419,8 +373,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -428,8 +381,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -437,8 +389,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -446,8 +397,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -455,8 +405,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -464,8 +413,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/release/el/el_pan_sahelian/el_pan_sahelian.keyboard_info
+++ b/release/el/el_pan_sahelian/el_pan_sahelian.keyboard_info
@@ -5,8 +5,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/release/l/lao_2008_basic/lao_2008_basic.keyboard_info
+++ b/release/l/lao_2008_basic/lao_2008_basic.keyboard_info
@@ -5,8 +5,7 @@
       "font": {
         "family": "Saysettha_OT",
         "source": [
-          "saysettha_ot.ttf",
-          "saysettha_OT.mobileconfig"
+          "saysettha_ot.ttf"
         ]
       },
       "example": {

--- a/release/sil/sil_euro_latin/sil_euro_latin.keyboard_info
+++ b/release/sil/sil_euro_latin/sil_euro_latin.keyboard_info
@@ -5,8 +5,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -14,8 +13,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -23,8 +21,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -32,8 +29,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -41,8 +37,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -50,8 +45,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -59,8 +53,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -68,8 +61,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -77,8 +69,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -86,8 +77,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -95,8 +85,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -104,8 +93,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -113,8 +101,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -122,8 +109,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -131,8 +117,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -140,8 +125,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -149,8 +133,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -158,8 +141,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -167,8 +149,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -176,8 +157,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -185,8 +165,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -194,8 +173,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -203,8 +181,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -212,8 +189,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -221,8 +197,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -230,8 +205,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -239,8 +213,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -248,8 +221,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -257,8 +229,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -266,8 +237,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -275,8 +245,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -284,8 +253,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -293,8 +261,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -302,8 +269,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -311,8 +277,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -320,8 +285,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -329,8 +293,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -338,8 +301,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -347,8 +309,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -356,8 +317,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -365,8 +325,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -374,8 +333,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -383,8 +341,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -392,8 +349,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -401,8 +357,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -410,8 +365,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -419,8 +373,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -428,8 +381,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -437,8 +389,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -446,8 +397,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -455,8 +405,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -464,8 +413,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -473,8 +421,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -482,8 +429,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -491,8 +437,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -500,8 +445,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -509,8 +453,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -518,8 +461,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -527,8 +469,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -536,8 +477,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -545,8 +485,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -554,8 +493,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -563,8 +501,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -572,8 +509,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -581,8 +517,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -590,8 +525,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -599,8 +533,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -608,8 +541,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -617,8 +549,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -626,8 +557,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -635,8 +565,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -644,8 +573,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -653,8 +581,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -662,8 +589,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -671,8 +597,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -680,8 +605,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -689,8 +613,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -698,8 +621,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -707,8 +629,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -716,8 +637,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -725,8 +645,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -734,8 +653,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -743,8 +661,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -752,8 +669,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -761,8 +677,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -770,8 +685,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -779,8 +693,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -788,8 +701,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -797,8 +709,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -806,8 +717,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -815,8 +725,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -824,8 +733,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -833,8 +741,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -842,8 +749,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -851,8 +757,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -860,8 +765,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -869,8 +773,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -878,8 +781,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -887,8 +789,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -896,8 +797,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -905,8 +805,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -914,8 +813,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -923,8 +821,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -932,8 +829,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -941,8 +837,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -950,8 +845,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -959,8 +853,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -968,8 +861,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -977,8 +869,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -986,8 +877,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -995,8 +885,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1004,8 +893,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1013,8 +901,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1022,8 +909,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1031,8 +917,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1040,8 +925,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1049,8 +933,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1058,8 +941,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1067,8 +949,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1076,8 +957,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1085,8 +965,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1094,8 +973,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1103,8 +981,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1112,8 +989,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1121,8 +997,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1130,8 +1005,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1139,8 +1013,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1148,8 +1021,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1157,8 +1029,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1166,8 +1037,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1175,8 +1045,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1184,8 +1053,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1193,8 +1061,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1202,8 +1069,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1211,8 +1077,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1220,8 +1085,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1229,8 +1093,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1238,8 +1101,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1247,8 +1109,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1256,8 +1117,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1265,8 +1125,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1274,8 +1133,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1283,8 +1141,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1292,8 +1149,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1301,8 +1157,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1310,8 +1165,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1319,8 +1173,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1328,8 +1181,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1337,8 +1189,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1346,8 +1197,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1355,8 +1205,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1364,8 +1213,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1373,8 +1221,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1382,8 +1229,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1391,8 +1237,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1400,8 +1245,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1409,8 +1253,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1418,8 +1261,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1427,8 +1269,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1436,8 +1277,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1445,8 +1285,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1454,8 +1293,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1463,8 +1301,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1472,8 +1309,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1481,8 +1317,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1490,8 +1325,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1499,8 +1333,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1508,8 +1341,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1517,8 +1349,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1526,8 +1357,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1535,8 +1365,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1544,8 +1373,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1553,8 +1381,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1562,8 +1389,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1571,8 +1397,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1580,8 +1405,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1589,8 +1413,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1598,8 +1421,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1607,8 +1429,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1616,8 +1437,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1625,8 +1445,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1634,8 +1453,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1643,8 +1461,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1652,8 +1469,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1661,8 +1477,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1670,8 +1485,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1679,8 +1493,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1688,8 +1501,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1697,8 +1509,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1706,8 +1517,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1715,8 +1525,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1724,8 +1533,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1733,8 +1541,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1742,8 +1549,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1751,8 +1557,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1760,8 +1565,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1769,8 +1573,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1778,8 +1581,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1787,8 +1589,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1796,8 +1597,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1805,8 +1605,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1814,8 +1613,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1823,8 +1621,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1832,8 +1629,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1841,8 +1637,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1850,8 +1645,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1859,8 +1653,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1868,8 +1661,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1877,8 +1669,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1886,8 +1677,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1895,8 +1685,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1904,8 +1693,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1913,8 +1701,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1922,8 +1709,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1931,8 +1717,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1940,8 +1725,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1949,8 +1733,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1958,8 +1741,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1967,8 +1749,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1976,8 +1757,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1985,8 +1765,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -1994,8 +1773,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2003,8 +1781,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2012,8 +1789,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2021,8 +1797,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2030,8 +1805,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2039,8 +1813,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2048,8 +1821,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2057,8 +1829,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2066,8 +1837,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2075,8 +1845,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2084,8 +1853,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2093,8 +1861,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2102,8 +1869,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2111,8 +1877,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2120,8 +1885,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2129,8 +1893,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2138,8 +1901,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2147,8 +1909,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2156,8 +1917,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2165,8 +1925,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2174,8 +1933,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2183,8 +1941,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2192,8 +1949,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2201,8 +1957,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2210,8 +1965,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2219,8 +1973,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2228,8 +1981,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2237,8 +1989,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2246,8 +1997,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2255,8 +2005,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2264,8 +2013,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2273,8 +2021,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2282,8 +2029,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2291,8 +2037,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2300,8 +2045,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2309,8 +2053,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2318,8 +2061,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2327,8 +2069,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2336,8 +2077,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2345,8 +2085,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2354,8 +2093,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2363,8 +2101,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2372,8 +2109,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2381,8 +2117,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2390,8 +2125,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2399,8 +2133,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2408,8 +2141,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2417,8 +2149,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2426,8 +2157,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2435,8 +2165,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2444,8 +2173,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2453,8 +2181,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2462,8 +2189,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2471,8 +2197,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2480,8 +2205,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2489,8 +2213,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2498,8 +2221,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2507,8 +2229,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2516,8 +2237,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2525,8 +2245,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2534,8 +2253,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2543,8 +2261,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2552,8 +2269,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2561,8 +2277,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2570,8 +2285,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2579,8 +2293,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2588,8 +2301,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2597,8 +2309,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2606,8 +2317,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2615,8 +2325,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2624,8 +2333,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2633,8 +2341,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2642,8 +2349,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2651,8 +2357,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2660,8 +2365,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2669,8 +2373,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2678,8 +2381,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2687,8 +2389,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2696,8 +2397,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2705,8 +2405,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2714,8 +2413,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2723,8 +2421,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2732,8 +2429,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2741,8 +2437,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2750,8 +2445,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2759,8 +2453,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2768,8 +2461,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2777,8 +2469,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2786,8 +2477,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2795,8 +2485,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2804,8 +2493,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2813,8 +2501,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2822,8 +2509,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2831,8 +2517,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2840,8 +2525,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2849,8 +2533,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2858,8 +2541,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2867,8 +2549,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2876,8 +2557,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2885,8 +2565,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2894,8 +2573,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2903,8 +2581,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2912,8 +2589,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2921,8 +2597,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2930,8 +2605,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2939,8 +2613,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2948,8 +2621,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2957,8 +2629,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2966,8 +2637,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2975,8 +2645,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2984,8 +2653,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -2993,8 +2661,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3002,8 +2669,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3011,8 +2677,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3020,8 +2685,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3029,8 +2693,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3038,8 +2701,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3047,8 +2709,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3056,8 +2717,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3065,8 +2725,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3074,8 +2733,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3083,8 +2741,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3092,8 +2749,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3101,8 +2757,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3110,8 +2765,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3119,8 +2773,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3128,8 +2781,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3137,8 +2789,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3146,8 +2797,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3155,8 +2805,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3164,8 +2813,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3173,8 +2821,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3182,8 +2829,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3191,8 +2837,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3200,8 +2845,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3209,8 +2853,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3218,8 +2861,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3227,8 +2869,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3236,8 +2877,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3245,8 +2885,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3254,8 +2893,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3263,8 +2901,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     },
@@ -3272,8 +2909,7 @@
       "font": {
         "family": "LatinWeb",
         "source": [
-          "DejaVuSans.ttf",
-          "DejaVuSans.mobileconfig"
+          "DejaVuSans.ttf"
         ]
       }
     }

--- a/release/t/thamizha_anjal_paangu/thamizha_anjal_paangu.keyboard_info
+++ b/release/t/thamizha_anjal_paangu/thamizha_anjal_paangu.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/release/t/thamizha_bamini/thamizha_bamini.keyboard_info
+++ b/release/t/thamizha_bamini/thamizha_bamini.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/release/t/thamizha_new_typewriter/thamizha_new_typewriter.keyboard_info
+++ b/release/t/thamizha_new_typewriter/thamizha_new_typewriter.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       }
     }

--- a/release/t/thamizha_tamil99_ext/thamizha_tamil99_ext.keyboard_info
+++ b/release/t/thamizha_tamil99_ext/thamizha_tamil99_ext.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       }
     }

--- a/release/t/tibetan_direct_input/tibetan_direct_input.keyboard_info
+++ b/release/t/tibetan_direct_input/tibetan_direct_input.keyboard_info
@@ -9,8 +9,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -27,8 +26,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -45,8 +43,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -58,8 +55,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -71,8 +67,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -84,8 +79,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -97,8 +91,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -110,8 +103,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -123,8 +115,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -136,8 +127,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -149,8 +139,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -162,8 +151,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -175,8 +163,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -188,8 +175,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -201,8 +187,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -214,8 +199,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -227,8 +211,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -240,8 +223,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -253,8 +235,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -266,8 +247,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -279,8 +259,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -292,8 +271,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -305,8 +283,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -318,8 +295,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -331,8 +307,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -344,8 +319,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -357,8 +331,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -370,8 +343,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -384,8 +356,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -397,8 +368,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     }

--- a/release/t/tibetan_ewts/tibetan_ewts.keyboard_info
+++ b/release/t/tibetan_ewts/tibetan_ewts.keyboard_info
@@ -9,8 +9,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -22,8 +21,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -35,8 +33,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -48,8 +45,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -61,8 +57,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -74,8 +69,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -87,8 +81,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -100,8 +93,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -113,8 +105,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -126,8 +117,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -139,8 +129,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -152,8 +141,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -165,8 +153,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -178,8 +165,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -191,8 +177,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -204,8 +189,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -217,8 +201,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -230,8 +213,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -243,8 +225,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -256,8 +237,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -269,8 +249,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -282,8 +261,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -295,8 +273,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -308,8 +285,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -321,8 +297,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       },
       "example": {
@@ -339,8 +314,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -352,8 +326,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -365,8 +338,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -378,8 +350,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -391,8 +362,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -404,8 +374,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -417,8 +386,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     },
@@ -430,8 +398,7 @@
       "oskFont": {
         "family": "TibetanWebOsk",
         "source": [
-          "DDC_Uchen.ttf",
-          "ddc_uchen-webfont.svg#ddc_uchenregular"
+          "DDC_Uchen.ttf"
         ]
       }
     }

--- a/release/v/vm_tamil_modular/vm_tamil_modular.keyboard_info
+++ b/release/v/vm_tamil_modular/vm_tamil_modular.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {

--- a/release/v/vm_tamil_typewriter/vm_tamil_typewriter.keyboard_info
+++ b/release/v/vm_tamil_typewriter/vm_tamil_typewriter.keyboard_info
@@ -5,9 +5,7 @@
       "font": {
         "family": "TamilWeb",
         "source": [
-          "aava1.ttf",
-          "AAVARAN0.eot",
-          "aava1.mobileconfig"
+          "aava1.ttf"
         ]
       },
       "example": {


### PR DESCRIPTION
Fixes #2346.

Removes .svg, .eot, and .mobileconfig font references from all .keyboard_info files. These three formats are no longer used by Keyman and we are phasing out all references.

Note that changes to release/ and experimental/ .keyboard_info files are technically ignored by latest .kmc, and these will be removed in an upcoming commit.