### PR TITLE
fix: support build of just fv_all from build.sh

### DIFF
--- a/resources/build_targets.inc.sh
+++ b/resources/build_targets.inc.sh
@@ -26,19 +26,19 @@ function collect_build_targets() {
 
     if [[ "$target" == */*/* ]]; then
       # echo "$target" >> build_targets.txt
-      find "$target" -maxdepth 1 -type d -wholename "$target" | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
+      (find "$target" -maxdepth 1 -type d -wholename "$target" | grep -vP '^(release/packages/fv_all)' || true) >> build_targets_temp.txt
       if [[ "$target" == "release/packages/fv_all" ]]; then
         fv_all=true
       fi
     elif [[ "$target" == */* ]]; then
-      find "$target" -maxdepth 1 -type d -wholename "$target"'/*' | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
+      (find "$target" -maxdepth 1 -type d -wholename "$target"'/*' | grep -vP '^(release/packages/fv_all)' || true) >> build_targets_temp.txt
       if [[ "$target" == "release/packages" ]]; then
         fv_all=true
       fi
     else
-      find "$target" -maxdepth 2 -type d -wholename "$target"'/*/*' | grep -vP '^(release/packages|release/shared|release/template)' || true >> build_targets_temp.txt
+      (find "$target" -maxdepth 2 -type d -wholename "$target"'/*/*' | grep -vP '^(release/packages|release/shared|release/template)' || true) >> build_targets_temp.txt
       if [[ "$target" == release ]]; then
-        find "$target" -maxdepth 2 -type d -wholename 'release/packages/*' | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
+        (find "$target" -maxdepth 2 -type d -wholename 'release/packages/*' | grep -vP '^(release/packages/fv_all)' || true) >> build_targets_temp.txt
         fv_all=true
       fi
     fi

--- a/resources/build_targets.inc.sh
+++ b/resources/build_targets.inc.sh
@@ -26,19 +26,19 @@ function collect_build_targets() {
 
     if [[ "$target" == */*/* ]]; then
       # echo "$target" >> build_targets.txt
-      find "$target" -maxdepth 1 -type d -wholename "$target" | grep -vP '^(release/packages/fv_all)' >> build_targets_temp.txt
+      find "$target" -maxdepth 1 -type d -wholename "$target" | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
       if [[ "$target" == "release/packages/fv_all" ]]; then
         fv_all=true
       fi
     elif [[ "$target" == */* ]]; then
-      find "$target" -maxdepth 1 -type d -wholename "$target"'/*' | grep -vP '^(release/packages/fv_all)' >> build_targets_temp.txt
+      find "$target" -maxdepth 1 -type d -wholename "$target"'/*' | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
       if [[ "$target" == "release/packages" ]]; then
         fv_all=true
       fi
     else
-      find "$target" -maxdepth 2 -type d -wholename "$target"'/*/*' | grep -vP '^(release/packages|release/shared|release/template)' >> build_targets_temp.txt
+      find "$target" -maxdepth 2 -type d -wholename "$target"'/*/*' | grep -vP '^(release/packages|release/shared|release/template)' || true >> build_targets_temp.txt
       if [[ "$target" == release ]]; then
-        find "$target" -maxdepth 2 -type d -wholename 'release/packages/*' | grep -vP '^(release/packages/fv_all)' >> build_targets_temp.txt
+        find "$target" -maxdepth 2 -type d -wholename 'release/packages/*' | grep -vP '^(release/packages/fv_all)' || true >> build_targets_temp.txt
         fv_all=true
       fi
     fi

--- a/tools/regression.sh
+++ b/tools/regression.sh
@@ -48,7 +48,7 @@ KEYBOARDROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 cd "$KEYBOARDROOT"
 
-. "$KEYBOARDROOT/resources/util.sh"
+. "$KEYBOARDROOT/resources/util.inc.sh"
 . "$KEYBOARDROOT/resources/environment.sh"
 . "$KEYBOARDROOT/resources/download-compiler.sh"
 . "$KEYBOARDROOT/resources/regression-build.sh"


### PR DESCRIPTION
Relates to keymanapp/keyman#11811.

Build script would fail if `-k release/packages/fv_all` were the only command line parameters, as `grep` would return an error while preparing the list of files to build.