### PR TITLE
[ekwtamil99uni, yidgha] Fill in blank descriptions

### DIFF
--- a/release/e/ekwtamil99uni/source/ekwtamil99uni.kps
+++ b/release/e/ekwtamil99uni/source/ekwtamil99uni.kps
@@ -31,7 +31,10 @@
     <Version URL=""></Version>
     <Author URL="mailto:mugunth@gmail.com">Mugunth, Umar, K. Sethu</Author>
     <WebSite URL="http://www.thamizha.com">http://www.thamizha.com</WebSite>
-    <Description>null</Description>
+    <Description>This keyboard is designed for the Tamil language, and uses the Tamil 99 standard 
+which has been officially approved by the regional government of Tamil Nadu. 
+Typing follows a consonant-vowel pattern, and the Tamil characters are arranged to make 
+typing simple and fast for users who are familiar with the script.</Description>
   </Info>
   <Files>
     <File>

--- a/release/y/yidgha/source/yidgha.kps
+++ b/release/y/yidgha/source/yidgha.kps
@@ -20,7 +20,9 @@
     <Version URL=""></Version>
     <Name URL="">Yidgha Keyboard</Name>
     <Copyright URL="">(c) 2018-2020 Forum for Language Initiatives</Copyright>
-    <Description>null</Description>
+    <Description>This keyboard layout is designed for Yidgha. It includes an on screen keyboard which 
+can be viewed by clicking on the Keyman icon and selecting the On Screen Keyboard menu item. 
+Similar keyboards are also available for other desktop and mobile platforms.</Description>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
I noticed two keyboard pages listed `null` for the Description
https://keyman.com/keyboards/ekwtamil99uni
https://keyman.com/keyboards/yidgha

This adds descriptions to the .kps files (from the help.keyman.com Overview content)

Not bumping keyboard versions