### PR TITLE
[cs-pinyin] Remove macos from target list

### DIFF
--- a/legacy/c/cs-pinyin/cs-pinyin.keyboard_info
+++ b/legacy/c/cs-pinyin/cs-pinyin.keyboard_info
@@ -19,7 +19,6 @@
   "version": "1.3",
   "minKeymanVersion": "7.0",
   "platformSupport": {
-    "windows": "full",
-    "macos": "full"
+    "windows": "full"
   }
 }


### PR DESCRIPTION
Fixes #2494 

Since this keyboard is in `legacy` we aren't updating the keyboard package itself, just the target to Windows only.