### PR TITLE
[fv_all] Add fv_ojibwa_rdot and fv_severn_ojibwa_rdot

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 12.11 (28 Jun 2024)
+* Add fv_ojibwa_rdot and fv_severn_ojibwa_rdot
+
 ## 12.10 (May 18 2024)
 * Add keyboards.csv file
 

--- a/release/packages/fv_all/keyboards.csv
+++ b/release/packages/fv_all/keyboards.csv
@@ -53,7 +53,9 @@ fv_swampy_cree,Eastern Subarctic
 fv_moose_cree,Eastern Subarctic
 fv_northern_east_cree,Eastern Subarctic
 fv_severn_ojibwa,Eastern Subarctic
+fv_severn_ojibwa_rdot,Eastern Subarctic
 fv_ojibwa,Eastern Subarctic
+fv_ojibwa_rdot,Eastern Subarctic
 fv_naskapi,Eastern Subarctic
 sil_euro_latin,European
 basic_kbdcan,European

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -19,7 +19,7 @@
     <Copyright URL="">(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.10</Version>
+    <Version URL="">12.11</Version>
     <Description>This package includes FirstVoices keyboards for Windows, Android, and iOS. It is distributed as part of the FirstVoices project</Description>
   </Info>
   <Files>


### PR DESCRIPTION
Adds new keyboards fv_ojibwa_rdot (#2849) and fv_severn_ojibwa_rdot (#2851) to fv_all.kmp.

* Also added the 2 keyboards + regions to `keyboards.csv` (not currently used, but eventually will be used when the FV app gets moved from the main repo)
 
TODO: Update keyboards.csv in the main repo which is still being actively used to build the mobile apps.