### PR TITLE
chore(foochow): restore missing FollowKeyboardVersion tag

### DIFF
--- a/release/f/foochow/source/foochow.kps
+++ b/release/f/foochow/source/foochow.kps
@@ -11,6 +11,7 @@
     <WelcomeFile>welcome.htm</WelcomeFile>
     <MSIFileName></MSIFileName>
     <MSIOptions></MSIOptions>
+    <FollowKeyboardVersion />
   </Options>
   <StartMenu>
     <Folder></Folder>


### PR DESCRIPTION
See also https://github.com/keymanapp/keyman/issues/12193