### PR TITLE
[obolo_chwerty] Revert png filenames in help

### DIFF
--- a/release/o/obolo_chwerty/source/help/obolo_chwerty.php
+++ b/release/o/obolo_chwerty/source/help/obolo_chwerty.php
@@ -46,13 +46,13 @@ The position of your BACKSLASH key depends on type of keyboard you are using.
 <p>The three keyboard types and the respective position of the BACKSLASH keys are shown below.
 <p>You can tell where your BACKSLASH key is by looking at the shape of your ENTER/RETURN key:
 <p>
- <img src="chwertyftenterkey1.png"
+ <img src="chwertyftkey1.png"
 alt="ANSI Keyboard">
 <p>
-<img src="chwertyftenterkey2.png"
+<img src="chwertyftkey2.png"
 alt="ISO/JIS Keyboard">
 <p>
-<img src="chwertyftenterkey3.png"
+<img src="chwertyftkey3.png"
 alt="Backward-L Keyboard">
 <p>
 Keyman ... type to the world in your language.


### PR DESCRIPTION
Reverts the png references that were changed in #2804.

Since the png filenames stayed the same in welcome.htm, I elected to use the original filenames.

To fix the failing help deployment on keymanapp/help.keyman.com#1305
