### PR TITLE
fix: restore color variables and die() function to util.inc.sh

### DIFF
--- a/docs/custom-build-script.md
+++ b/docs/custom-build-script.md
@@ -1,12 +1,12 @@
 
-The following example shows how to create a minimal build script for a keyboard. 
+The following example shows how to create a minimal build script for a keyboard.
 If you don't need a custom build step, don't include a build script in the keyboard.
 
 ````bash
 #!/bin/bash
 echo A custom build.sh script for a release/ keyboard
 
-. ../../../resources/util.sh
+. ../../../resources/util.inc.sh
 
 parse_args $@
 

--- a/resources/help-keyman-com.sh
+++ b/resources/help-keyman-com.sh
@@ -66,7 +66,7 @@ CI_CACHE="$KEYBOARDROOT/.cache"
 keyboards_to_push=0
 
 . "$KEYBOARDROOT/servervars.sh"
-. "$KEYBOARDROOT/resources/util.sh"
+. "$KEYBOARDROOT/resources/util.inc.sh"
 
 echo "Uploading keyboard documentation to help.keyman.com"
 


### PR DESCRIPTION
These were removed as part of the builder script implementation of build.sh in the staging-17.0 branch, but I neglected to check other usages. Safer to put them back (copied out of util.sh pre-merge), and then we can tidily remove them again in the future.