### PR TITLE
[sgaw_karen]: Fix single quote in help page name

### DIFF
--- a/release/s/sgaw_karen/source/help/sgaw_karen.php
+++ b/release/s/sgaw_karen/source/help/sgaw_karen.php
@@ -1,5 +1,5 @@
 ﻿<?php 
-  $pagename = '>ကညီကျိာ် S'gaw Karen Keyboard Help';
+  $pagename = '>ကညီကျိာ် S\'gaw Karen Keyboard Help';
   $pagetitle = $pagename;
   require_once('header.php');
 ?>


### PR DESCRIPTION
Follows #2832 to fix help deployment current failing on keymanapp/help.keyman.com#1328
