### PR TITLE
[SIL Ethiopic Power-G] Add On-Screen keyboard in v1.2.4

### DIFF
--- a/release/sil/sil_ethiopic_power_g/HISTORY.md
+++ b/release/sil/sil_ethiopic_power_g/HISTORY.md
@@ -1,6 +1,12 @@
 SIL Ethiopic Power-G Change History
 ===================================
 
+1.2.4 (2024-06-17)
+-------------------
+* On-Screen keyboard added.
+* AbyssinicaSIL-Regular.ttf added to package.
+* Upgrade project to Keyman Developer 17.0 format.
+
 1.2.3 (2023-04-19)
 ------------------
 * cleanup

--- a/release/sil/sil_ethiopic_power_g/LICENSE.md
+++ b/release/sil/sil_ethiopic_power_g/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2020 SIL Ethiopia
+Copyright (c) 2017-2024 SIL Ethiopia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil_ethiopic_power_g/sil_ethiopic_power_g.kpj
+++ b/release/sil/sil_ethiopic_power_g/sil_ethiopic_power_g.kpj
@@ -1,82 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <KeymanDeveloperProject>
   <Options>
-    <BuildPath>$PROJECTPATH\build</BuildPath>
+    <Version>2.0</Version>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
-    <WarnDeprecatedCode>True</WarnDeprecatedCode>
-    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <SkipMetadataFiles>True</SkipMetadataFiles>
   </Options>
-  <Files>
-    <File>
-      <ID>id_bda56e77315421037dee055447cbbb25</ID>
-      <Filename>sil_ethiopic_power_g.kmn</Filename>
-      <Filepath>source\sil_ethiopic_power_g.kmn</Filepath>
-      <FileVersion>1.2.3</FileVersion>
-      <FileType>.kmn</FileType>
-      <Details>
-        <Name>SIL Ethiopic Power-G</Name>
-        <Copyright>© 2017-2023 SIL Ethiopia</Copyright>
-        <Message>The SIL Ethiopic Power-G keyboard enables typing in all Ethiopic Saba Fidel scripts using the keyboarding sequences found in the Power Geez (Phonetic) keyboard from Concepts Data Systems.</Message>
-      </Details>
-    </File>
-    <File>
-      <ID>id_d0915a5483352a48da2d2ceced32c686</ID>
-      <Filename>sil_ethiopic_power_g.kps</Filename>
-      <Filepath>source\sil_ethiopic_power_g.kps</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.kps</FileType>
-      <Details>
-        <Name>SIL Ethiopic Power-G</Name>
-        <Copyright>© 2017-2023 SIL Ethiopia</Copyright>
-      </Details>
-    </File>
-    <File>
-      <ID>id_0e07d51117c0343eb856afb40b7d7d70</ID>
-      <Filename>sil_ethiopic_power_g.ico</Filename>
-      <Filepath>source\sil_ethiopic_power_g.ico</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.ico</FileType>
-      <ParentFileID>id_bda56e77315421037dee055447cbbb25</ParentFileID>
-    </File>
-    <File>
-      <ID>id_323e9b4c060efc5d3b4e7fd96bf13653</ID>
-      <Filename>sil_ethiopic_power_g.kmx</Filename>
-      <Filepath>source\..\build\sil_ethiopic_power_g.kmx</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.kmx</FileType>
-      <ParentFileID>id_d0915a5483352a48da2d2ceced32c686</ParentFileID>
-    </File>
-    <File>
-      <ID>id_7bbd7e58f34b3babbbe34ca8a8c85f1c</ID>
-      <Filename>sil_ethiopic_power_g_sideimage.bmp</Filename>
-      <Filepath>source\sil_ethiopic_power_g_sideimage.bmp</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.bmp</FileType>
-      <ParentFileID>id_d0915a5483352a48da2d2ceced32c686</ParentFileID>
-    </File>
-    <File>
-      <ID>id_eaea1b5d250f3cf25c13ff6c74d63602</ID>
-      <Filename>SIL-Ethiopic-Power-G-Keyboard-Help.pdf</Filename>
-      <Filepath>source\SIL-Ethiopic-Power-G-Keyboard-Help.pdf</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.pdf</FileType>
-      <ParentFileID>id_d0915a5483352a48da2d2ceced32c686</ParentFileID>
-    </File>
-    <File>
-      <ID>id_8da344c4cea6f467013357fe099006f5</ID>
-      <Filename>readme.htm</Filename>
-      <Filepath>source\readme.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
-      <ParentFileID>id_d0915a5483352a48da2d2ceced32c686</ParentFileID>
-    </File>
-    <File>
-      <ID>id_724e5b4c63f10bc0abf7077f7c3172fc</ID>
-      <Filename>welcome.htm</Filename>
-      <Filepath>source\welcome\welcome.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
-      <ParentFileID>id_d0915a5483352a48da2d2ceced32c686</ParentFileID>
-    </File>
-  </Files>
 </KeymanDeveloperProject>

--- a/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kmn
+++ b/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kmn
@@ -1,9 +1,9 @@
 ﻿store(&VERSION) '9.0'
 store(&NAME) 'SIL Ethiopic Power-G'
 store(&TARGETS) 'web desktop'
-store(&KEYBOARDVERSION) '1.2.3'
+store(&KEYBOARDVERSION) '1.2.4'
 store(&BITMAP) 'sil_ethiopic_power_g.ico'
-store(&COPYRIGHT) '© 2017-2020 SIL Ethiopia'
+store(&COPYRIGHT) '© 2017-2024 SIL Ethiopia'
 store(&MESSAGE) 'The SIL Ethiopic Power-G keyboard enables typing in all Ethiopic Saba Fidel scripts using the keyboarding sequences found in the Power Geez (Phonetic) keyboard from Concepts Data Systems.'
 c store(&LANGUAGE) 'x045E'
 c store(&WINDOWSLANGUAGES) 'x045E'
@@ -166,6 +166,7 @@ c Diacritics
 
 store(diacKey) "1"    "2"    "3"    "4"    "5"    "6"    "7"    "8"    "9"    "0"    "'"    '"'    ":"
 store(diacU)   U+030f U+0300 U+0304 U+0301 U+030b U+0302 U+030c U+0307 U+0308 U+0303 U+135f U+135d U+135e
+store(&VISUALKEYBOARD) 'sil_ethiopic_power_g.kvks'
 
 begin unicode > use(Main)
 

--- a/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kps
+++ b/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kps
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>11.0.1356.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.326.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
     <ExecuteProgram></ExecuteProgram>
     <ReadMeFile>readme.htm</ReadMeFile>
     <GraphicFile>sil_ethiopic_power_g_sideimage.bmp</GraphicFile>
+    <LicenseFile>..\LICENSE.md</LicenseFile>
+    <WelcomeFile>welcome\welcome.htm</WelcomeFile>
     <MSIFileName></MSIFileName>
     <MSIOptions></MSIOptions>
     <FollowKeyboardVersion/>
-    <LicenseFile>..\LICENSE.md</LicenseFile>
   </Options>
   <StartMenu>
     <Folder></Folder>
@@ -20,10 +21,10 @@
   <Info>
     <Name URL="">SIL Ethiopic Power-G</Name>
     <Version URL=""></Version>
-    <Copyright URL="">© 2017-2023 SIL Ethiopia</Copyright>
+    <Copyright URL="">© 2017-2024 SIL Ethiopia</Copyright>
     <Author URL="mailto:computer_ethiopia@sil.org">SIL Ethiopia</Author>
     <WebSite URL="http://www.silethiopia.org">http://www.silethiopia.org</WebSite>
-    <Description>The SIL Ethiopic Power-G keyboard enables typing in all Ethiopic Saba
+    <Description URL="">The SIL Ethiopic Power-G keyboard enables typing in all Ethiopic Saba
 Fidel scripts using the keyboarding sequences found in the \"Power
 Ge\'ez (Phonetic)\" keyboard from Concepts Data Systems.</Description>
   </Info>
@@ -70,12 +71,26 @@ Ge\'ez (Phonetic)\" keyboard from Concepts Data Systems.</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.md</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</Name>
+      <Description>Font Abyssinica SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\build\sil_ethiopic_power_g.kvk</Name>
+      <Description>File sil_ethiopic_power_g.kvk</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kvk</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>SIL Ethiopic Power-G</Name>
       <ID>sil_ethiopic_power_g</ID>
-      <Version>1.2.3</Version>
+      <Version>1.2.4</Version>
+      <OSKFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</DisplayFont>
       <Languages>
         <Language ID="am">Amharic</Language>
         <Language ID="bst-Ethi">Basketo (Ethiopic)</Language>

--- a/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kvks
+++ b/release/sil/sil_ethiopic_power_g/source/sil_ethiopic_power_g.kvks
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<visualkeyboard>
+  <header>
+    <version>10.0</version>
+    <kbdname>sil_ethiopic_power_g</kbdname>
+    <flags>
+      <displayunderlying/>
+    </flags>
+  </header>
+  <encoding name="unicode" fontname="Abyssinica SIL" fontsize="-12">
+    <layer shift="">
+      <key vkey="K_Q">ቀ</key>
+      <key vkey="K_W">ወ</key>
+      <key vkey="K_E">እ</key>
+      <key vkey="K_R">ረ</key>
+      <key vkey="K_T">ተ</key>
+      <key vkey="K_U">ኡ</key>
+      <key vkey="K_I">ኢ</key>
+      <key vkey="K_O">ኦ</key>
+      <key vkey="K_P">ፐ</key>
+      <key vkey="K_BKQUOTE">`</key>
+      <key vkey="K_1">1</key>
+      <key vkey="K_2">2</key>
+      <key vkey="K_A">ኣ</key>
+      <key vkey="K_Z">ዘ</key>
+      <key vkey="K_S">ሰ</key>
+      <key vkey="K_D">ደ</key>
+      <key vkey="K_X">አ</key>
+      <key vkey="K_C">ቸ</key>
+      <key vkey="K_V">ቨ</key>
+      <key vkey="K_F">ፈ</key>
+      <key vkey="K_G">ገ</key>
+      <key vkey="K_B">በ</key>
+      <key vkey="K_H">ሀ</key>
+      <key vkey="K_J">ጀ</key>
+      <key vkey="K_N">ነ</key>
+      <key vkey="K_M">መ</key>
+      <key vkey="K_K">ከ</key>
+      <key vkey="K_L">ለ</key>
+      <key vkey="K_COLON">፤</key>
+      <key vkey="K_QUOTE">'</key>
+      <key vkey="K_LBRKT">[</key>
+      <key vkey="K_RBRKT">]</key>
+      <key vkey="K_BKSLASH">\</key>
+      <key vkey="K_COMMA">፥</key>
+      <key vkey="K_PERIOD">።</key>
+      <key vkey="K_SLASH">/</key>
+      <key vkey="K_3">3</key>
+      <key vkey="K_4">4</key>
+      <key vkey="K_5">5</key>
+      <key vkey="K_6">6</key>
+      <key vkey="K_7">7</key>
+      <key vkey="K_8">8</key>
+      <key vkey="K_9">9</key>
+      <key vkey="K_0">0</key>
+      <key vkey="K_HYPHEN">-</key>
+      <key vkey="K_EQUAL">=</key>
+    </layer>
+    <layer shift="S">
+      <key vkey="K_A">ዓ</key>
+      <key vkey="K_Q">ቐ</key>
+      <key vkey="K_W">ኧ</key>
+      <key vkey="K_E">ዕ</key>
+      <key vkey="K_T">ጠ</key>
+      <key vkey="K_S">ሸ</key>
+      <key vkey="K_D">ዸ</key>
+      <key vkey="K_Z">ዠ</key>
+      <key vkey="K_X">ዐ</key>
+      <key vkey="K_C">ጨ</key>
+      <key vkey="K_V">ፀ</key>
+      <key vkey="K_N">ኘ</key>
+      <key vkey="K_F">ጸ</key>
+      <key vkey="K_G">ጘ</key>
+      <key vkey="K_H">ሐ</key>
+      <key vkey="K_J">ሠ</key>
+      <key vkey="K_K">ኸ</key>
+      <key vkey="K_L">ኀ</key>
+      <key vkey="K_COMMA">&lt;</key>
+      <key vkey="K_PERIOD">&gt;</key>
+      <key vkey="K_SLASH">?</key>
+      <key vkey="K_COLON">፡</key>
+      <key vkey="K_QUOTE">"</key>
+      <key vkey="K_BKSLASH">|</key>
+      <key vkey="K_RBRKT">}</key>
+      <key vkey="K_LBRKT">{</key>
+      <key vkey="K_P">ጰ</key>
+      <key vkey="K_O">ዖ</key>
+      <key vkey="K_I">ዒ</key>
+      <key vkey="K_U">ዑ</key>
+      <key vkey="K_BKQUOTE">~</key>
+      <key vkey="K_1">!</key>
+      <key vkey="K_2">@</key>
+      <key vkey="K_3">#</key>
+      <key vkey="K_4">$</key>
+      <key vkey="K_5">%</key>
+      <key vkey="K_6">^</key>
+      <key vkey="K_7">&amp;</key>
+      <key vkey="K_8">*</key>
+      <key vkey="K_9">(</key>
+      <key vkey="K_0">)</key>
+      <key vkey="K_HYPHEN">-</key>
+      <key vkey="K_EQUAL">+</key>
+      <key vkey="K_Y">የ</key>
+    </layer>
+  </encoding>
+</visualkeyboard>


### PR DESCRIPTION
Minor revisions to the SIL Ethiopic Power-G keyboard to include an on-screen keyboard and the inclusion of the Abyssinica SIL font in the distribution.

* On-Screen keyboard added.
* AbyssinicalSIL-Regular.ttf added to package.
* Upgrade project to Keyman Developer 17.0 format.
