### PR TITLE
[newa_traditional_extended] show texts for the invisible character keys on OSK

### DIFF
--- a/release/n/newa_traditional_extended/HISTORY.md
+++ b/release/n/newa_traditional_extended/HISTORY.md
@@ -1,5 +1,9 @@
 # Newa Traditional Extended Change History
 
+## 1.0.1 (2023-10-29)
+
+- Show texts for zwnj, zwj and dead keys on OSK
+
 ## 1.0 (2023-10-23)
 
 - Created by Swornim Nakarmi

--- a/release/n/newa_traditional_extended/newa_traditional_extended.kpj
+++ b/release/n/newa_traditional_extended/newa_traditional_extended.kpj
@@ -12,7 +12,7 @@
       <ID>id_d3c155065be2584ea6bfbd874a35c017</ID>
       <Filename>newa_traditional_extended.kmn</Filename>
       <Filepath>source\newa_traditional_extended.kmn</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.0.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Newa Traditional Extended</Name>

--- a/release/n/newa_traditional_extended/source/newa_traditional_extended.kmn
+++ b/release/n/newa_traditional_extended/source/newa_traditional_extended.kmn
@@ -2,7 +2,7 @@
 store(&VERSION) '10.0'
 store(&NAME) 'Newa Traditional Extended'
 store(&COPYRIGHT) '© Swornim Nakarmi'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&TARGETS) 'any'
 store(&BITMAP) 'newa_traditional_extended.ico'
 store(&VISUALKEYBOARD) 'newa_traditional_extended.kvks'

--- a/release/n/newa_traditional_extended/source/newa_traditional_extended.kps
+++ b/release/n/newa_traditional_extended/source/newa_traditional_extended.kps
@@ -87,7 +87,7 @@
     <Keyboard>
       <Name>Newa Traditional Extended</Name>
       <ID>newa_traditional_extended</ID>
-      <Version>1.0</Version>
+      <Version>1.0.1</Version>
       <OSKFont>..\..\..\shared\fonts\noto\Newa\NotoSansNewa-Regular.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\noto\Newa\NotoSansNewa-Regular.ttf</DisplayFont>
       <Languages>

--- a/release/n/newa_traditional_extended/source/newa_traditional_extended.kvks
+++ b/release/n/newa_traditional_extended/source/newa_traditional_extended.kvks
@@ -50,9 +50,10 @@
       <key vkey="K_Z">𑐱𑑂𑐬</key>
       <key vkey="K_6">𑐚</key>
       <key vkey="K_HYPHEN">𑐍</key>
-      <key vkey="K_BKSLASH">‍</key>
+      <key vkey="K_BKSLASH">zwj</key>
       <key vkey="K_RBRKT">𑐿</key>
       <key vkey="K_BKQUOTE">𑑇</key>
+      <key vkey="K_LBRKT">dead</key>
     </layer>
     <layer shift="">
       <key vkey="K_QUOTE">𑐸</key>
@@ -88,7 +89,7 @@
       <key vkey="K_J">𑐰</key>
       <key vkey="K_K">𑐥</key>
       <key vkey="K_L">𑐶</key>
-      <key vkey="K_M">‌</key>
+      <key vkey="K_M">zwnj</key>
       <key vkey="K_N">𑐮</key>
       <key vkey="K_O">𑐫</key>
       <key vkey="K_P">𑐄</key>


### PR DESCRIPTION
Show texts for the invisible character keys i.e. zwnj, zwj and dead keys on OSK, which were missing in the previous version.