### PR TITLE
fix: remove codesign.sh and fix util.inc.sh reference in ci.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -37,8 +37,7 @@ else
 fi
 
 . "$KEYBOARDROOT/servervars.sh"
-. "$KEYBOARDROOT/resources/util.sh"
-. "$KEYBOARDROOT/resources/codesign.sh"
+. "$KEYBOARDROOT/resources/util.inc.sh"
 . "$KEYBOARDROOT/resources/rsync-tools.sh"
 
 function parse_args {


### PR DESCRIPTION
After merging staging-17.0, found that ci.sh still had references to old include scripts.