### PR TITLE
feat: Add tool to generate gesture table

### DIFF
--- a/tools/gestureChart/.editorconfig
+++ b/tools/gestureChart/.editorconfig
@@ -1,0 +1,7 @@
+
+[*.{js,ts,json}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+tab_width = 2
+trim_trailing_whitespace = true

--- a/tools/gestureChart/.gitignore
+++ b/tools/gestureChart/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+gestureChart.js
+*.md

--- a/tools/gestureChart/README.md
+++ b/tools/gestureChart/README.md
@@ -1,0 +1,16 @@
+# getureChart
+
+A tool to document gestures in a touch layout as Markdown tables. (issue #2213)
+
+Gestures can be: 
+* longpress
+* flicks
+* multitap
+
+
+## Usage
+```
+node gestureChart.js -k <keyboard>
+
+    -k, --keyboard <full path to keyboard directory>
+```

--- a/tools/gestureChart/gestureChart.ts
+++ b/tools/gestureChart/gestureChart.ts
@@ -81,8 +81,8 @@ function processKeyboard(dir: string) {
     l => l.row.some(r => r.key.some(k =>
       k.sk || k.flick || k.multitap)));
   if (filteredKeys && filteredKeys.length > 0) {
-    let gestureTable = `## ${name} Gesture Table\n`;
-    gestureTable += generateTable(formFactor, filteredKeys);
+    let gestureTable = `${newTitle(name)}${newPreamble(formFactor)}`;
+    gestureTable += generateTable(filteredKeys);
 
     // Write Gesture Table to file
     if (gestureTable) {
@@ -97,12 +97,11 @@ function processKeyboard(dir: string) {
 
 /**
  * Create Markdown table
- * @param formFactor phone or tablet
  * @param filteredKeys Filtered touch layout object containing all the gestures
  * @returns Markdown table as string
  */
-function generateTable(formFactor: formFactorType, filteredKeys) : string {
-  let table = `### ${formFactor} Layout\n`;
+function generateTable(filteredKeys) : string {
+  let table = '';
   for (let l in filteredKeys) {
     let layer = filteredKeys[l];
     let layerID = layer.id;
@@ -152,6 +151,16 @@ function generateTable(formFactor: formFactorType, filteredKeys) : string {
   }
 
   return table;
+}
+
+function newTitle(name: string): string {
+  return `---\n` +
+         `title: ${name} Gesture Table\n` +
+         `---\n\n`;
+}
+
+function newPreamble(formFactor: formFactorType) : string {
+  return `Gestures for the ${formFactor} Keyboard layers are described in the tables below:\n\n`;
 }
 
 function newTableHeader(): string {

--- a/tools/gestureChart/gestureChart.ts
+++ b/tools/gestureChart/gestureChart.ts
@@ -1,0 +1,208 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { CommanderError, program } from 'commander';
+
+type formFactorType = "tablet" | "phone";
+
+////////////////////////////////////////////////////////////////////
+// Get parameters
+////////////////////////////////////////////////////////////////////
+program
+  .description("Tool to document gestures in a touch layout as Markdown tables.\n" +
+    "Gestures can be: longpress, flicks, multitap")
+    .option("-k, --keyboard <full path to keyboard directory>", "path to a keyboard directory")
+    .exitOverride();
+try {
+  program.parse();
+} catch (error: unknown) {
+  if (error instanceof CommanderError) {
+    console.error(error.message);
+  }
+  process.exit(1);
+}
+
+// Debugging parameters
+const options = program.opts();
+const debugMode = true;
+if (debugMode) {
+  console.log('Parameters:');
+  if (options.keyboard) {
+    console.log(`Keyboard path: "${options.keyboard}"`);
+  }
+  console.log('\n');
+}
+
+// Keyboard path required
+if (!options.keyboard) {
+  console.error("Keyboard path required");
+  process.exit(1);
+}
+if (!fs.existsSync(options.keyboard) || !fs.statSync(options.keyboard).isDirectory()) {
+  console.error(`${options.keyboard} is not a directory`);
+  process.exit(1);
+}
+
+processKeyboard(options.keyboard);
+
+function stripBom(s: string): string {
+  if (s.startsWith('\uFEFF')) return s.substr(1);
+  return s;
+}
+
+function keyboardTouchLayoutFilename(dir: string, name: string) {
+  return dir + path.sep + name + '.keyman-touch-layout';
+}
+
+function keyboardTouchChartFilename(name: string, formFactor: string) : string {
+  return `${name}-${formFactor}.md`;
+}
+
+function loadKeyboardTouchLayout(dir: string, name: string) {
+  return JSON.parse(stripBom(fs.readFileSync(keyboardTouchLayoutFilename(dir, name), 'utf8')));
+}
+
+function processKeyboard(dir: string) {
+  let name = path.basename(dir);
+  console.log(`Keyboard ${name}`);
+
+  let touch_layout = loadKeyboardTouchLayout(`${dir}${path.sep}source${path.sep}`, name);
+  let phone = touch_layout.phone;
+  let tablet = touch_layout.tablet;
+  let formFactor: formFactorType = 'tablet';
+  let layer;
+  if (tablet) {
+    layer = tablet.layer
+  } else {
+    layer = phone.layer;
+    formFactor = 'phone';
+  }
+  // Filter for keys that have gestures
+  let filteredKeys = layer.filter(
+    l => l.row.some(r => r.key.some(k =>
+      k.sk || k.flick || k.multitap)));
+  if (filteredKeys && filteredKeys.length > 0) {
+    let gestureTable = `## ${name} Gesture Table\n`;
+    gestureTable += generateTable(formFactor, filteredKeys);
+
+    // Write Gesture Table to file
+    if (gestureTable) {
+      let filename = keyboardTouchChartFilename(name, formFactor);
+      fs.writeFileSync(filename, gestureTable, 'utf8');
+      console.log(`Gesture table written to ${filename}`);
+    }
+  } else {
+    console.log(`No gestures exist for ${name}`);
+  }
+}
+
+/**
+ * Create Markdown table
+ * @param formFactor phone or tablet
+ * @param filteredKeys Filtered touch layout object containing all the gestures
+ * @returns Markdown table as string
+ */
+function generateTable(formFactor: formFactorType, filteredKeys) : string {
+  let table = `### ${formFactor} Layout\n`;
+  for (let l in filteredKeys) {
+    let layer = filteredKeys[l];
+    let layerID = layer.id;
+    table += `#### ${layerID} Layer\n`;
+    for (let r in layer.row) {
+      let row = layer.row[r];
+      table += `##### Row ${row.id}\n`;
+      table += newTableHeader();
+      for (let k in row.key) {
+        // Print a new row
+        table += ` | `;
+
+        // Base Key
+        let key = row.key[k];
+        table += ` ${getTextFromKey(key)} `;
+        table += ` | `;
+
+        // Longpress
+        if (key.sk) {
+          for (let s in key.sk) {
+            let sk = key.sk[s];
+            table += ` ${getTextFromKey(sk)} `
+          }
+        }
+        table += ` | `;
+
+        // Flick
+        if (key.flick) {
+          for(let f in key.flick) {
+            let flick = key.flick[f];
+            table += ` '${f}': ${getTextFromKey(flick)} <br/>`;
+          }
+        }
+        table += ` | `;
+
+        // Multitap
+        if (key.multitap) {
+          for(let m in key.multitap) {
+            let multitap = key.multitap[m];
+            // Multitap is 0-indexed
+            table += ` ${parseInt(m)+1}x: ${getTextFromKey(multitap)} <br/> `;
+          }
+        }
+        table += ` |\n`;
+      }
+    }
+  }
+
+  return table;
+}
+
+function newTableHeader(): string {
+  return `|Base Key | Longpress | Flick | Multipress |\n` +
+         `|---------|-----------|-------|------------|\n`;
+}
+
+/**
+ * Determine the text for a key based on its "text", otherwise "id"
+ * Extra formatting for special Markdown characters
+ * @param key
+ * @returns string
+ */
+function getTextFromKey(key) : string {
+  let text = "";
+  if (key.text) {
+    if (key.text.startsWith('|')) {
+      // Handle vertical line character
+      text += key.text.replaceAll('|', '&#124;');
+    } else if (key.text.startsWith('_') || key.text.startsWith('*')) {
+      // Handle other special Markdown characters
+      text += ` \`${key.text}\` `;
+    } else {
+      text += ` ${key.text} `;
+    }
+  } else if (key.id) {
+    text += ` ${getTextFromID(key.id)} `;
+  }
+
+  return text;
+}
+
+/**
+ * Parse the key ID to determine the text (keycap)
+ * @param id
+ * @returns string
+ */
+function getTextFromID(id: string) : string {
+  let text = "", codes;
+  if (id.startsWith("U_")) {
+    // Parse U_XXXX or U_XXXX_YYYY
+    codes = id.substring(2).split('_');
+    for(let c in codes) {
+      text += `&#x${codes[c]};`;
+    }
+  } else if (id.startsWith("K_")) {
+    // Parse K_ID
+    text = id.substring(2);
+  } else {
+    text = `[${id}]`;
+    console.warn(`id ${id} doesn't start with U_`);
+  }
+  return text;
+}

--- a/tools/gestureChart/package-lock.json
+++ b/tools/gestureChart/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "gestureChart",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gestureChart",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.3.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.24",
+        "commander": "12.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    }
+  }
+}

--- a/tools/gestureChart/package.json
+++ b/tools/gestureChart/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gestureChart",
+  "version": "1.0.0",
+  "description": "",
+  "main": "gestureChart.js",
+  "scripts": {
+    "build": "tsc gestureChart.ts"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "typescript": "^5.3.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "commander": "12.0.0"
+  }
+}


### PR DESCRIPTION
Addresses #2213

This adds a gestureChart tool to document gestures in a touch layout as a Markdown table. Future TODO is incorporating the Markdown table into the welcome.htm / .php help docs. If we sync the .md file along with the .php help, the site could render it as
![image](https://github.com/keymanapp/keyboards/assets/7358010/205245b4-6e7f-4c2f-b3b1-e5f36d37b0c4)


As of 17.0, gestures can be:
* longpress
* flicks
* multitap


## Usage
```
node gestureChart.js -k <keyboard>
    -k, --keyboard <full path to keyboard directory>
```

Sample outputs:
Current sil_ipa gestures (on master)
[sil_ipa-tablet (current).md](https://github.com/keymanapp/keyboards/files/14517501/sil_ipa-tablet.current.md)

sil_ipa incorporating gestures from #2521
[sil_ipa-tablet.md](https://github.com/keymanapp/keyboards/files/14518490/sil_ipa-tablet.md)

rawang from #2554
[rawang-tablet.md](https://github.com/keymanapp/keyboards/files/14518469/rawang-tablet.md)
