### PR TITLE
chore: add missing keyboard descriptions

### DIFF
--- a/release/c/cs_pinyin/source/cs_pinyin.kps
+++ b/release/c/cs_pinyin/source/cs_pinyin.kps
@@ -44,9 +44,15 @@
   <Info>
     <Name URL="">Simplified Chinese</Name>
     <Version URL=""></Version>
-    <Copyright URL="">© SIL International</Copyright>
+    <Copyright URL="">© SIL International, Linguasoft</Copyright>
     <Author URL="mailto:support@keyman.com">SIL International</Author>
     <WebSite URL="https://keyman.com/">https://keyman.com/</WebSite>
+    <Description>An innovative input method extension for Keyman,
+with Pinyin, RAD-RSC and Four Corner Index input mapping for Simplified Chinese,
+with more than 100,000 Han characters, multi-character words, proper names, and
+place name abbreviations.
+
+Chinese language content developed and copyright by Linguasoft.</Description>
   </Info>
   <Files>
     <File>

--- a/release/o/obolo_chwerty/source/obolo_chwerty.kps
+++ b/release/o/obolo_chwerty/source/obolo_chwerty.kps
@@ -23,6 +23,11 @@
     <Copyright URL="">© 2019-2024 Rogers Katelem Edeh</Copyright>
     <Author URL="mailto:katelem247@gmail.com">Rogers Katelem Edeh</Author>
     <WebSite URL="katelem24.wordpress.com">katelem24.wordpress.com</WebSite>
+    <Description>Obolo Chwerty Keyboard is a keyboard layout for the Obolo language
+of Nigeria. This layout covers the need of every dialect in that language.
+
+On this keyboard, accents are typed after the base letters. So, to type Obolo language,
+simply tap the given latters and tap the appropriate accent key to place the accent on the letter.</Description>
   </Info>
   <Files>
     <File>

--- a/release/s/sgaw_karen/source/sgaw_karen.kps
+++ b/release/s/sgaw_karen/source/sgaw_karen.kps
@@ -20,6 +20,7 @@
     <Version URL=""/>
     <Name URL="">sgaw_karen</Name>
     <Copyright URL="">© 2024 Jcturner12</Copyright>
+    <Description>A Unicode keyboard for the S'gaw Karen language.</Description>
   </Info>
   <Files>
     <File>
@@ -77,4 +78,3 @@
   </Keyboards>
   <Strings/>
 </Package>
-

--- a/release/s/sharada_inscript/source/sharada_inscript.kps
+++ b/release/s/sharada_inscript/source/sharada_inscript.kps
@@ -22,6 +22,7 @@
     <Name URL="">Sharada Inscript</Name>
     <Copyright URL="">Copyright © SIL International</Copyright>
     <Author URL="">Lorna Evans</Author>
+    <Description>This keyboard is for the Kashmiri and Sanskrit languages which sometimes use the Sharada script. It is based on an Inscript layout.</Description>
   </Info>
   <Files>
     <File>

--- a/release/v/vithkuqi/source/vithkuqi.kps
+++ b/release/v/vithkuqi/source/vithkuqi.kps
@@ -20,6 +20,7 @@
     <Name URL="">Vithkuqi</Name>
     <Copyright URL="">© 2024 SIL International</Copyright>
     <Author URL=""></Author>
+    <Description>This keyboard layout is designed for Albanian using the Vithkuqi script.</Description>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
These changes do not require version bumps because at present the Description field is used only by the website.

Relates-to: keymanapp/keyman#12202