### PR TITLE
chore: re-release Imperial Aramaic 1.0.1

### DIFF
--- a/release/i/imperial_aramaic/HISTORY.md
+++ b/release/i/imperial_aramaic/HISTORY.md
@@ -1,6 +1,8 @@
 Imperial Aramaic Change History
 ====================
 
-1.0.0 (2024-07-25)
-----------------
+## 1.0.1 (2024-09-17)
+* Republishing with updated LDML compiler to resolve visual keyboard issues
+
+## 1.0.0 (2024-07-25)
 * Created by Lorna Evans

--- a/release/i/imperial_aramaic/source/imperial_aramaic.xml
+++ b/release/i/imperial_aramaic/source/imperial_aramaic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="arc" conformsTo="45">
   <info author="Lorna Evans" name="Imperial Aramaic"/>
-  <version number="1.0.0"/>
+  <version number="1.0.1"/>
   <!-- This keyboard is for Western Neo-Aramaic and Official Aramaic using the Imperial Aramaic script.-->
   <locales>
     <locale id="amw-Armi"/>


### PR DESCRIPTION
Resolves an issue with the visual keyboard by using updated kmc 17.0.330 compiler.