### PR TITLE
[fv_all] Update package version to 13.0

### DIFF
--- a/release/packages/fv_all/HISTORY.md
+++ b/release/packages/fv_all/HISTORY.md
@@ -1,5 +1,8 @@
 # fv_all Keyboard Package
 
+## 13.0 (3 Sep 2024)
+* New desktop layout for fv_nexwslayemucen based on KlallamU
+
 ## 12.15 (26 Jul 2024)
 * Add fv_lekwungen
 

--- a/release/packages/fv_all/source/fv_all.kps.in
+++ b/release/packages/fv_all/source/fv_all.kps.in
@@ -19,7 +19,7 @@
     <Copyright URL="">(c) 2015-2024 FirstVoices, SIL International, 2015 First Peoples' Cultural Foundation</Copyright>
     <WebSite URL="https://www.firstvoices.com">https://www.firstvoices.com</WebSite>
     <Name URL="">First Voices Keyboards</Name>
-    <Version URL="">12.15</Version>
+    <Version URL="">13.0</Version>
     <Description>This package includes FirstVoices keyboards for Windows, Android, and iOS. It is distributed as part of the FirstVoices project</Description>
   </Info>
   <Files>


### PR DESCRIPTION
This is a major bump of fv_all.kmp to 13.0 which incorporates all of the FirstVoices keyboard updates up to July 31, 2024.

Note: does not include #3011

