### PR TITLE
[fv_hailzaqvla] patch to on-screen keyboard

### DIFF
--- a/release/fv/fv_hailzaqvla/HISTORY.md
+++ b/release/fv/fv_hailzaqvla/HISTORY.md
@@ -1,5 +1,9 @@
 Háiɫzaqvḷa Change History
 ============================
+9.5.1 (4 Mar 2024)
+---------------
+* Added left/right distinction to alt keys, updated on-screen keyboard layout, so on-screen keyboard words correctly on Mac
+
 9.5 (22 Jan 2024)
 ----------------
 * Corrected language and keyboard name

--- a/release/fv/fv_hailzaqvla/fv_hailzaqvla.kpj
+++ b/release/fv/fv_hailzaqvla/fv_hailzaqvla.kpj
@@ -12,7 +12,7 @@
       <ID>id_2b89ed8c2311d9d632f502942aac3369</ID>
       <Filename>fv_hailzaqvla.kmn</Filename>
       <Filepath>source\fv_hailzaqvla.kmn</Filepath>
-      <FileVersion>9.5</FileVersion>
+      <FileVersion>9.5.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Háiɫzaqvḷa</Name>
@@ -27,7 +27,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>Háiɫzaqvḷa</Name>
-        <Copyright>© 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
+        <Copyright>© 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
       </Details>
     </File>
     <File>

--- a/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kmn
+++ b/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kmn
@@ -1,5 +1,5 @@
 ﻿store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) '9.5'
+store(&KEYBOARDVERSION) '9.5.1'
 c store(&ETHNOLOGUECODE) "hei"
 store(&COPYRIGHT) '(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' U+0027 ' Cultural Foundation'
 store(&NAME) 'Háiɫzaqvḷa'
@@ -29,36 +29,36 @@ store(&CasedKeys) [K_BKQUOTE] [K_BKSLASH] [K_RBRKT] [K_LBRKT]
 + [SHIFT K_6] > U+030C
 + [SHIFT K_HYPHEN] > U+0301
 
-+ [ALT K_SLASH] > 'ʔ'
-+ [ALT K_G] > 'ǧ'
-+ [ALT K_X] > 'x̌'
-+ [ALT K_N] > 'ṇ'
-+ [ALT K_L] > 'ḷ'
-+ [ALT K_M] > 'ṃ'
-+ [ALT K_BKQUOTE] > U+0300
++ [RALT K_SLASH] > 'ʔ'
++ [RALT K_G] > 'ǧ'
++ [RALT K_X] > 'x̌'
++ [RALT K_N] > 'ṇ'
++ [RALT K_L] > 'ḷ'
++ [RALT K_M] > 'ṃ'
++ [RALT K_BKQUOTE] > U+0300
 
-+ [ALT K_6] > '^'
-+ [ALT K_BKSLASH] > '\'
-+ [ALT K_PERIOD] > '>'
-+ [ALT K_COMMA] > '<'
-+ [ALT K_RBRKT] > ']'
-+ [ALT K_LBRKT] > '['
++ [RALT K_6] > '^'
++ [RALT K_BKSLASH] > '\'
++ [RALT K_PERIOD] > '>'
++ [RALT K_COMMA] > '<'
++ [RALT K_RBRKT] > ']'
++ [RALT K_LBRKT] > '['
 
-+ [SHIFT ALT K_X] > 'X̌'
-+ [SHIFT ALT K_G] > 'Ǧ'
-+ [SHIFT ALT K_N] > 'Ṇ'
-+ [SHIFT ALT K_M] > 'Ṃ'
-+ [SHIFT ALT K_L] > 'Ḷ'
-+ [SHIFT ALT K_SLASH] > 'ʔ'
++ [SHIFT RALT K_X] > 'X̌'
++ [SHIFT RALT K_G] > 'Ǧ'
++ [SHIFT RALT K_N] > 'Ṇ'
++ [SHIFT RALT K_M] > 'Ṃ'
++ [SHIFT RALT K_L] > 'Ḷ'
++ [SHIFT RALT K_SLASH] > 'ʔ'
 
-+ [SHIFT ALT K_EQUAL] > '`'
-+ [SHIFT ALT K_BKSLASH] > '|'
-+ [SHIFT ALT K_HYPHEN] > '_'
-+ [SHIFT ALT K_PERIOD] > '>'
-+ [SHIFT ALT K_COMMA] > '<'
-+ [SHIFT ALT K_RBRKT] > '}'
-+ [SHIFT ALT K_LBRKT] > '{'
-+ [SHIFT ALT K_BKQUOTE] > '~'
++ [SHIFT RALT K_EQUAL] > '`'
++ [SHIFT RALT K_BKSLASH] > '|'
++ [SHIFT RALT K_HYPHEN] > '_'
++ [SHIFT RALT K_PERIOD] > '>'
++ [SHIFT RALT K_COMMA] > '<'
++ [SHIFT RALT K_RBRKT] > '}'
++ [SHIFT RALT K_LBRKT] > '{'
++ [SHIFT RALT K_BKQUOTE] > '~'
 
 
 c --- START OF TOUCH LAYOUT RULES ---
@@ -200,7 +200,7 @@ c diacritics
 c combining apostr [SHIFT K_COMMA] U+0313
 c combining caron [SHIFT K_6] U+030C
 c combining acute [SHIFT K_HYPHEN] U+0301
-c combining grave [ALT K_BKQUOTE] U+0300
+c combining grave [RALT K_BKQUOTE] U+0300
 
 c Accents on vowels should create single character version
 store(vowels) 'aeiouAEIOU'
@@ -208,7 +208,7 @@ store(acutevowels) U+00E1 U+00E9 U+00ED U+00F3 U+00FA U+00C1 U+00C9 U+00CD U+00D
 store(gravevowels) U+00E0 U+00E8 U+00EC U+00F2 U+00F9 U+00C0 U+00C8 U+00CC U+00D2 U+00D9
 store(caronvowels) U+01CE U+011B U+01D0 U+01D2 U+01D4 U+01CD U+011A U+01CF U+01D1 U+01D3
 any(vowels) + [SHIFT K_HYPHEN] > index(acutevowels,1)
-any(vowels) + [ALT K_BKQUOTE] > index(gravevowels,1)
+any(vowels) + [RALT K_BKQUOTE] > index(gravevowels,1)
 any(vowels) + [SHIFT K_6] > index(caronvowels,1)
 c caron + g should create single character version
 store(plaing) 'gG'
@@ -219,7 +219,7 @@ store(diacritics) U+0313 U+0301 U+0300 U+030C
 any(diacritics) + [SHIFT K_COMMA] > U+0313
 any(diacritics) + [SHIFT K_6] > U+030C
 any(diacritics) + [SHIFT K_HYPHEN] > U+0301
-any(diacritics) + [ALT K_BKQUOTE] > U+0300
+any(diacritics) + [RALT K_BKQUOTE] > U+0300
 c if a diacritic added to a combined character, replace with the right new diacritic instead of stacking
 c adding acute
 any(acutevowels) + [SHIFT K_HYPHEN] > index(acutevowels,1)
@@ -228,11 +228,11 @@ any(caronvowels) + [SHIFT K_HYPHEN] > index(acutevowels,1)
 any(vowels) any(diacritics) + [SHIFT K_HYPHEN] > index(acutevowels,1)
 any(carong) + [SHIFT K_HYPHEN] > index(plaing,1) U+0301
 c adding grave
-any(acutevowels) + [ALT K_BKQUOTE] > index(gravevowels,1)
-any(gravevowels) + [ALT K_BKQUOTE] > index(gravevowels,1)
-any(caronvowels) + [ALT K_BKQUOTE] > index(gravevowels,1)
-any(vowels) any(diacritics) + [ALT K_BKQUOTE] > index(gravevowels,1)
-any(carong) + [ALT K_BKQUOTE] > index(plaing,1) U+0300
+any(acutevowels) + [RALT K_BKQUOTE] > index(gravevowels,1)
+any(gravevowels) + [RALT K_BKQUOTE] > index(gravevowels,1)
+any(caronvowels) + [RALT K_BKQUOTE] > index(gravevowels,1)
+any(vowels) any(diacritics) + [RALT K_BKQUOTE] > index(gravevowels,1)
+any(carong) + [RALT K_BKQUOTE] > index(plaing,1) U+0300
 c adding caron
 any(acutevowels) + [SHIFT K_6] > index(caronvowels,1)
 any(gravevowels) + [SHIFT K_6] > index(caronvowels,1)

--- a/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kps
+++ b/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kps
@@ -64,7 +64,7 @@
       <ID>fv_hailzaqvla</ID>
       <Version>9.4.1</Version>
       <Languages>
-        <Language ID="hei">Heiltsuk (Latin)</Language>
+        <Language ID="hei">Heiltsuk</Language>
       </Languages>
     </Keyboard>
   </Keyboards>

--- a/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kvks
+++ b/release/fv/fv_hailzaqvla/source/fv_hailzaqvla.kvks
@@ -5,40 +5,10 @@
     <kbdname>fv_hailzaqvla</kbdname>
     <flags>
       <displayunderlying/>
+      <usealtgr/>
     </flags>
   </header>
   <encoding name="unicode" fontname="Times New Roman" fontsize="12">
-    <layer shift="SA">
-      <key vkey="K_EQUAL">`</key>
-      <key vkey="K_COMMA">&lt;</key>
-      <key vkey="K_PERIOD">&gt;</key>
-      <key vkey="K_SLASH">ʔ</key>
-      <key vkey="K_G">Ǧ</key>
-      <key vkey="K_L">Ḷ</key>
-      <key vkey="K_X">X̌</key>
-      <key vkey="K_N">Ṇ</key>
-      <key vkey="K_M">Ṃ</key>
-      <key vkey="K_LBRKT">{</key>
-      <key vkey="K_RBRKT">}</key>
-      <key vkey="K_BKSLASH">|</key>
-      <key vkey="K_HYPHEN">_</key>
-      <key vkey="K_BKQUOTE">~</key>
-    </layer>
-    <layer shift="A">
-      <key vkey="K_COMMA">&lt;</key>
-      <key vkey="K_PERIOD">&gt;</key>
-      <key vkey="K_SLASH">ʔ</key>
-      <key vkey="K_6">^</key>
-      <key vkey="K_BKQUOTE">`</key>
-      <key vkey="K_G">ǧ</key>
-      <key vkey="K_X">x̌</key>
-      <key vkey="K_N">ṇ</key>
-      <key vkey="K_L">ḷ</key>
-      <key vkey="K_M">ṃ</key>
-      <key vkey="K_LBRKT">[</key>
-      <key vkey="K_RBRKT">]</key>
-      <key vkey="K_BKSLASH">\</key>
-    </layer>
     <layer shift="">
       <key vkey="K_BKQUOTE">ħ</key>
       <key vkey="K_BKSLASH">ɫ</key>
@@ -136,6 +106,37 @@
       <key vkey="K_M">M</key>
       <key vkey="K_PERIOD">̣</key>
       <key vkey="K_SLASH">?</key>
+    </layer>
+    <layer shift="RA">
+      <key vkey="K_BKQUOTE">`</key>
+      <key vkey="K_6">^</key>
+      <key vkey="K_LBRKT">[</key>
+      <key vkey="K_RBRKT">]</key>
+      <key vkey="K_BKSLASH">\</key>
+      <key vkey="K_G">ǧ</key>
+      <key vkey="K_L">ḷ</key>
+      <key vkey="K_X">x̌</key>
+      <key vkey="K_N">ṇ</key>
+      <key vkey="K_M">ṃ</key>
+      <key vkey="K_COMMA">&lt;</key>
+      <key vkey="K_PERIOD">&gt;</key>
+      <key vkey="K_SLASH">ʔ</key>
+    </layer>
+    <layer shift="SRA">
+      <key vkey="K_BKQUOTE">~</key>
+      <key vkey="K_HYPHEN">_</key>
+      <key vkey="K_EQUAL">`</key>
+      <key vkey="K_LBRKT">{</key>
+      <key vkey="K_RBRKT">}</key>
+      <key vkey="K_BKSLASH">|</key>
+      <key vkey="K_G">Ǧ</key>
+      <key vkey="K_L">Ḷ</key>
+      <key vkey="K_X">X̌</key>
+      <key vkey="K_N">Ṇ</key>
+      <key vkey="K_M">Ṃ</key>
+      <key vkey="K_COMMA">&lt;</key>
+      <key vkey="K_PERIOD">&gt;</key>
+      <key vkey="K_SLASH">ʔ</key>
     </layer>
   </encoding>
 </visualkeyboard>

--- a/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
+++ b/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
@@ -39,31 +39,31 @@ END;
   <li>λ: type the [ key. (Capital is not available in all fonts.)</li>
   <li>ƛ: type the ] key. (Capital is not available.)</li>
   <li>ɫ: type the \ key.</li>
-  <li>ʔ: hold ALT and type the / key.</li>
+  <li>ʔ: hold RIGHT ALT and type the / key.</li>
     <ul>
-      <li><b>NOTE</b>: When using Google Docs with Google Chrome, ALT or OPTION + / is already used as a shortcut. ʔ can instead be typed ALT/OPTION + SHIFT + /</li>
+      <li><b>NOTE</b>: When using Google Docs with Google Chrome, RIGHT ALT or OPTION + / is already used as a shortcut. ʔ can instead be typed RIGHT ALT/OPTION + SHIFT + /</li>
     </ul>
   <li>ǧ x̌:
     <ul>
       <li>Type g/x, then hold SHIFT and press 6 to add the extra ˇ mark.</li>
-      <li>OR hold ALT and type g/x.</li>
+      <li>OR hold RIGHT ALT and type g/x.</li>
     </ul>
   </li>
   <li>ḷ ṃ ṇ:
     <ul>
       <li>Type l/m/n, then hold SHIFT and press . (period) to add the extra dot.</li>
-      <li>OR hold ALT and type l/m/n. 
-      <br><em>Note: ALT+SHIFT+M is used in Keyman by default to open the Keyman menu, so this method cannot be used to type Ṃ. You must either use the first method, or go to Configuration < Hotkeys in the Keyman menu to remove that default.</em></li>
+      <li>OR hold RIGHT ALT and type l/m/n. 
+      <br><em>Note: RIGHT ALT+SHIFT+M is used in Keyman by default to open the Keyman menu, so this method cannot be used to type Ṃ. You must either use the first method, or go to Configuration < Hotkeys in the Keyman menu to remove that default.</em></li>
     </ul>
   </li>
   <li>p̓ t̓ a̓, etc: Type the letter you want, then hold SHIFT and press , (comma) to add the glottal.</li>
   <li>á ú, à ù, etc:
     <ul>
       <li>Type the letter you want, then hold SHIFT and press - (hyphen) to add the ´ accent.</li>
-      <li>Type the letter you want, then hold ALT and press ` (next to the number 1) to add the ` accent.</li>
+      <li>Type the letter you want, then hold RIGHT ALT and press ` (next to the number 1) to add the ` accent.</li>
     </ul>
   </li>
-  <li>For punctuation keys that were replaced with some other letter or accent, you can get the original symbol by pressing ALT. (Example: hold ALT and press \ to type \.)</li>
+  <li>For punctuation keys that were replaced with some other letter or accent, you can get the original symbol by pressing RIGHT ALT. (Example: hold RIGHT ALT and press \ to type \.)</li>
 </ul>
 
 <div class='vspace'></div>

--- a/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
+++ b/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
@@ -13,7 +13,7 @@ END;
 ?>
 
 <p style='margin: 16px 0 0 0'>
-  This keyboard is designed for the <b>Haiɫzaqvla</b> language of the BC Coast region of Canada.
+  This keyboard is designed for the <b>Háiɫzaqvḷa</b> language of the BC Coast region of Canada.
 </p>
 <p>
   If square boxes are displayed instead of characters when using this keyboard (and in the keyboard layouts below), please read our <a href="/troubleshooting/#boxes">troubleshooting guide</a>.

--- a/release/fv/fv_hailzaqvla/source/welcome.htm
+++ b/release/fv/fv_hailzaqvla/source/welcome.htm
@@ -22,31 +22,31 @@
   <li>λ: type the [ key. (Capital is not available in all fonts.)</li>
   <li>ƛ: type the ] key. (Capital is not available.)</li>
   <li>ɫ: type the \ key.</li>
-  <li>ʔ: hold ALT and type the / key.</li>
+  <li>ʔ: hold RIGHT ALT and type the / key.</li>
     <ul>
-      <li><b>NOTE</b>: When using Google Docs with Google Chrome, ALT or OPTION + / is already used as a shortcut. ʔ can instead be typed ALT/OPTION + SHIFT + /</li>
+      <li><b>NOTE</b>: When using Google Docs with Google Chrome, RIGHT ALT or OPTION + / is already used as a shortcut. ʔ can instead be typed ALT/OPTION + SHIFT + /</li>
     </ul>
   <li>ǧ x̌:
     <ul>
       <li>Type g/x, then hold SHIFT and press 6 to add the extra ˇ mark.</li>
-      <li>OR hold ALT and type g/x.</li>
+      <li>OR hold RIGHT ALT and type g/x.</li>
     </ul>
   </li>
   <li>ḷ ṃ ṇ:
     <ul>
       <li>Type l/m/n, then hold SHIFT and press . (period) to add the extra dot.</li>
-      <li>OR hold ALT and type l/m/n. 
-        <br><em>Note: ALT+SHIFT+M is used in Keyman by default to open the Keyman menu, so this method cannot be used to type Ṃ. You must either use the first method, or go to Configuration < Hotkeys in the Keyman menu to remove that default.</em></li>
+      <li>OR hold RIGHT ALT and type l/m/n. 
+        <br><em>Note: RIGHT ALT+SHIFT+M is used in Keyman by default to open the Keyman menu, so this method cannot be used to type Ṃ. You must either use the first method, or go to Configuration < Hotkeys in the Keyman menu to remove that default.</em></li>
     </ul>
   </li>
   <li>p̓ t̓ a̓, etc: Type the letter you want, then hold SHIFT and press , (comma) to add the glottal.</li>
   <li>á ú, à ù, etc:
     <ul>
       <li>Type the letter you want, then hold SHIFT and press - (hyphen) to add the ´ accent.</li>
-      <li>Type the letter you want, then hold ALT and press ` (next to the number 1) to add the ` accent.</li>
+      <li>Type the letter you want, then hold RIGHT ALT and press ` (next to the number 1) to add the ` accent.</li>
     </ul>
   </li>
-  <li>For punctuation keys that were replaced with some other letter or accent, you can get the original symbol by pressing ALT. (Example: hold ALT and press \ to type \.)</li>
+  <li>For punctuation keys that were replaced with some other letter or accent, you can get the original symbol by pressing RIGHT ALT. (Example: hold RIGHT ALT and press \ to type \.)</li>
 </ul>
 
 <div class='vspace'></div>


### PR DESCRIPTION
Added left/right alt distinction and updated on-screen keyboard to correct issue with on-screen keyboard not showing option layer correctly on Mac.