### PR TITLE
[fv_all] - Add fv_sguuxs

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.8 (Apr 10 2024)
+* Add fv_sguuxs
+
 ## 12.7 (18 Mar 2024)
 * Fix keyboard versions
 

--- a/release/packages/fv_all/LICENSE.md
+++ b/release/packages/fv_all/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
+Copyright (c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/packages/fv_all/README.md
+++ b/release/packages/fv_all/README.md
@@ -1,7 +1,7 @@
 FirstVoices Keyboard Package
 ==================================================
 
-(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
+(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation
 
 __DESCRIPTION__
 

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -18,7 +18,7 @@
     <Copyright URL="">(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.7</Version>
+    <Version URL="">12.8</Version>
   </Info>
   <Files>
     <File>

--- a/release/packages/fv_all/source/readme.htm
+++ b/release/packages/fv_all/source/readme.htm
@@ -9,7 +9,7 @@
 
 <h1>FirstVoices Keyboard Package</h1>
 
-<p style='margin:0px'>(c) 2015-2023 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
+<p style='margin:0px'>(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</p>
        
 <p>This package includes all the FirstVoices keyboards for Windows and mobile. It is distributed as part of the FirstVoices project.</p>
 


### PR DESCRIPTION
Addresses the first part of #2675 
> * fv_all kps version in the [source file](https://github.com/keymanapp/keyboards/blob/02603516ed2382d610d5571a0cd2dbdd3fa4d416/release/packages/fv_all/source/fv_all.kps.in#L21)

Changes:
* Increments fv_all package so rebuilding fv_all will add fv_sguuxs (from #2648)
* Update copyright dates