### PR TITLE
GFF Ethiopian Tigrinya Keyboard v2.0.3

### DIFF
--- a/release/gff/gff_tigrinya_ethiopia/HISTORY.md
+++ b/release/gff/gff_tigrinya_ethiopia/HISTORY.md
@@ -1,5 +1,10 @@
 # ትግርኛ-ኢትዮጵያ (Tigrinya Keyboard for Ethiopian Conventions) Change History
 
+2.0.3 (24 Oct 2023)
+-------------------
+* Removed "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf" 
+  fonts which have an unknown license.
+  
 2.0.2 (2023-06-20)
 ------------------
 * Fix for smart-dot and smart-comma composition.

--- a/release/gff/gff_tigrinya_ethiopia/README.md
+++ b/release/gff/gff_tigrinya_ethiopia/README.md
@@ -3,7 +3,7 @@
 
 Copyright © 2009-2023 Geʾez Frontier Foundation
 
-Version 2.0.2
+Version 2.0.3
 
 This is a Tigrinya (ti-ET, ትግርኛ-ኢትዮጵያ) language mnemonic input method that applies Ethiopian writing conventions.  It requires
 a font supporting Ethiopic script under the Unicode 3.0 standard.

--- a/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
+++ b/release/gff/gff_tigrinya_ethiopia/gff_tigrinya_ethiopia.kpj
@@ -12,7 +12,7 @@
       <ID>id_15b398ddd59c4ed96532bf79befbb12c</ID>
       <Filename>gff_tigrinya_ethiopia.kmn</Filename>
       <Filepath>source\gff_tigrinya_ethiopia.kmn</Filepath>
-      <FileVersion>2.0.2</FileVersion>
+      <FileVersion>2.0.3</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>ትግርኛ (Tigrinya)</Name>
@@ -119,22 +119,6 @@
       <ID>id_1cf609e3b924a25eaff15a4316006dd2</ID>
       <Filename>Brana-Regular.ttf</Filename>
       <Filepath>source\..\..\..\shared\fonts\geez\Brana-Regular.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
-    </File>
-    <File>
-      <ID>id_cbe96fda04eb77e2be4e01a4fbcec5cf</ID>
-      <Filename>EthiopicUnicodeItalic.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\geez\EthiopicUnicodeItalic.ttf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ttf</FileType>
-      <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>
-    </File>
-    <File>
-      <ID>id_1b189c0d076b0a7576f7169c1ada6430</ID>
-      <Filename>EthiopicUnicodeNormal.ttf</Filename>
-      <Filepath>source\..\..\..\shared\fonts\geez\EthiopicUnicodeNormal.ttf</Filepath>
       <FileVersion></FileVersion>
       <FileType>.ttf</FileType>
       <ParentFileID>id_a2cb378b738abdcf8e94b036db2e0b91</ParentFileID>

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kmn
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kmn
@@ -13,7 +13,7 @@ c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
 store(&VERSION) '15.0'
-store(&KEYBOARDVERSION) '2.0.2'
+store(&KEYBOARDVERSION) '2.0.3'
 store(&Name) 'ትግርኛ (Tigrinya)'
 store(&COPYRIGHT) '© 2009-2023 Geʾez Frontier Foundation'
 store(&Message) 'This is a Tigrinya language mnemonic input method that applies Ethiopian writing conventions.  It requires a font supporting Ethiopic script under the Unicode 3.0 standard.'

--- a/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
+++ b/release/gff/gff_tigrinya_ethiopia/source/gff_tigrinya_ethiopia.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.141.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -100,18 +100,6 @@
     <File>
       <Name>..\..\..\shared\fonts\geez\Brana-Regular.ttf</Name>
       <Description>Font Brana Regular</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\EthiopicUnicodeItalic.ttf</Name>
-      <Description>Font Ethiopic Unicode Italic</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\EthiopicUnicodeNormal.ttf</Name>
-      <Description>Font Ethiopic Unicode Normal</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.ttf</FileType>
     </File>


### PR DESCRIPTION
This update removes the "EthiopicUnicodeNormal.ttf" and "EthiopicUnicodeItalic.ttf"  fonts which have an unknown license.  Aside from the version number, no other changes occur.