### PR TITLE
chore: ensure master up to date earlier when deploying help

### DIFF
--- a/resources/help-keyman-com.sh
+++ b/resources/help-keyman-com.sh
@@ -210,8 +210,6 @@ function commit_and_push {
 
   local branch=auto/keyboards/upload/$uuid
 
-  echo "ensuring master is up to date"
-  git pull origin master || return 1
   git add keyboard || return 1
   git diff --cached --no-ext-diff --quiet --exit-code && {
     # if no changes then don't do anything.
@@ -239,9 +237,19 @@ function commit_and_push {
   return 0
 }
 
+function update_help_repo() {
+  pushd $HELP_KEYMAN_COM
+  echo "ensuring master is up to date"
+  git pull origin master || return 1
+  popd
+
+  return 0
+}
+
 #
 # Main
 #
 
+update_help_repo || exit 1
 upload_keyboard_helps_by_target || exit 1
 commit_and_push || exit 1


### PR DESCRIPTION
Per https://build.palaso.org/buildConfiguration/Keyboards_Upload/417714?buildTab=log&focusLine=26382&linesState=25980&logView=flowAware, the build failed due to:

```
05:55:14   Committing and pushing updated keyboard documentation (if any)
05:55:14   ensuring master is up to date
05:55:15   From https://github.com/keymanapp/help.keyman.com
05:55:15    * branch              master     -> FETCH_HEAD
05:55:15      6cc08de9..51fbc572  master     -> origin/master
05:55:18   error: The following untracked working tree files would be overwritten by merge:
05:55:18     keyboard/fv_nuucaanul/9.1.4/Nuucaanul.png
05:55:18     keyboard/fv_nuucaanul/9.1.4/fv_nuucaanul.php
05:55:18   Please move or remove them before you merge.
05:55:18   Updating 6cc08de9..51fbc572
05:55:18   Aborting
05:55:18   Process exited with code 1
```

This updates the deployment to bring master up to date first.