### PR TITLE
[galaxie_hebrew] Update Galaxie Hebrew keyboards to use DISPLAYMAP

### DIFF
--- a/release/g/galaxie_hebrew_mnemonic/HISTORY.md
+++ b/release/g/galaxie_hebrew_mnemonic/HISTORY.md
@@ -1,5 +1,8 @@
 # Galaxie Hebrew (Mnemonic) Keyboard Change History
 
+## 3.3.1 (30 Oct 2024)
+* Change to use KbdHebr display font for better OSK display
+
 ## 3.3 (19 Sep 2024)
 * Changed targets
 

--- a/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kmn
+++ b/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kmn
@@ -4,9 +4,10 @@ store(&COPYRIGHT) '© Galaxie Software and SIL Global'
 store(&KMW_RTL) '1'
 $KeymanOnly: store(&mnemoniclayout) '1' 
 store(&BITMAP) 'galaxie_hebrew_mnemonic.ico'
-store(&KEYBOARDVERSION) '3.3'
+store(&KEYBOARDVERSION) '3.3.1'
 store(&TARGETS) 'web desktop'
 store(&VISUALKEYBOARD) 'galaxie_hebrew_mnemonic.kvks'
+store(&DISPLAYMAP) '../../../shared/fonts/kbd/kbdhebr/KbdHebr.json'
 
 begin Unicode > use(main)
 

--- a/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kps
+++ b/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>17.0.329.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.330.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -65,14 +65,34 @@ layout.</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Name>
+      <Description>File EzraSIL_Licenses.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Name>
+      <Description>Font Ezra SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Name>
+      <Description>Font KbdHebr Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Galaxie Hebrew (Mnemonic)</Name>
       <ID>galaxie_hebrew_mnemonic</ID>
-      <Version>3.3</Version>
+      <Version>3.3.1</Version>
+      <OSKFont>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</DisplayFont>
       <Languages>
-        <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
+        <Language ID="hbo">Ancient Hebrew</Language>
         <Language ID="he">Hebrew</Language>
       </Languages>
     </Keyboard>

--- a/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kvks
+++ b/release/g/galaxie_hebrew_mnemonic/source/galaxie_hebrew_mnemonic.kvks
@@ -7,7 +7,7 @@
       <displayunderlying/>
     </flags>
   </header>
-  <encoding name="unicode" fontname="Ezra SIL" fontsize="12">
+  <encoding name="unicode" fontname="KbdHebr" fontsize="12">
     <layer shift="">
       <key vkey="K_1">1</key>
       <key vkey="K_2">2</key>
@@ -20,7 +20,7 @@
       <key vkey="K_9">9</key>
       <key vkey="K_0">0</key>
       <key vkey="K_HYPHEN">־</key>
-      <key vkey="K_EQUAL">◌ְ</key>
+      <key vkey="K_EQUAL">ְ</key>
       <key vkey="K_Q">ק</key>
       <key vkey="K_W">ו</key>
       <key vkey="K_E">ךֵ</key>
@@ -33,7 +33,7 @@
       <key vkey="K_P">פ</key>
       <key vkey="K_LBRKT">ף</key>
       <key vkey="K_RBRKT">ש</key>
-      <key vkey="K_BKSLASH">◌ֽ</key>
+      <key vkey="K_BKSLASH">ֽ</key>
       <key vkey="K_A">א</key>
       <key vkey="K_S">ס</key>
       <key vkey="K_D">ד</key>
@@ -55,21 +55,21 @@
       <key vkey="K_COMMA">,</key>
       <key vkey="K_PERIOD">׃</key>
       <key vkey="K_SLASH">ן</key>
-      <key vkey="K_BKQUOTE">◌֫</key>
+      <key vkey="K_BKQUOTE">֫</key>
     </layer>
     <layer shift="S">
-      <key vkey="K_BKQUOTE">◌֤</key>
-      <key vkey="K_1">◌ִ</key>
-      <key vkey="K_2">◌ֵ</key>
-      <key vkey="K_3">◌ֶ</key>
-      <key vkey="K_4">◌ֱ</key>
-      <key vkey="K_5">◌ֻ</key>
-      <key vkey="K_6">◌ַ</key>
-      <key vkey="K_7">◌ֲ</key>
-      <key vkey="K_8">◌ָ</key>
-      <key vkey="K_9">◌ֳ</key>
-      <key vkey="K_0">◌ֹ</key>
-      <key vkey="K_HYPHEN">◌ֿ</key>
+      <key vkey="K_BKQUOTE">֤</key>
+      <key vkey="K_1">ִ</key>
+      <key vkey="K_2">ֵ</key>
+      <key vkey="K_3">ֶ</key>
+      <key vkey="K_4">ֱ</key>
+      <key vkey="K_5">ֻ</key>
+      <key vkey="K_6">ַ</key>
+      <key vkey="K_7">ֲ</key>
+      <key vkey="K_8">ָ</key>
+      <key vkey="K_9">ֳ</key>
+      <key vkey="K_0">ֹ</key>
+      <key vkey="K_HYPHEN">ֿ</key>
       <key vkey="K_Q">קּ</key>
       <key vkey="K_W">וּ</key>
       <key vkey="K_E">ךְ</key>
@@ -103,7 +103,7 @@
       <key vkey="K_M">מּ</key>
       <key vkey="K_COMMA">ם</key>
       <key vkey="K_PERIOD">.</key>
-      <key vkey="K_SLASH">◌ּ</key>
+      <key vkey="K_SLASH">ּ</key>
       <key vkey="K_EQUAL">‹LTN›</key>
     </layer>
   </encoding>
@@ -120,7 +120,7 @@
       <key vkey="K_9">9</key>
       <key vkey="K_0">0</key>
       <key vkey="K_HYPHEN">־</key>
-      <key vkey="K_EQUAL">◌ְ</key>
+      <key vkey="K_EQUAL">ְ</key>
       <key vkey="K_Q">ק</key>
       <key vkey="K_W">ו</key>
       <key vkey="K_E">ךֵ</key>
@@ -133,7 +133,7 @@
       <key vkey="K_P">פ</key>
       <key vkey="K_LBRKT">ף</key>
       <key vkey="K_RBRKT">ש</key>
-      <key vkey="K_BKSLASH">◌ֽ</key>
+      <key vkey="K_BKSLASH">ֽ</key>
       <key vkey="K_A">א</key>
       <key vkey="K_S">ס</key>
       <key vkey="K_D">ד</key>
@@ -155,21 +155,21 @@
       <key vkey="K_COMMA">,</key>
       <key vkey="K_PERIOD">׃</key>
       <key vkey="K_SLASH">ן</key>
-      <key vkey="K_BKQUOTE">◌֫</key>
+      <key vkey="K_BKQUOTE">֫</key>
     </layer>
     <layer shift="S">
-      <key vkey="K_BKQUOTE">◌֤</key>
-      <key vkey="K_1">◌ִ</key>
-      <key vkey="K_2">◌ֵ</key>
-      <key vkey="K_3">◌ֶ</key>
-      <key vkey="K_4">◌ֱ</key>
-      <key vkey="K_5">◌ֻ</key>
-      <key vkey="K_6">◌ַ</key>
-      <key vkey="K_7">◌ֲ</key>
-      <key vkey="K_8">◌ָ</key>
-      <key vkey="K_9">◌ֳ</key>
-      <key vkey="K_0">◌ֹ</key>
-      <key vkey="K_HYPHEN">◌ֿ</key>
+      <key vkey="K_BKQUOTE">֤</key>
+      <key vkey="K_1">ִ</key>
+      <key vkey="K_2">ֵ</key>
+      <key vkey="K_3">ֶ</key>
+      <key vkey="K_4">ֱ</key>
+      <key vkey="K_5">ֻ</key>
+      <key vkey="K_6">ַ</key>
+      <key vkey="K_7">ֲ</key>
+      <key vkey="K_8">ָ</key>
+      <key vkey="K_9">ֳ</key>
+      <key vkey="K_0">ֹ</key>
+      <key vkey="K_HYPHEN">ֿ</key>
       <key vkey="K_EQUAL">+</key>
       <key vkey="K_Q">קּ</key>
       <key vkey="K_W">וּ</key>
@@ -204,7 +204,7 @@
       <key vkey="K_M">מּ</key>
       <key vkey="K_COMMA">ם</key>
       <key vkey="K_PERIOD">.</key>
-      <key vkey="K_SLASH">◌ּ</key>
+      <key vkey="K_SLASH">ּ</key>
     </layer>
   </encoding>
 </visualkeyboard>

--- a/release/g/galaxie_hebrew_positional/HISTORY.md
+++ b/release/g/galaxie_hebrew_positional/HISTORY.md
@@ -1,5 +1,8 @@
 # Galaxie Hebrew (Positional) Keyboard Change History
 
+## 2.3.1 (30 Oct 2024)
+* Change to use KbdHebr display font for better OSK display
+
 ## 2.3 (18 Sep 2024)
 * Added mobile layout
 

--- a/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.keyman-touch-layout
+++ b/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.keyman-touch-layout
@@ -54,7 +54,7 @@
               },
               {
                 "id": "K_EQUAL",
-                "text": "◌ְ"
+                "text": "ְ"
               },
               {
                 "id": "K_BKSP",
@@ -174,7 +174,7 @@
               },
               {
                 "id": "K_BKSLASH",
-                "text": "◌ּ"
+                "text": "ּ"
               }
             ]
           },
@@ -266,47 +266,47 @@
             "key": [
               {
                 "id": "K_1",
-                "text": "◌ִ"
+                "text": "ִ"
               },
               {
                 "id": "K_2",
-                "text": "◌ֵ"
+                "text": "ֵ"
               },
               {
                 "id": "K_3",
-                "text": "◌ֶ"
+                "text": "ֶ"
               },
               {
                 "id": "K_4",
-                "text": "◌ֱ"
+                "text": "ֱ"
               },
               {
                 "id": "K_5",
-                "text": "◌ֻ"
+                "text": "ֻ"
               },
               {
                 "id": "K_6",
-                "text": "◌ַ"
+                "text": "ַ"
               },
               {
                 "id": "K_7",
-                "text": "◌ֲ"
+                "text": "ֲ"
               },
               {
                 "id": "K_8",
-                "text": "◌ָ"
+                "text": "ָ"
               },
               {
                 "id": "K_9",
-                "text": "◌ֳ"
+                "text": "ֳ"
               },
               {
                 "id": "K_0",
-                "text": "◌ֹ"
+                "text": "ֹ"
               },
               {
                 "id": "K_HYPHEN",
-                "text": "◌ֿ"
+                "text": "ֿ"
               },
               {
                 "id": "K_EQUAL",

--- a/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kmn
+++ b/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kmn
@@ -6,9 +6,10 @@ store(&COPYRIGHT) '(c) Galaxie Software and SIL Global'
 c store(&mnemoniclayout) '1'                     
 store(&VISUALKEYBOARD) 'galaxie_hebrew_positional.kvks'
 store(&KMW_RTL) '1'
-store(&KEYBOARDVERSION) '2.3'
+store(&KEYBOARDVERSION) '2.3.1'
 store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'galaxie_hebrew_positional.keyman-touch-layout'
+store(&DISPLAYMAP) '../../../shared/fonts/kbd/kbdhebr/KbdHebr.json'
 
 begin Unicode > use(main)
 

--- a/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kps
+++ b/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>17.0.329.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.330.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -67,6 +67,24 @@ ancient Near East and the language of the Hebrew Bible</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Name>
+      <Description>Font KbdHebr Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Name>
+      <Description>File EzraSIL_Licenses.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Name>
+      <Description>Font Ezra SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
@@ -74,12 +92,14 @@ ancient Near East and the language of the Hebrew Bible</Description>
       <ID>galaxie_hebrew_positional</ID>
       <Version>2.3</Version>
       <RTL>True</RTL>
+      <OSKFont>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</DisplayFont>
       <Languages>
-        <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
+        <Language ID="hbo">Ancient Hebrew</Language>
         <Language ID="he">Hebrew</Language>
       </Languages>
       <Examples>
-        <Example ID="hbo-Hebr" Keys="b \\ = r @ a v ! y t" Text="בְּרֵאשִׁית" Note="&quot;In the beginning&quot; or &quot;Genesis&quot;"/>
+        <Example ID="hbo" Keys="b \\ = r @ a v ! y t" Text="בְּרֵאשִׁית" Note="&quot;In the beginning&quot; or &quot;Genesis&quot;"/>
       </Examples>
     </Keyboard>
   </Keyboards>

--- a/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kvks
+++ b/release/g/galaxie_hebrew_positional/source/galaxie_hebrew_positional.kvks
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <visualkeyboard>
   <header>
     <version>10.0</version>
     <kbdname>galaxie_hebrew_positional</kbdname>
     <flags/>
   </header>
-  <encoding name="unicode" fontname="Arial" fontsize="-12">
+  <encoding name="unicode" fontname="KbdHebr" fontsize="-12">
     <layer shift="">
-      <key vkey="K_SPACE"> </key>
+      <key vkey="K_SPACE"></key>
       <key vkey="K_QUOTE">'</key>
       <key vkey="K_COMMA">,</key>
       <key vkey="K_HYPHEN">־</key>
@@ -25,7 +25,7 @@
       <key vkey="K_9">9</key>
       <key vkey="K_COLON">ךָ</key>
       <key vkey="K_LBRKT">ף</key>
-      <key vkey="K_BKSLASH">◌ּ</key>
+      <key vkey="K_BKSLASH">ּ</key>
       <key vkey="K_A">א</key>
       <key vkey="K_B">ב</key>
       <key vkey="K_C">שׂ</key>
@@ -52,23 +52,23 @@
       <key vkey="K_X">צ</key>
       <key vkey="K_Y">י</key>
       <key vkey="K_Z">ז</key>
-      <key vkey="K_EQUAL">◌ְ</key>
+      <key vkey="K_EQUAL">ְ</key>
     </layer>
     <layer shift="S">
       <key vkey="K_QUOTE">"</key>
-      <key vkey="K_3">◌ֶ</key>
-      <key vkey="K_4">◌ֱ</key>
-      <key vkey="K_5">◌ֻ</key>
-      <key vkey="K_7">◌ֲ</key>
-      <key vkey="K_9">◌ֳ</key>
-      <key vkey="K_0">◌ֹ</key>
-      <key vkey="K_8">◌ָ</key>
+      <key vkey="K_3">ֶ</key>
+      <key vkey="K_4">ֱ</key>
+      <key vkey="K_5">ֻ</key>
+      <key vkey="K_7">ֲ</key>
+      <key vkey="K_9">ֳ</key>
+      <key vkey="K_0">ֹ</key>
+      <key vkey="K_8">ָ</key>
       <key vkey="K_EQUAL">+</key>
       <key vkey="K_COLON">ךֶ</key>
       <key vkey="K_COMMA">ם</key>
       <key vkey="K_PERIOD">.</key>
       <key vkey="K_SLASH">ש</key>
-      <key vkey="K_2">◌ֵ</key>
+      <key vkey="K_2">ֵ</key>
       <key vkey="K_A">אּ</key>
       <key vkey="K_B">בּ</key>
       <key vkey="K_C">שּׂ</key>
@@ -95,13 +95,13 @@
       <key vkey="K_X">צּ</key>
       <key vkey="K_Y">יּ</key>
       <key vkey="K_Z">זּ</key>
-      <key vkey="K_6">◌ַ</key>
-      <key vkey="K_HYPHEN">◌ֿ</key>
+      <key vkey="K_6">ַ</key>
+      <key vkey="K_HYPHEN">ֿ</key>
       <key vkey="K_LBRKT">ףּ</key>
       <key vkey="K_BKSLASH">|</key>
       <key vkey="K_RBRKT">שּּ</key>
       <key vkey="K_BKQUOTE">~</key>
-      <key vkey="K_1">◌ִ</key>
+      <key vkey="K_1">ִ</key>
     </layer>
   </encoding>
 </visualkeyboard>

--- a/release/packages/galaxie_greek_hebrew_mnemonic/HISTORY.md
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/HISTORY.md
@@ -1,5 +1,8 @@
 # Galaxie Greek/Hebrew (Mnemonic) Keyboard Package
 
+## 3.4.1 (30 Oct 2024)
+* Change to use KbdHebr display font for better OSK display
+
 ## 3.4 (19 Sep 2024)
 * Change targets
 

--- a/release/packages/galaxie_greek_hebrew_mnemonic/galaxie_greek_hebrew_mnemonic.kpj
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/galaxie_greek_hebrew_mnemonic.kpj
@@ -9,7 +9,7 @@
       <ID>id_24d45c74b8f91ec6adcabf9c32d150b0</ID>
       <Filename>galaxie_hebrew_mnemonic.kmn</Filename>
       <Filepath>..\..\g\galaxie_hebrew_mnemonic\source\galaxie_hebrew_mnemonic.kmn</Filepath>
-      <FileVersion>3.3</FileVersion>
+      <FileVersion>3.3.1</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
         <Name>Galaxie Hebrew (Mnemonic)</Name>
@@ -31,12 +31,12 @@
       <ID>id_d35d8529aead72a58fbeb371a5a6a059</ID>
       <Filename>galaxie_greek_hebrew_mnemonic.kps</Filename>
       <Filepath>source\galaxie_greek_hebrew_mnemonic.kps</Filepath>
-      <FileVersion>3.4</FileVersion>
+      <FileVersion>3.4.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Galaxie Greek/Hebrew (Mnemonic) Keyboard Package</Name>
-        <Copyright>Galaxie Software and SIL Global</Copyright>
-        <Version>3.4</Version>
+        <Copyright>(c) Galaxie Software and SIL Global</Copyright>
+        <Version>3.4.1</Version>
       </Details>
     </File>
     <File>
@@ -133,6 +133,30 @@
       <Filepath>source\..\build\galaxie_hebrew_mnemonic.kvk</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kvk</FileType>
+      <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
+    </File>
+    <File>
+      <ID>id_215d69190a83c100ce35ea2d456b3f27</ID>
+      <Filename>EzraSIL_Licenses.txt</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.txt</FileType>
+      <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
+    </File>
+    <File>
+      <ID>id_034603c7653c8a15972484d6ef8d0f7c</ID>
+      <Filename>SILEOT.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
+      <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
+    </File>
+    <File>
+      <ID>id_6359e5c1bb35cf68f5ee06abe223ad70</ID>
+      <Filename>KbdHebr-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_d35d8529aead72a58fbeb371a5a6a059</ParentFileID>
     </File>
   </Files>

--- a/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
+++ b/release/packages/galaxie_greek_hebrew_mnemonic/source/galaxie_greek_hebrew_mnemonic.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>17.0.329.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.330.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -18,8 +18,8 @@
   </StartMenu>
   <Info>
     <Name URL="">Galaxie Greek/Hebrew (Mnemonic) Keyboard Package</Name>
-    <Copyright URL="">Galaxie Software and SIL Global</Copyright>
-    <Version URL="">3.4</Version>
+    <Copyright URL="">(c) Galaxie Software and SIL Global</Copyright>
+    <Version URL="">3.4.1</Version>
     <Description URL="">This package includes 2 mnemonic keyboards called: Galaxie Greek
 (Mnemonic) and Galaxie Hebrew (Mnemonic).</Description>
     <Author URL="">Hampton Keathley</Author>
@@ -85,14 +85,34 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Name>
+      <Description>File EzraSIL_Licenses.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Name>
+      <Description>Font Ezra SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Name>
+      <Description>Font KbdHebr Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Galaxie Hebrew (Mnemonic)</Name>
       <ID>galaxie_hebrew_mnemonic</ID>
-      <Version>3.3</Version>
+      <Version>3.3.1</Version>
+      <OSKFont>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</DisplayFont>
       <Languages>
-        <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
+        <Language ID="hbo">Ancient Hebrew</Language>
         <Language ID="he">Hebrew (Hebrew)</Language>
       </Languages>
     </Keyboard>

--- a/release/packages/galaxie_greek_hebrew_positional/HISTORY.md
+++ b/release/packages/galaxie_greek_hebrew_positional/HISTORY.md
@@ -1,5 +1,8 @@
 # Galaxie Greek/Hebrew (Positional) Keyboard Package
 
+## 2.3.1 (30 Oct 2024)
+* Change to use KbdHebr display font for better OSK display
+
 ## 2.3 (18 Sept 2024)
 * Update mobile layout
 

--- a/release/packages/galaxie_greek_hebrew_positional/galaxie_greek_hebrew_positional.kpj
+++ b/release/packages/galaxie_greek_hebrew_positional/galaxie_greek_hebrew_positional.kpj
@@ -9,12 +9,12 @@
       <ID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ID>
       <Filename>galaxie_greek_hebrew_positional.kps</Filename>
       <Filepath>source\galaxie_greek_hebrew_positional.kps</Filepath>
-      <FileVersion>2.3</FileVersion>
+      <FileVersion>2.3.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Galaxie Greek/Hebrew (Positional)</Name>
         <Copyright>(c) Galaxie Software and SIL Global</Copyright>
-        <Version>2.3</Version>
+        <Version>2.3.1</Version>
       </Details>
     </File>
     <File>
@@ -150,6 +150,30 @@
       <Filepath>source\..\build\galaxie_greek_positional.kmx</Filepath>
       <FileVersion></FileVersion>
       <FileType>.kmx</FileType>
+      <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
+    </File>
+    <File>
+      <ID>id_6359e5c1bb35cf68f5ee06abe223ad70</ID>
+      <Filename>KbdHebr-Regular.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
+      <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
+    </File>
+    <File>
+      <ID>id_215d69190a83c100ce35ea2d456b3f27</ID>
+      <Filename>EzraSIL_Licenses.txt</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.txt</FileType>
+      <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
+    </File>
+    <File>
+      <ID>id_034603c7653c8a15972484d6ef8d0f7c</ID>
+      <Filename>SILEOT.ttf</Filename>
+      <Filepath>source\..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.ttf</FileType>
       <ParentFileID>id_21c4c4aaca0a3122b8234ac6c2a5c661</ParentFileID>
     </File>
   </Files>

--- a/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
+++ b/release/packages/galaxie_greek_hebrew_positional/source/galaxie_greek_hebrew_positional.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>17.0.329.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.330.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -19,7 +19,7 @@
   <Info>
     <Name URL="">Galaxie Greek/Hebrew (Positional)</Name>
     <Copyright URL="">(c) Galaxie Software and SIL Global</Copyright>
-    <Version URL="">2.3</Version>
+    <Version URL="">2.3.1</Version>
     <Description URL="">This package includes 2 positional keyboards called: Galaxie Greek
 (Phonetic) and Galaxie Hebrew (Positional).</Description>
   </Info>
@@ -96,15 +96,35 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.kmx</FileType>
     </File>
+    <File>
+      <Name>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</Name>
+      <Description>Font KbdHebr Regular</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\EzraSIL_Licenses.txt</Name>
+      <Description>File EzraSIL_Licenses.txt</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.txt</FileType>
+    </File>
+    <File>
+      <Name>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</Name>
+      <Description>Font Ezra SIL</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.ttf</FileType>
+    </File>
   </Files>
   <Keyboards>
     <Keyboard>
       <Name>Galaxie Hebrew (Positional)</Name>
       <ID>galaxie_hebrew_positional</ID>
-      <Version>2.3</Version>
+      <Version>2.3.1</Version>
       <RTL>True</RTL>
+      <OSKFont>..\..\..\shared\fonts\kbd\kbdhebr\KbdHebr-Regular.ttf</OSKFont>
+      <DisplayFont>..\..\..\shared\fonts\sil\ezra\SILEOT.ttf</DisplayFont>
       <Languages>
-        <Language ID="hbo-Hebr">Ancient Hebrew (Hebrew)</Language>
+        <Language ID="hbo">Ancient Hebrew</Language>
         <Language ID="he">Hebrew (Hebrew)</Language>
       </Languages>
     </Keyboard>


### PR DESCRIPTION
- Updated the two Galaxie Hebrew keyboards to use the `&DISPLAYMAP`.
  - Added KbdHebr as the OSKFont
  - Removed 25cc from OSK and touch layout 
  - Added Ezra SIL for DisplayFont
- Updated the two Galaxie keyboard packages that include both the Greek and Hebrew keyboards.