### PR TITLE
fix special chars in keyboard help page names/titles

### DIFF
--- a/legacy/d/devu-mikes/source/help/devu-mikes.php
+++ b/legacy/d/devu-mikes/source/help/devu-mikes.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'DevnagriUnicode Mike&apos;s Keyboard Help';
+  $pagename = 'DevnagriUnicode Mike\'s Keyboard Help';
   $pagetitle = $pagename;
   // Header we will tidy up later  
   require_once('header.php');

--- a/release/gff/gff_awngi_xamtanga/source/help/gff_awngi_xamtanga.php
+++ b/release/gff/gff_awngi_xamtanga/source/help/gff_awngi_xamtanga.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'GFF Awngi &amp; Khimtanga';
+  $pagename = 'GFF Awngi & Khimtanga';
   $pagetitle = 'The Geʾez Frontier Foundation Keyboard for Awngi & Khimtanga Languages';
   $pagestyle = <<<END
   img.indented { text-indent: 10%}

--- a/release/gff/gff_gurage_legacy/source/help/gff_gurage_legacy.php
+++ b/release/gff/gff_gurage_legacy/source/help/gff_gurage_legacy.php
@@ -1,6 +1,6 @@
 <?php 
   $pagename = "GFF Gurage (Legacy) Keyboard Help";
-  $pagetitle = "The Ge&rsquo;ez Frontier Foundation Keyboard for Ge&rsquo;ez Language";
+  $pagetitle = "The Geʾez Frontier Foundation Keyboard for Geʾez Language";
   $pagestyle = <<<END
   img.indented { text-indent: 10%}
 

--- a/release/sil/sil_nko/source/help/sil_nko.php
+++ b/release/sil/sil_nko/source/help/sil_nko.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'N&rsquo;Ko (SIL) Keyboard Help';
+  $pagename = 'NʾKo (SIL) Keyboard Help';
   $pagetitle = $pagename;
   // Header we will tidy up later  
   require_once('header.php');


### PR DESCRIPTION
Relates to keymanapp/help.keyman.com#1209

where @mcdurdin said
> The correct fix is to take the HTML entities out of the $pagetitle in the affected pages in keyboards.

This updates the current help pages for:
* devu-mikes
* gff_awngi_xamtanga
* gff_gurage_legacy
* sil_nko