### PR TITLE
[baybayin] removed r and R from nul store

### DIFF
--- a/release/b/baybayin/HISTORY.md
+++ b/release/b/baybayin/HISTORY.md
@@ -1,5 +1,10 @@
 Baybayin Keyboard Changelog
 
+1.2 (2023-12-04)
+----------------
+* Fixed a character:
+170D ᜍ TAGALOG LETTER RA
+
 1.1.1 (2023-11-29)
 ----------------
 * Used shared font instead of local

--- a/release/b/baybayin/baybayin.kpj
+++ b/release/b/baybayin/baybayin.kpj
@@ -3,14 +3,16 @@
   <Options>
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>True</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
   <Files>
     <File>
       <ID>id_74265b326209a3e1908d5f32d6221ff0</ID>
       <Filename>baybayin.kmn</Filename>
       <Filepath>source\baybayin.kmn</Filepath>
-      <FileVersion>1.1.1</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Baybayin</Name>

--- a/release/b/baybayin/source/baybayin.kmn
+++ b/release/b/baybayin/source/baybayin.kmn
@@ -2,11 +2,11 @@
 store(&VERSION) '10.0'
 store(&NAME) 'Baybayin'
 store(&COPYRIGHT) '© Ilham Nurwansah'
-store(&KEYBOARDVERSION) '1.1.1'
+store(&KEYBOARDVERSION) '1.2'
 store(&VISUALKEYBOARD) 'baybayin.kvks'
 store(&MESSAGE) 'Keyboard for typing Baybayin script'
 store(&BITMAP) 'baybayin.ico'
-store(nul) "acefjoqrvxzBCDEFGHJKLMOPQRSTVWXYZ"
+store(nul) "acefjoqvxzBCDEFGHJKLMOPQSTVWXYZ"
 store(&TARGETS) 'any'
 
 begin Unicode > use(main)


### PR DESCRIPTION
Fixed a character:
170D ᜍ TAGALOG LETTER RA

Report on App Store (by Rymarpinoy – Nov 22, 2023), quoted below:
> The app is cool and all with the Ancient Filipino Scripts but here’s the thing, 1 The Baybayin script keyboard itself The weird things is I can’t backspace the Pamudpod symbol and I can’t type the symbol “Ra” 2 The keyboard won’t load for me on the keyboard itself


