### PR TITLE
[sil_tanguat] Build for 16.0

### DIFF
--- a/release/sil/sil_tanguat/sil_tanguat.keyboard_info
+++ b/release/sil/sil_tanguat/sil_tanguat.keyboard_info
@@ -1,0 +1,7 @@
+{
+  "license": "mit",
+  "languages": [
+    "tbs"
+  ],
+  "description": "This keyboard is designed for the Tanguat language of PNG."
+}

--- a/release/sil/sil_tanguat/sil_tanguat.kpj
+++ b/release/sil/sil_tanguat/sil_tanguat.kpj
@@ -1,8 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <KeymanDeveloperProject>
   <Options>
-    <Version>2.0</Version>
+    <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>True</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
   </Options>
+  <Files>
+    <File>
+      <ID>id_caa17db2739ae8db77ef908aaf9e2108</ID>
+      <Filename>sil_tanguat.kmn</Filename>
+      <Filepath>source\sil_tanguat.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Tanguat (SIL)</Name>
+        <Copyright>© SIL International</Copyright>
+        <Message>Keyboard for Tanguat language of PNG</Message>
+      </Details>
+    </File>
+    <File>
+      <ID>id_3a7335b4fd9484eece5b8039889117fb</ID>
+      <Filename>sil_tanguat.kps</Filename>
+      <Filepath>source\sil_tanguat.kps</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.kps</FileType>
+      <Details>
+        <Name>Tanguat (SIL)</Name>
+        <Copyright>© 2024 SIL International</Copyright>
+      </Details>
+    </File>
+  </Files>
 </KeymanDeveloperProject>

--- a/release/sil/sil_tanguat/source/sil_tanguat.kps
+++ b/release/sil/sil_tanguat/source/sil_tanguat.kps
@@ -7,7 +7,6 @@
   <Options>
     <ExecuteProgram></ExecuteProgram>
     <ReadMeFile>readme.htm</ReadMeFile>
-    <LicenseFile>..\LICENSE.md</LicenseFile>
     <MSIFileName></MSIFileName>
     <MSIOptions></MSIOptions>
     <FollowKeyboardVersion/>
@@ -20,7 +19,6 @@
     <Name URL="">Tanguat (SIL)</Name>
     <Copyright URL="">Copyright © SIL International</Copyright>
     <Author URL="">SIL International</Author>
-    <Description URL="">This keyboard is designed for the Tanguat language of PNG</Description>
     <Version URL=""></Version>
   </Info>
   <Files>
@@ -111,12 +109,7 @@
       <Languages>
         <Language ID="tbs">Tanguat</Language>
       </Languages>
-      <Examples>
-        <Example ID="tbs" Keys="hoci" Text="hoñi" Note="people"/>
-        <Example ID="tbs" Keys="acfr" Text="añər" Note="go"/>
-      </Examples>
     </Keyboard>
   </Keyboards>
-  <RelatedPackages/>
   <Strings/>
 </Package>


### PR DESCRIPTION
Follow-on to #2625 which failed to deploy because the .keyboard_info file was missing. Also because kmcomp in the CI build doesn't handle .kpj 2.0 format.

* Downgrade .kpj format to 1.0
* Add .keyboard_info file for keyboard deployment