### PR TITLE
[idc_help] add help file for idc_deseret

### DIFF
--- a/release/i/idc_deseret/source/help/idc_deseret.php
+++ b/release/i/idc_deseret/source/help/idc_deseret.php
@@ -1,0 +1,14 @@
+<?php 
+  $pagename = 'IDC Deseret Keyboard Help';
+  $pagetitle = $pagename;
+  require_once('header.php');
+?>
+
+
+<p>IDC Deseret structures the keyboard broadly with unvoiced consonants on the top (numeric) row, voiced consonants below it, and vowels and semivowels on the bottom two rows.  This completely decouples the Deseret letter position from any correspondence with QWERTY or any other roman-type keyboard.  Letter order is inspired by the Unicode ordering but deviates in several instances for correspondence.</p>
+
+<h2>Desktop Keyboard Layout</h2>
+<div id='osk' data-states='default shift'>
+</div>
+
+<p>The underlying number keys and punctuation masked by the Deseret characters may be reacquired by using <code>RALT</code> with the regular key.</p>


### PR DESCRIPTION
I approved the `idc_deseret` keyboard without an online help file.