### PR TITLE
[kaithi_inscript] Correct copyright in LICENSE.md

### DIFF
--- a/release/k/kaithi_inscript/HISTORY.md
+++ b/release/k/kaithi_inscript/HISTORY.md
@@ -1,6 +1,10 @@
 Kaithi Inscript Change History
 ====================
 
+1.0.1 (2024-07-02)
+----------------
+* Correct copyright
+
 1.0 (2024-06-20)
 ----------------
 * Created by Lorna Evans

--- a/release/k/kaithi_inscript/LICENSE.md
+++ b/release/k/kaithi_inscript/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2024 Lorna Evans
+Copyright © 2024 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/k/kaithi_inscript/source/kaithi_inscript.kmn
+++ b/release/k/kaithi_inscript/source/kaithi_inscript.kmn
@@ -3,7 +3,7 @@ c with name "Kaithi Inscript"
 store(&VERSION) '10.0'
 store(&NAME) 'Kaithi Inscript'
 store(&COPYRIGHT) 'Copyright © SIL International'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&TARGETS) 'any'
 store(&BITMAP) 'kaithi_inscript.ico'
 store(&VISUALKEYBOARD) 'kaithi_inscript.kvks'


### PR DESCRIPTION
LICENSE had the wrong copyright. Since it is now included in the Keyman package I decided the keyboard version needed bumping.