### PR TITLE
chore: upgrade to kmc 17.0.326

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ function do_clean_targets() {
 #------------------------------------------------------------
 
 function do_configure() {
-  npm install --no-optional
+  npm ci --omit=optional
   builder_echo "kmc version: $($KMC --version)"
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,49 +9,49 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/kmc": "17.0.325"
+        "@keymanapp/kmc": "17.0.326"
       }
     },
     "node_modules/@keymanapp/common-types": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/common-types/-/common-types-17.0.325.tgz",
-      "integrity": "sha512-77KUn1SgLXjo0Vi4/5NRMmS3OtraPgjpaC7q5cHB/xcDpWYdM1OP+v1IsU4PLHsR9YqQpkboInH4WAImyk41qQ==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/common-types/-/common-types-17.0.326.tgz",
+      "integrity": "sha512-6At2SOLv8O3032pJZHkeWAjZTeGavyHC7YYCtujraeRyL99RxtvbebZJxXrHp0hTE661lug9wyHKmxhfBXOnXw==",
       "dependencies": {
-        "@keymanapp/keyman-version": "17.0.325",
+        "@keymanapp/keyman-version": "17.0.326",
         "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
         "semver": "^7.5.2",
         "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js.git#535fe732dc408d697e0f847c944cc45f0baf0829"
       }
     },
     "node_modules/@keymanapp/developer-utils": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/developer-utils/-/developer-utils-17.0.325.tgz",
-      "integrity": "sha512-yuCgSojt7vVLKY3866puQiMh0TzFQJIKWGziI2IE2l13zxWRqOmxEu5tIwPKNzPvjz6KLba0j1fcjc8Mfd/Dvg==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/developer-utils/-/developer-utils-17.0.326.tgz",
+      "integrity": "sha512-tkmAdrKB7o1KysWXYzvMpGriKJvN1O++YBwy4f7UQ4xtO73k3O2MMdyDpMPBpOr4DaQ693fhCAfLSCsoboB29Q==",
       "dependencies": {
         "@sentry/node": "^7.57.0"
       }
     },
     "node_modules/@keymanapp/keyman-version": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-17.0.325.tgz",
-      "integrity": "sha512-tkBbhuuW9AOXgxgn+zCE79lClPWxNzXoz+tX0EGA6+rbqZJB+qcJt4IPn00a7R+yLcwyZejKYAvHeEQUW8X2Lw=="
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-17.0.326.tgz",
+      "integrity": "sha512-HUkedYMqzjcn/iiVy2SXty3X1JZ53gkZZzNNmHvgv9EUgvtLqEYEOfueNlKNezHiVD9teaZy2t/DafHr3I+97Q=="
     },
     "node_modules/@keymanapp/kmc": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc/-/kmc-17.0.325.tgz",
-      "integrity": "sha512-mXfvbxp/7ou9tQpga05LDTa4Pd6DRnt2vWbaXih6D4xQ0OfhDhsjusPG+4s5bopLPA+FQ7a8qWcXlAbSNXF7hw==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc/-/kmc-17.0.326.tgz",
+      "integrity": "sha512-7oU6B+9hAetbN7BNMVaHv8QH94pzPrA3xhWaA5nYeJO8LH1DM2ohR7N1gANenveTWU2TFWp+tDgMkD58+gOCrQ==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
-        "@keymanapp/developer-utils": "17.0.325",
-        "@keymanapp/keyman-version": "17.0.325",
-        "@keymanapp/kmc-analyze": "17.0.325",
-        "@keymanapp/kmc-keyboard-info": "17.0.325",
-        "@keymanapp/kmc-kmn": "17.0.325",
-        "@keymanapp/kmc-ldml": "17.0.325",
-        "@keymanapp/kmc-model": "17.0.325",
-        "@keymanapp/kmc-model-info": "17.0.325",
-        "@keymanapp/kmc-package": "17.0.325",
-        "@keymanapp/models-types": "17.0.325",
+        "@keymanapp/common-types": "17.0.326",
+        "@keymanapp/developer-utils": "17.0.326",
+        "@keymanapp/keyman-version": "17.0.326",
+        "@keymanapp/kmc-analyze": "17.0.326",
+        "@keymanapp/kmc-keyboard-info": "17.0.326",
+        "@keymanapp/kmc-kmn": "17.0.326",
+        "@keymanapp/kmc-ldml": "17.0.326",
+        "@keymanapp/kmc-model": "17.0.326",
+        "@keymanapp/kmc-model-info": "17.0.326",
+        "@keymanapp/kmc-package": "17.0.326",
+        "@keymanapp/models-types": "17.0.326",
         "@sentry/node": "^7.57.0",
         "chalk": "^2.4.2",
         "commander": "^10.0.0",
@@ -64,123 +64,122 @@
       }
     },
     "node_modules/@keymanapp/kmc-analyze": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-analyze/-/kmc-analyze-17.0.325.tgz",
-      "integrity": "sha512-wemaX4q0eaRM41ognZcIHGoj/OlGV1Ar1Bs7vOjH/9mV3TU7PbOQ7qQp5i3hfMhMJJ2NSSex0eYSob4V+5qOdA==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-analyze/-/kmc-analyze-17.0.326.tgz",
+      "integrity": "sha512-bOxzDUnT59k6Y2UsjSQvKnkN0yfNbUQrlFg8oy7GDdwtFd3pY0AS0Gt4kCAlK2hStYI25M/oaCGnPA8hbwUr8w==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
-        "@keymanapp/developer-utils": "17.0.325",
-        "@keymanapp/kmc-kmn": "17.0.325"
+        "@keymanapp/common-types": "17.0.326",
+        "@keymanapp/developer-utils": "17.0.326",
+        "@keymanapp/kmc-kmn": "17.0.326"
       }
     },
     "node_modules/@keymanapp/kmc-keyboard-info": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-keyboard-info/-/kmc-keyboard-info-17.0.325.tgz",
-      "integrity": "sha512-U6PC76bfTNhSEkZkhKqMnaX6NID4oxJ7c05VVptqm/nUJMVPtKfyT0GWaV+q6s47/nM52Ckx/m+tgsHNnIWSAg==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-keyboard-info/-/kmc-keyboard-info-17.0.326.tgz",
+      "integrity": "sha512-RgaH0KQGMrgE6KFHOetbaZkft3UGw62klXfrjraiytI5sbICWFwCsvlNw/Rw9SXppxmRhn0Yt5Wv7e7AV2tROA==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
-        "@keymanapp/developer-utils": "17.0.325",
-        "@keymanapp/kmc-package": "17.0.325",
-        "ttfmeta": "^1.1.2"
+        "@keymanapp/common-types": "17.0.326",
+        "@keymanapp/developer-utils": "17.0.326",
+        "@keymanapp/kmc-package": "17.0.326"
       }
     },
     "node_modules/@keymanapp/kmc-kmn": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-kmn/-/kmc-kmn-17.0.325.tgz",
-      "integrity": "sha512-kb/TBF7JpWl8OnOWkCCc18ZDDev4TEpU04Nj69EXJMFnm1/hFH1I+w6koLLFkw1/pefvlbjy3IAsBOZ7gdrMtA==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-kmn/-/kmc-kmn-17.0.326.tgz",
+      "integrity": "sha512-2m3E7Nj5C5mSbOkDfMX4vG6H5Sll4mlTsDYkvxy7k6tpvZBCEKrflT3pvZ4SH9IOPG1mj0OQMb7NAM2sh/Hkdw==",
       "dependencies": {
-        "@keymanapp/developer-utils": "17.0.325",
-        "@keymanapp/keyman-version": "17.0.325",
-        "@keymanapp/kmc-kmn": "17.0.325"
+        "@keymanapp/developer-utils": "17.0.326",
+        "@keymanapp/keyman-version": "17.0.326",
+        "@keymanapp/kmc-kmn": "17.0.326"
       }
     },
     "node_modules/@keymanapp/kmc-ldml": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-ldml/-/kmc-ldml-17.0.325.tgz",
-      "integrity": "sha512-s9ihnOaNhzBNlTesgpKfTmwsMrv2oik/a5tfrcNf27lZBkkvkT2FNmucHcjyD/fm3bfa66zhcLQ2Uowi9wT9YQ==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-ldml/-/kmc-ldml-17.0.326.tgz",
+      "integrity": "sha512-CLZT5W8Zoe0taTOGcp3s0cukJ01Xz9wVlvRzSqGkXhhfcKTafp6+jxMSTPB4HycM6kklcGrWwQgozZdFbRhg3g==",
       "dependencies": {
-        "@keymanapp/keyman-version": "17.0.325",
-        "@keymanapp/kmc-kmn": "17.0.325",
-        "@keymanapp/ldml-keyboard-constants": "17.0.325",
+        "@keymanapp/keyman-version": "17.0.326",
+        "@keymanapp/kmc-kmn": "17.0.326",
+        "@keymanapp/ldml-keyboard-constants": "17.0.326",
         "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
         "semver": "^7.5.2"
       }
     },
     "node_modules/@keymanapp/kmc-model": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model/-/kmc-model-17.0.325.tgz",
-      "integrity": "sha512-l8sjh22kZZHZeRqi5ZyNtn31mv/2hrJPVA5TcqgB+59s4O3iP8ynxmHPE3H8kVdJv4o71of69xXmVcOLK2rHQA==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model/-/kmc-model-17.0.326.tgz",
+      "integrity": "sha512-RjtXfnEhd2GZhOnG1gOXtAbt+JSGPzOsRK3WmQ0ZZEnczwEq2B60pmqN+FN3VDwNQ6WR5bFcFcfDcrZ91RaPIA==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
-        "@keymanapp/keyman-version": "17.0.325",
-        "@keymanapp/models-types": "17.0.325",
+        "@keymanapp/common-types": "17.0.326",
+        "@keymanapp/keyman-version": "17.0.326",
+        "@keymanapp/models-types": "17.0.326",
         "typescript": "^4.9.5"
       }
     },
     "node_modules/@keymanapp/kmc-model-info": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model-info/-/kmc-model-info-17.0.325.tgz",
-      "integrity": "sha512-L+WST51fWrp5e4dJ3dm3LSeWidPpBPiQQSxJ8/GSwDo8N05d+9IGxAic9unPfgnAZapIp4hU84LGcqIZF/VQYA==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model-info/-/kmc-model-info-17.0.326.tgz",
+      "integrity": "sha512-Dq/9lcvXPP2bzMTh8GGZ92ySBTIgsGX0bDSPOigUH8mX2UdHzhCK8rbJG5PpMEPeZptvBcb21vHzDPg+gc4Rbw==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
-        "@keymanapp/developer-utils": "17.0.325",
-        "@keymanapp/models-types": "17.0.325"
+        "@keymanapp/common-types": "17.0.326",
+        "@keymanapp/developer-utils": "17.0.326",
+        "@keymanapp/models-types": "17.0.326"
       }
     },
     "node_modules/@keymanapp/kmc-package": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-package/-/kmc-package-17.0.325.tgz",
-      "integrity": "sha512-uFNvvYBfXYPnUcAeHu6FRmTVzBHTFW/zuuS/Yer1H1X6a1XGknOTFqOSmzGgt47Nxa3GIOfWkTPjnbKajn7hkA==",
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-package/-/kmc-package-17.0.326.tgz",
+      "integrity": "sha512-Le4H35bPNPR8dNY15zdBD+MsGWAZEiVb4Mo/I/p07zjCfsArIHVxZMNPaKbnX8nan6iF0/dxjV0XLs/2kBJxoQ==",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.325",
+        "@keymanapp/common-types": "17.0.326",
         "jszip": "^3.7.0",
         "marked": "^7.0.0",
         "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js.git#535fe732dc408d697e0f847c944cc45f0baf0829"
       }
     },
     "node_modules/@keymanapp/ldml-keyboard-constants": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/ldml-keyboard-constants/-/ldml-keyboard-constants-17.0.325.tgz",
-      "integrity": "sha512-mVJBV7gtRCMlgU4qVEvPzgCHYz5VFgMbj2r67tH5uGFpila0OGbYTPlgKGftuE/aOpW6YdAh2j9w+ZE52SAKEA=="
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/ldml-keyboard-constants/-/ldml-keyboard-constants-17.0.326.tgz",
+      "integrity": "sha512-pLS7twSvlYcJib9zPJp7sr67cZZsKwH3OOAFhFl5KwOyP+ReuXuxMEsB8xAQskR90PZO+nKLt6Slm5dI4RFf/g=="
     },
     "node_modules/@keymanapp/models-types": {
-      "version": "17.0.325",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-17.0.325.tgz",
-      "integrity": "sha512-QA7Ht+NZ8oi+z8Y9f9rCLJJViQmbUlZCp1lToGvmkTiGtSOamNLFPvs0w7JI4dXYCB2FoZZjcxMMHnAlKMVaIg=="
+      "version": "17.0.326",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-17.0.326.tgz",
+      "integrity": "sha512-0Cx5wlF5wIPcrtAOUMNIkEL2snwYOrNNDyvN+KmJp4uQqjBO2FCJUl1fDM4nTNebIvrtTAVFyjQN/Qpdb5cwUg=="
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.115.0.tgz",
-      "integrity": "sha512-n1w3eJadvzkL4HebjtJGHre8Z9WbYpPw5GxSNI8ZFM+OTnhzzCAEcNL2C4tr7ssD2Lkao4+N3KaigJi54geOmg==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.116.0.tgz",
+      "integrity": "sha512-y5ppEmoOlfr77c/HqsEXR72092qmGYS4QE5gSz5UZFn9CiinEwGfEorcg2xIrrCuU7Ry/ZU2VLz9q3xd04drRA==",
       "dependencies": {
-        "@sentry/core": "7.115.0",
-        "@sentry/types": "7.115.0",
-        "@sentry/utils": "7.115.0"
+        "@sentry/core": "7.116.0",
+        "@sentry/types": "7.116.0",
+        "@sentry/utils": "7.116.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.115.0.tgz",
-      "integrity": "sha512-LSacE6rY/pJY4esXdLex5qVjo82DX6sQuvDLcEcR00bvRWGWMxSi2SipeW4RLbKmYyi0Ub+T+tUJxIOViyqyXw==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.116.0.tgz",
+      "integrity": "sha512-J6Wmjjx+o7RwST0weTU1KaKUAlzbc8MGkJV1rcHM9xjNTWTva+nrcCM3vFBagnk2Gm/zhwv3h0PvWEqVyp3U1Q==",
       "dependencies": {
-        "@sentry/types": "7.115.0",
-        "@sentry/utils": "7.115.0"
+        "@sentry/types": "7.116.0",
+        "@sentry/utils": "7.116.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.115.0.tgz",
-      "integrity": "sha512-0a75FIfG2mLPTmQ2QYFYoh3yvHqGT+D4SBAcsWVZEG24lNCiofSHnjffzIOXZX+2Spi1nY+cxIt9ItSyS2Z8VQ==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.116.0.tgz",
+      "integrity": "sha512-UZb60gaF+7veh1Yv79RiGvgGYOnU6xA97H+hI6tKgc1uT20YpItO4X56Vhp0lvyEyUGFZzBRRH1jpMDPNGPkqw==",
       "dependencies": {
-        "@sentry/core": "7.115.0",
-        "@sentry/types": "7.115.0",
-        "@sentry/utils": "7.115.0",
+        "@sentry/core": "7.116.0",
+        "@sentry/types": "7.116.0",
+        "@sentry/utils": "7.116.0",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -188,34 +187,34 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.115.0.tgz",
-      "integrity": "sha512-Y8kiwHqiICLkraSTsm7O/MWkfakRXOjhwpv4f3f+5CmPIigW0YCMTQZ3sSX+NhnvDhdkmakWy3tH9CX8+T2Ykg==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.116.0.tgz",
+      "integrity": "sha512-HB/4TrJWbnu6swNzkid+MlwzLwY/D/klGt3R0aatgrgWPo2jJm6bSl4LUT39Cr2eg5I1gsREQtXE2mAlC6gm8w==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.115.0",
-        "@sentry/core": "7.115.0",
-        "@sentry/integrations": "7.115.0",
-        "@sentry/types": "7.115.0",
-        "@sentry/utils": "7.115.0"
+        "@sentry-internal/tracing": "7.116.0",
+        "@sentry/core": "7.116.0",
+        "@sentry/integrations": "7.116.0",
+        "@sentry/types": "7.116.0",
+        "@sentry/utils": "7.116.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.115.0.tgz",
-      "integrity": "sha512-KbhDS0DX+lk9VFCCR4AwPdiU9KUAH+vI+5HBLlgCNMY7KRGxRLnpXi3VyGi80iRdt2gi8sg2ncsVhc+SunBx7w==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.116.0.tgz",
+      "integrity": "sha512-QCCvG5QuQrwgKzV11lolNQPP2k67Q6HHD9vllZ/C4dkxkjoIym8Gy+1OgAN3wjsR0f/kG9o5iZyglgNpUVRapQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.115.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.115.0.tgz",
-      "integrity": "sha512-MhrpHOMPwsjlXE3vnfFFyexneozPluaMCgL7MzH2iL0m7FxXG8A9CEe7W9sVG8hh1kw8ksYz1ryb2Mx2L+UTJA==",
+      "version": "7.116.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.116.0.tgz",
+      "integrity": "sha512-Vn9fcvwTq91wJvCd7WTMWozimqMi+dEZ3ie3EICELC2diONcN16ADFdzn65CQQbYwmUzRjN9EjDN2k41pKZWhQ==",
       "dependencies": {
-        "@sentry/types": "7.115.0"
+        "@sentry/types": "7.116.0"
       },
       "engines": {
         "node": ">=8"
@@ -386,8 +385,7 @@
     "node_modules/restructure": {
       "version": "3.0.0",
       "resolved": "git+ssh://git@github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
-      "integrity": "sha512-TxgE+TFgblOfmvJyv9TCzABfDo4nvNHeYD0+awQ5UoE/KhSuENJ1Uhc1rtegx8SbmvI3nqXFaHgnVATNcCOhXw==",
-      "license": "MIT"
+      "integrity": "sha512-8fnsPzbRwc78uoJbdoQIH6QbAFlI5reezVfmFkcaLB08ZyZevPyoK2aR/gg6ue4pYIqrshEi0f9cx6GB1qRSew=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -395,9 +393,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -434,14 +432,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/ttfmeta": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ttfmeta/-/ttfmeta-1.1.2.tgz",
-      "integrity": "sha512-x0mKp7IkWjEa6CpI4/6HdCA3lzk8PaSBF5hubq03G2HyIzuDSdZRrO1dYgW4XD7q4sFdEWXSMYw7j0pzl4Ty6Q==",
-      "engines": {
-        "node": ">=16.0"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -462,8 +452,7 @@
     "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "git+ssh://git@github.com/keymanapp/dependency-node-xml2js.git#535fe732dc408d697e0f847c944cc45f0baf0829",
-      "integrity": "sha512-5CS+yWxp0qg8zO7ng/iXrBZm2FXgpiJ+RJ3E0LzRxDXChESqzazRwzl8sXYe8/7je/NfwG4EXcClaRKUkcIvtQ==",
-      "license": "MIT",
+      "integrity": "sha512-IHudpUj5OPA+0eCLSJPoFE33zBUs3m5Z2DDOxdtBhbw07YIgh6niCd3ySnhmNEgcaWYiktRyTitE0K2a6ozodg==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/keymanapp/keyboards#readme",
   "dependencies": {
-    "@keymanapp/kmc": "17.0.325"
+    "@keymanapp/kmc": "17.0.326"
   }
 }


### PR DESCRIPTION
Also moves to npm ci instead of npm install for consistent versioning