### PR TITLE
[khmer_angkor] Add non-printing characters to spacebar

### DIFF
--- a/release/k/khmer_angkor/HISTORY.md
+++ b/release/k/khmer_angkor/HISTORY.md
@@ -1,6 +1,10 @@
 Khmer Angkor Change History
 =======================
 
+1.4 (5 Mar 2024)
+----------------
+* add spacing glyphs to touch layout spacebar
+
 1.3 (19 Jul 2022)
 ----------------------
 * update OSK in the documentation and bump version number

--- a/release/k/khmer_angkor/source/khmer_angkor.keyman-touch-layout
+++ b/release/k/khmer_angkor/source/khmer_angkor.keyman-touch-layout
@@ -59,8 +59,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "100",
-                "sp": "1"
+                "width": 100,
+                "sp": 1
               }
             ]
           },
@@ -70,7 +70,7 @@
               {
                 "id": "K_Q",
                 "text": "ឆ",
-                "pad": "75"
+                "pad": 75
               },
               {
                 "id": "K_W",
@@ -119,8 +119,8 @@
               {
                 "id": "T_new_138",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -187,8 +187,8 @@
               {
                 "id": "K_SHIFT",
                 "text": "*Shift*",
-                "width": "160",
-                "sp": "1",
+                "width": 160,
+                "sp": 1,
                 "nextlayer": "shift"
               },
               {
@@ -238,8 +238,8 @@
               {
                 "id": "T_new_164",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -249,26 +249,26 @@
               {
                 "id": "K_LCONTROL",
                 "text": "*AltGr*",
-                "width": "160",
-                "sp": "1",
+                "width": 160,
+                "sp": 1,
                 "nextlayer": "rightalt"
               },
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               },
               {
                 "id": "K_SPACE",
                 "text": "​",
-                "width": "930"
+                "width": 930
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -331,8 +331,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "100",
-                "sp": "1"
+                "width": 100,
+                "sp": 1
               }
             ]
           },
@@ -342,7 +342,7 @@
               {
                 "id": "K_Q",
                 "text": "ៜ",
-                "pad": "75"
+                "pad": 75
               },
               {
                 "id": "K_W",
@@ -391,8 +391,8 @@
               {
                 "id": "T_new_307",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -459,8 +459,8 @@
               {
                 "id": "K_SHIFT",
                 "text": "*Shift*",
-                "width": "160",
-                "sp": "1",
+                "width": 160,
+                "sp": 1,
                 "nextlayer": "shift"
               },
               {
@@ -510,8 +510,8 @@
               {
                 "id": "T_new_333",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -521,26 +521,26 @@
               {
                 "id": "K_LCONTROL",
                 "text": "*AltGr*",
-                "width": "160",
-                "sp": "2",
+                "width": 160,
+                "sp": 2,
                 "nextlayer": "default"
               },
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               },
               {
                 "id": "K_SPACE",
                 "text": " ",
-                "width": "930"
+                "width": 930
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -603,8 +603,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "100",
-                "sp": "1"
+                "width": 100,
+                "sp": 1
               }
             ]
           },
@@ -614,7 +614,7 @@
               {
                 "id": "K_Q",
                 "text": "ឈ",
-                "pad": "75"
+                "pad": 75
               },
               {
                 "id": "K_W",
@@ -663,8 +663,8 @@
               {
                 "id": "T_new_364",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -731,8 +731,8 @@
               {
                 "id": "K_SHIFT",
                 "text": "*Shift*",
-                "width": "160",
-                "sp": "2",
+                "width": 160,
+                "sp": 2,
                 "nextlayer": "default"
               },
               {
@@ -782,8 +782,8 @@
               {
                 "id": "T_new_390",
                 "text": "",
-                "width": "10",
-                "sp": "10"
+                "width": 10,
+                "sp": 10
               }
             ]
           },
@@ -793,26 +793,26 @@
               {
                 "id": "K_LCONTROL",
                 "text": "*AltGr*",
-                "width": "160",
-                "sp": "1",
+                "width": 160,
+                "sp": 1,
                 "nextlayer": "rightalt"
               },
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "width": "930"
+                "width": 930
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -833,7 +833,6 @@
               {
                 "id": "K_Q",
                 "text": "ឆ",
-                "pad": "",
                 "sk": [
                   {
                     "text": "ឈ",
@@ -1058,8 +1057,7 @@
               {
                 "id": "K_A",
                 "text": "",
-                "pad": "",
-                "width": "100",
+                "width": 100,
                 "sk": [
                   {
                     "text": "",
@@ -1230,8 +1228,6 @@
               {
                 "id": "K_Z",
                 "text": "ឋ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ឍ",
@@ -1403,7 +1399,7 @@
               {
                 "id": "K_QUOTE",
                 "text": "",
-                "width": "100",
+                "width": 100,
                 "sk": [
                   {
                     "text": "",
@@ -1419,8 +1415,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "100",
-                "sp": "1"
+                "width": 100,
+                "sp": 1
               }
             ]
           },
@@ -1430,21 +1426,21 @@
               {
                 "id": "K_NUMLOCK",
                 "text": "១២៣",
-                "width": "140",
-                "sp": "1",
+                "width": 140,
+                "sp": 1,
                 "nextlayer": "numeric"
               },
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "120",
-                "sp": "1"
+                "width": 120,
+                "sp": 1
               },
               {
                 "id": "K_SPACE",
                 "text": "​",
-                "width": "555",
-                "sp": "0",
+                "width": 555,
+                "sp": 0,
                 "sk": [
                   {
                     "text": " ",
@@ -1456,7 +1452,7 @@
               {
                 "id": "K_PERIOD",
                 "text": "។",
-                "width": "120",
+                "width": 120,
                 "sk": [
                   {
                     "text": "៕",
@@ -1476,8 +1472,8 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "width": "140",
-                "sp": "1"
+                "width": 140,
+                "sp": 1
               }
             ]
           }
@@ -1492,7 +1488,6 @@
               {
                 "id": "K_1",
                 "text": "១",
-                "pad": "",
                 "sk": [
                   {
                     "text": "1",
@@ -1602,7 +1597,6 @@
               {
                 "id": "U_0040",
                 "text": "@",
-                "pad": "",
                 "sk": [
                   {
                     "text": "©",
@@ -1766,7 +1760,6 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "",
                 "sk": [
                   {
                     "text": "»",
@@ -1883,8 +1876,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -1894,28 +1886,27 @@
               {
                 "id": "K_LCONTROL",
                 "text": "១២៣",
-                "width": "140",
-                "sp": "2",
+                "width": 140,
+                "sp": 2,
                 "nextlayer": "default"
               },
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "120",
-                "sp": "1"
+                "width": 120,
+                "sp": 1
               },
               {
                 "id": "K_SPACE",
                 "text": "​",
-                "width": "555",
-                "sp": "0",
-                "layer": "shift",
-                "sk": []
+                "width": 555,
+                "sp": 0,
+                "layer": "shift"
               },
               {
                 "id": "K_PERIOD",
                 "text": "។",
-                "width": "120",
+                "width": 120,
                 "sk": [
                   {
                     "text": "៕",
@@ -1935,8 +1926,8 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "width": "140",
-                "sp": "1"
+                "width": 140,
+                "sp": 1
               }
             ]
           }

--- a/release/k/khmer_angkor/source/khmer_angkor.keyman-touch-layout
+++ b/release/k/khmer_angkor/source/khmer_angkor.keyman-touch-layout
@@ -1438,13 +1438,13 @@
               },
               {
                 "id": "K_SPACE",
-                "text": "​",
+                "text": "*ZWSp*",
                 "width": 555,
                 "sp": 0,
                 "sk": [
                   {
-                    "text": " ",
                     "id": "U_0020",
+                    "text": "*Sp*",
                     "layer": "default"
                   }
                 ]
@@ -1898,7 +1898,7 @@
               },
               {
                 "id": "K_SPACE",
-                "text": "​",
+                "text": "*Sp*",
                 "width": 555,
                 "sp": 0,
                 "layer": "shift"

--- a/release/k/khmer_angkor/source/khmer_angkor.kmn
+++ b/release/k/khmer_angkor/source/khmer_angkor.kmn
@@ -1,10 +1,10 @@
 ﻿store(&VERSION) '10.0'
 store(&NAME) "Khmer Angkor"
-store(&COPYRIGHT) '© 2015-2022 SIL International'
+store(&COPYRIGHT) '© 2015-2024 SIL International'
 store(&MESSAGE) "More than just a Khmer Unicode keyboard."
 store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'khmer_angkor.keyman-touch-layout'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
 store(&BITMAP) 'khmer_angkor.ico'
 store(&VISUALKEYBOARD) 'khmer_angkor.kvks'
 


### PR DESCRIPTION
Fixes #2221 by adding 17.0 non-printing glyphs  (see keymanapp/keyman#9846) to the khmer_angkor spacebar.
Default spacebar outputs ZWSP (text `*ZWSp*`)
shift-spacebar outputs U+0020  (text `*Sp*`)

Because the spacebar typically shows the keyboard name, only the longpress glyph is really visible

![image](https://github.com/keymanapp/keyboards/assets/7358010/f5ca852f-15be-42ba-998a-7de751219a30)

Note: first commit is just differences from Keyman Developer 17.0 beta.
Can jump to ll. 1441, 1447,  and 1901.