### PR TITLE
fv_henqeminem - minor changes

### DIFF
--- a/release/fv/fv_henqeminem/HISTORY.md
+++ b/release/fv/fv_henqeminem/HISTORY.md
@@ -1,5 +1,9 @@
 hǝn̓q̓ǝmin̓ǝm̓ Change History
 ============================
+10.1 (10 May 2024)
+-------------------
+* Added a rule for backspacing vowels with acute accent
+* Added colon to the mobile layout, moved middle dot to longpress
 
 10.0.1 (1 Apr 2024)
 -------------------

--- a/release/fv/fv_henqeminem/fv_henqeminem.kpj
+++ b/release/fv/fv_henqeminem/fv_henqeminem.kpj
@@ -12,7 +12,7 @@
       <ID>id_a09fca24697e871964e4a6f051397ee4</ID>
       <Filename>fv_henqeminem.kmn</Filename>
       <Filepath>source\fv_henqeminem.kmn</Filepath>
-      <FileVersion>10.0.1</FileVersion>
+      <FileVersion>10.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>hǝn̓q̓ǝmin̓ǝm̓</Name>

--- a/release/fv/fv_henqeminem/source/fv_henqeminem.keyman-touch-layout
+++ b/release/fv/fv_henqeminem/source/fv_henqeminem.keyman-touch-layout
@@ -316,8 +316,14 @@
                 "sp": 1
               },
               {
-                "id": "T_middot",
-                "text": "•"
+                "id": "T_long",
+                "text": ":",
+                "sk": [
+                  {
+                    "text": "•",
+                    "id": "T_long_0"
+                  }
+                ]
               },
               {
                 "id": "K_SPACE",
@@ -697,8 +703,14 @@
                 "sp": 1
               },
               {
-                "id": "T_middot",
-                "text": "•"
+                "id": "T_long",
+                "text": ":",
+                "sk": [
+                  {
+                    "text": "•",
+                    "id": "T_long_0"
+                  }
+                ]
               },
               {
                 "id": "K_SPACE",

--- a/release/fv/fv_henqeminem/source/fv_henqeminem.kmn
+++ b/release/fv/fv_henqeminem/source/fv_henqeminem.kmn
@@ -1,6 +1,6 @@
 ﻿
 store(&VERSION) "10.0"
-store(&KEYBOARDVERSION) '10.0.1'
+store(&KEYBOARDVERSION) '10.1'
 store(&TARGETS) "any"
 c store(&ETHNOLOGUECODE) "hur"
 store(&COPYRIGHT) '(c) 2008-2024 FirstVoices, SIL International. Portions (c) 2006 Chris Harvey'
@@ -45,7 +45,8 @@ C capital letters (mobile shifted layer)
 + [SHIFT T_A] > 'A' layer('default')
 + [SHIFT T_S] > 'S' layer('default')
 + [SHIFT T_D] > 'D' layer('default')
-+ [SHIFT T_middot] > '·' layer('default')
++ [SHIFT T_long_0] > '·' layer('default')
++ [SHIFT T_long] > ':' layer('default')
 + [SHIFT T_G_0] > 'T̓ᶿ' layer('default')
 + [SHIFT T_G] > 'Θ' layer('default')
 + [SHIFT T_H] > 'H' layer('default')
@@ -140,7 +141,8 @@ C lowercase letters (mobile unshifted layer)
 + [T_N] > 'n'
 + [T_M_0] > 'm̓'
 + [T_M] > 'm'
-+[T_middot] > '·'
++[T_long_0] > '·'
++[T_long] > ':'
 
 C combining glottal (with UNSHIFTED layer deadkey)
 'p' + [T_F] > 'p̓'
@@ -207,6 +209,11 @@ store(nohacek) 'cCsS'
 store(backspace) [K_BKSP]
 
 any(withhacek) + any(backspace) > index(nohacek,1)
+
+c rules for backspacing vowels with accent
+store(plainvowels) "aeiouAEIOU"
+store(acutevowels) "áéíóúÁÉÍÓÚ"
+any(acutevowels) + [K_BKSP] > index(plainvowels,1)
 
                   
 c ******


### PR DESCRIPTION
MOBILE - added colon, moved middle dot to longpress. GENERAL - added a rule for backspacing vowels with acute accent