### PR TITLE
[fv_all] Add keyboards.csv to fv_all.kmp package

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.10 (May 18 2024)
+* Add keyboards.csv file
+
 ## 12.9 (May 10 2024)
 * Add fv_nlakapamuxcheen
 * Add desktop keyboard for fv_nlha7kapmxtsin

--- a/release/packages/fv_all/build.sh
+++ b/release/packages/fv_all/build.sh
@@ -113,10 +113,15 @@ for keyboard in ../../fv/*/ ../../i/inuktitut_*/ ../../sil/sil_euro_latin/ ../..
 
   version=$(cat $keyboardInfo | $JQ -r '.version')
 
-  # Override sil_euro_latin keyboard to English language
+  # Override info for European keyboards (multi-lingual)
   if [[ $id = 'sil_euro_latin' ]]; then
+    name="English"
     bcp47="en"
     langname="English"
+  elif [[ $id = 'basic_kbdcan' ]]; then
+    name="Français"
+    bcp47="fr-CA"
+    langname="French (Canada)"
   fi
 
   # Build a file entry

--- a/release/packages/fv_all/keyboards.csv
+++ b/release/packages/fv_all/keyboards.csv
@@ -1,0 +1,101 @@
+ID,Region,,
+fv_inuvialuktun,Arctic
+inuktitut_pirurvik,Arctic
+inuktitut_latin,Arctic
+inuktitut_naqittaut,Arctic
+fv_uummarmiutun,Arctic
+fv_eastern_canadian_inuktitut,Arctic
+fv_migmaq,Atlantic
+fv_skicinuwatuwewakon,Atlantic
+fv_uwikala,BC Coast
+fv_dexwlesucid,BC Coast
+fv_diitiidatx,BC Coast
+fv_gitsenimx,BC Coast
+fv_hailzaqvla,BC Coast
+fv_haisla,BC Coast
+fv_halqemeylem,BC Coast
+fv_henqeminem,BC Coast
+fv_klahoose,BC Coast
+fv_hulquminum,BC Coast
+fv_hulquminum_combine,BC Coast
+fv_kwakwala_liqwala,BC Coast
+fv_kwakwala,BC Coast
+fv_nexwslayemucen,BC Coast
+fv_nisgaa,BC Coast
+fv_nuucaanul,BC Coast
+fv_nuxalk,BC Coast
+fv_sencoten,BC Coast
+fv_sguuxs,BC Coast
+fv_shashishalhem,BC Coast
+fv_skwxwumesh_snichim,BC Coast
+fv_smalgyax,BC Coast
+fv_xaislakala,BC Coast
+fv_hlgaagilda_xaayda_kil,BC Coast
+fv_dakelh,BC Interior
+fv_ktunaxa,BC Interior
+fv_kwadacha_tsekene,BC Interior
+fv_natwits,BC Interior
+fv_nlekepmxcin,BC Interior
+fv_nlha7kapmxtsin,BC Interior
+fv_nlakapamuxcheen,BC Interior
+fv_nsilxcen,BC Interior
+fv_secwepemctsin,BC Interior
+fv_stlatlimxec,BC Interior
+fv_statimcets,BC Interior
+fv_taltan,BC Interior
+fv_tsekehne,BC Interior
+fv_tsilhqotin,BC Interior
+fv_southern_carrier,BC Interior
+fv_anicinapemi8in,Eastern Subarctic
+fv_atikamekw,Eastern Subarctic
+fv_ilnu_innu_aimun,Eastern Subarctic
+fv_swampy_cree,Eastern Subarctic
+fv_moose_cree,Eastern Subarctic
+fv_northern_east_cree,Eastern Subarctic
+fv_severn_ojibwa,Eastern Subarctic
+fv_ojibwa,Eastern Subarctic
+fv_naskapi,Eastern Subarctic
+sil_euro_latin,European
+basic_kbdcan,European
+fv_anishinaabemowin,Great Lakes - St. Lawrence
+fv_bodewadminwen,Great Lakes - St. Lawrence
+fv_goyogohono,Great Lakes - St. Lawrence
+fv_kanienkeha_e,Great Lakes - St. Lawrence
+fv_lunaapeewi_huluniixsuwaakan,Great Lakes - St. Lawrence
+fv_onodagega_onondagega,Great Lakes - St. Lawrence
+fv_onodowaga,Great Lakes - St. Lawrence
+fv_onayotaaka,Great Lakes - St. Lawrence
+fv_skaru_re,Great Lakes - St. Lawrence
+fv_wendat,Great Lakes - St. Lawrence
+fv_wobanakiodwawogan,Great Lakes - St. Lawrence
+fv_australian,Pacific
+fv_maori,Pacific
+fv_blackfoot,Prairies
+fv_cree_latin,Prairies
+fv_dakota_mb,Prairies
+fv_dakota_sk,Prairies
+fv_isga_iabi,Prairies
+fv_lakota,Prairies
+fv_nakoda,Prairies
+fv_tsuutina,Prairies
+fv_plains_cree,Prairies
+fv_dine_bizaad,South West
+fv_dane_zaa_zaage,Western Subarctic
+fv_dene_dzage,Western Subarctic
+fv_dene_zhatie,Western Subarctic
+fv_denesuline_epsilon,Western Subarctic
+fv_denesuline,Western Subarctic
+fv_gwichin,Western Subarctic
+fv_han,Western Subarctic
+fv_kashogotine_yati,Western Subarctic
+fv_tlingit,Western Subarctic
+fv_neeaandeg,Western Subarctic
+fv_neeaaneegn,Western Subarctic
+fv_northern_tutchone,Western Subarctic
+fv_sahugotine_yati,Western Subarctic
+fv_shihgotine_yati,Western Subarctic
+fv_southern_tutchone,Western Subarctic
+fv_tagizi_dene,Western Subarctic
+fv_tlicho_yatii,Western Subarctic
+fv_dene_mb,Western Subarctic
+fv_dene_nt,Western Subarctic

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -18,7 +18,7 @@
     <Copyright URL="">(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.9</Version>
+    <Version URL="">12.10</Version>
   </Info>
   <Files>
     <File>
@@ -26,6 +26,12 @@
       <Description>File readme.htm</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.htm</FileType>
+    </File>
+    <File>
+      <Name>..\keyboards.csv</Name>
+      <Description>File keyboards.csv</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.csv</FileType>
     </File>
     <File>
       <Name>..\..\..\shared\fonts\canadian_aboriginal\AboriginalSansBOLD.ttf</Name>


### PR DESCRIPTION
Relates to Keyman 18.0 work for keymanapp/keyman#2036

This brings in [keyboards.csv](https://github.com/keymanapp/keyman/blob/master/oem/firstvoices/keyboards.csv) file to the keyboards repro for FV to maintain and includes it in the fv_all.kmp package.

Changes to keyboards.csv
* Streamline columns to ID, Region
* fv_all/build.sh script overrides name and language info for basic_kbdcan and sil_euro_latin

Also bumps fv_all version to 12.10.

Note, the fv_all.kps.in template is still for the kmcomp 16.0 compiler.
TODO to migrate it to staging-17.0 format.