### PR TITLE
[fv_gitsenimx] Fix help links to png file

### DIFF
--- a/release/fv/fv_gitsenimx/source/help/fv_gitsenimx.php
+++ b/release/fv/fv_gitsenimx/source/help/fv_gitsenimx.php
@@ -19,7 +19,7 @@ This keyboard is designed for the <b>Gitxsanimx̱-Gitsenimx̱-Gyaanimx̱</b> lan
 </p>
 
 <h2>Desktop Layout</h2>
-<img src="fv_gitxsenimx_U_.png" alt="" height="198" width="514" border="0" /></h2>
+<img src="fv_gitsenimx_U_.png" alt="" height="198" width="514" border="0" /></h2>
 					<ul>
 						<li>All accents are typed after the base character: x̱ is typed a then Semicolon ;</li>
 						<li>To type the underline accent use the Semicolon key ; — ḵ is typed k then Semicolon ;</li>

--- a/release/fv/fv_gitsenimx/source/welcome/welcome.htm
+++ b/release/fv/fv_gitsenimx/source/welcome/welcome.htm
@@ -23,7 +23,7 @@ a:active {	color: rgb(102,117,184); text-decoration:none;}
     <td colspan="2"><a href="http://www.firstvoices.com"><img src="FVLogo.gif" width="200" height="48" border="0" /></a>
      
     <h2>Desktop Layout</h2>  
-    <h2><img src="fv_gitxsenimx_U_.png" alt="" height="198" width="514" border="0" /></h2>
+    <h2><img src="fv_gitsenimx_U_.png" alt="" height="198" width="514" border="0" /></h2>
 					<ul>
 						<li>All accents are typed after the base character: x̱ is typed a then Semicolon ;</li>
 						<li>To type the underline accent use the Semicolon key ; — ḵ is typed k then Semicolon ;</li>


### PR DESCRIPTION
Fixes help deployment fail on [keymanapp/help.keyman.com#2100](https://github.com/keymanapp/help.keyman.com/actions/runs/9119237009/job/25074170077)

The png filename is **fv_gitsenimx_U_.png**

No version update since this is just help documentation.