### PR TITLE
GFF Tigre Keyboard v1.0.2

### DIFF
--- a/release/gff/gff_tigre/HISTORY.md
+++ b/release/gff/gff_tigre/HISTORY.md
@@ -3,7 +3,7 @@ gff_tigre Change History
 
 1.0.2 (24 Oct 2023)
 -------------------
-* Remove "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf" 
+* Removed "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf" 
   fonts which have an unknown license.
 
 1.0.1 (27 Jun 2023)

--- a/release/gff/gff_tigre/HISTORY.md
+++ b/release/gff/gff_tigre/HISTORY.md
@@ -1,6 +1,11 @@
 gff_tigre Change History
 ========================
 
+1.0.2 (24 Oct 2023)
+-------------------
+* Remove "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf" 
+  fonts which have an unknown license.
+
 1.0.1 (27 Jun 2023)
 -------------------
 * Smart-dot and smart-comma composition fix.

--- a/release/gff/gff_tigre/README.md
+++ b/release/gff/gff_tigre/README.md
@@ -3,7 +3,7 @@
 
 Copyright © 2023 Geʾez Frontier Foundation
 
-Version 1.0.1
+Version 1.0.2
 
 This is a Tigre (tig, ትግሬ,ትግረ) language mnemonic input method that applies Eritrean writing conventions.
 It requires a font supporting Ethiopic script under the Unicode 3.0 standard. 

--- a/release/gff/gff_tigre/gff_tigre.kpj
+++ b/release/gff/gff_tigre/gff_tigre.kpj
@@ -12,7 +12,7 @@
       <ID>id_c3b4023b7acd753996e405f4842a4017</ID>
       <Filename>gff_tigre.kmn</Filename>
       <Filepath>source\gff_tigre.kmn</Filepath>
-      <FileVersion>1.0.1</FileVersion>
+      <FileVersion>1.0.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ትግሬ (Tigre)</Name>
@@ -83,22 +83,6 @@
       <ID>id_1cf609e3b924a25eaff15a4316006dd2</ID>
       <Filename>Brana-Regular.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\Brana-Regular.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_53bb4a9c6c63d36d8d8dbc8f25ca4c67</ParentFileID>
-    </File>
-    <File>
-      <ID>id_cbe96fda04eb77e2be4e01a4fbcec5cf</ID>
-      <Filename>EthiopicUnicodeItalic.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\geez\EthiopicUnicodeItalic.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_53bb4a9c6c63d36d8d8dbc8f25ca4c67</ParentFileID>
-    </File>
-    <File>
-      <ID>id_1b189c0d076b0a7576f7169c1ada6430</ID>
-      <Filename>EthiopicUnicodeNormal.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\geez\EthiopicUnicodeNormal.ttf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.ttf</FileType>
       <ParentFileID>id_53bb4a9c6c63d36d8d8dbc8f25ca4c67</ParentFileID>

--- a/release/gff/gff_tigre/source/gff_tigre.kmn
+++ b/release/gff/gff_tigre/source/gff_tigre.kmn
@@ -13,7 +13,7 @@ c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
 store(&VERSION) '15.0'
-store(&KEYBOARDVERSION) '1.0.1'
+store(&KEYBOARDVERSION) '1.0.2'
 store(&NAME) 'ትግሬ (Tigre)'
 store(&COPYRIGHT) '© 2023 Geʾez Frontier Foundation'
 store(&Message) 'This is a Tigre language mnemonic input method that applies Eritrean writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.'

--- a/release/gff/gff_tigre/source/gff_tigre.kps
+++ b/release/gff/gff_tigre/source/gff_tigre.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.141.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -94,18 +94,6 @@
     <File>
       <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
       <Description>Font Brana Regular</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\EthiopicUnicodeItalic.ttf</Name>
-      <Description>Font Ethiopic Unicode Italic</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\EthiopicUnicodeNormal.ttf</Name>
-      <Description>Font Ethiopic Unicode Normal</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.ttf</FileType>
     </File>
@@ -234,7 +222,7 @@
     <Keyboard>
       <Name>ትግሬ (Tigre)</Name>
       <ID>gff_tigre</ID>
-      <Version>1.0</Version>
+      <Version>1.0.2</Version>
       <OSKFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</DisplayFont>
       <Languages>


### PR DESCRIPTION
This update removes the "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf"  fonts which have an unknown license.  Aside from the version number, no other changes occur.