### PR TITLE
[rac_dogri] chore: Simplify pathing in rac_dogri.kps

### DIFF
--- a/release/rac/rac_dogri/source/rac_dogri.kps
+++ b/release/rac/rac_dogri/source/rac_dogri.kps
@@ -37,19 +37,19 @@
       <FileType>.htm</FileType>
     </File>
     <File>
-      <Name>..\..\rac_dogri\build\rac_dogri.js</Name>
+      <Name>..\build\rac_dogri.js</Name>
       <Description>File rac_dogri.js</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
     <File>
-      <Name>..\..\rac_dogri\build\rac_dogri.kvk</Name>
+      <Name>..\build\rac_dogri.kvk</Name>
       <Description>File rac_dogri.kvk</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
     <File>
-      <Name>..\..\rac_dogri\build\rac_dogri.kmx</Name>
+      <Name>..\build\rac_dogri.kmx</Name>
       <Description>Keyboard Rachitrali-Dogri</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>


### PR DESCRIPTION
I was trying out the kmc compiler on staging-17.0 branch and had to replace a lot of slashes in .kps files to build on Linux.
That revealed the pathing in rac_dogri.kps can be simplified.

Not bumping versions since no rebuild necessary.