### PR TITLE
chore: upgrade to kmc 17.0.332

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,53 +9,54 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/kmc": "17.0.330"
+        "@keymanapp/kmc": "17.0.332"
       }
     },
     "node_modules/@keymanapp/common-types": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/common-types/-/common-types-17.0.330.tgz",
-      "integrity": "sha512-5Vof2bX1B7igo8wAzwHzvKIDAAN2MnuAi8P+0fYX3xmP9IqfM46VXYJe9OkQM3u4lOWymXy4871+4OwofNNzIg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/common-types/-/common-types-17.0.332.tgz",
+      "integrity": "sha512-9dfZDI9jgF/UU+n188alS5e064QUCP33sdhYR8TY4tQgAYncTqrRV5SElqNkvG9XHnOS/82W4/mw3DsavjRnRA==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/keyman-version": "17.0.330",
+        "@keymanapp/keyman-version": "17.0.332",
+        "@keymanapp/ldml-keyboard-constants": "17.0.332",
         "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
         "semver": "^7.5.2",
         "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js.git#535fe732dc408d697e0f847c944cc45f0baf0829"
       }
     },
     "node_modules/@keymanapp/developer-utils": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/developer-utils/-/developer-utils-17.0.330.tgz",
-      "integrity": "sha512-eXjiUMljjvgCnVJswknhW3pHTN+htave3oxbpjzrPFjnTbDo1fGfPdB4E6vA2SaS4IJNS3EJVSczCFZyTWfpGw==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/developer-utils/-/developer-utils-17.0.332.tgz",
+      "integrity": "sha512-I41OK6Pfs5xLw+fY8xe1ROE3GWyeEcQbi21k/4XggvMbqGC/2BwDxyoluegTAF04SR+aymtSmMLmL7swSVH6kg==",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^7.57.0"
       }
     },
     "node_modules/@keymanapp/keyman-version": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-17.0.330.tgz",
-      "integrity": "sha512-DG/gSycpLlG59XErCwNImCUlsrVrk/8AL6vm0OA24l+TfPOGDUi+lXuCVL+C5VmvS/9plHXgJZywurXumysrcA==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-17.0.332.tgz",
+      "integrity": "sha512-zSOY8R/SJCtD1iKzKbuIMIzfvcyXeLzsMxVU9AKs5YK6DAmRXZWVLx+lYHUi+97M5pohLjOJIDRAKxB4JB/pSQ==",
       "license": "MIT"
     },
     "node_modules/@keymanapp/kmc": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc/-/kmc-17.0.330.tgz",
-      "integrity": "sha512-qIPpEYiHFa4cxEwHy+BlXOCTH/LceMnFDARw9LlqnyT7E/9T2xzN7Ne2xrY8z6cWC6a3txXSdPI3rRfFsvMEOg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc/-/kmc-17.0.332.tgz",
+      "integrity": "sha512-8WJ+vgtpbzj/NhK5J4uZcMGvqq7ghucqmiHImg9wMrJEIKd3NkQZshWOoWiKm24H5ZVF52u1aZ8ZPTHZWDjsIg==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
-        "@keymanapp/developer-utils": "17.0.330",
-        "@keymanapp/keyman-version": "17.0.330",
-        "@keymanapp/kmc-analyze": "17.0.330",
-        "@keymanapp/kmc-keyboard-info": "17.0.330",
-        "@keymanapp/kmc-kmn": "17.0.330",
-        "@keymanapp/kmc-ldml": "17.0.330",
-        "@keymanapp/kmc-model": "17.0.330",
-        "@keymanapp/kmc-model-info": "17.0.330",
-        "@keymanapp/kmc-package": "17.0.330",
-        "@keymanapp/models-types": "17.0.330",
+        "@keymanapp/common-types": "17.0.332",
+        "@keymanapp/developer-utils": "17.0.332",
+        "@keymanapp/keyman-version": "17.0.332",
+        "@keymanapp/kmc-analyze": "17.0.332",
+        "@keymanapp/kmc-keyboard-info": "17.0.332",
+        "@keymanapp/kmc-kmn": "17.0.332",
+        "@keymanapp/kmc-ldml": "17.0.332",
+        "@keymanapp/kmc-model": "17.0.332",
+        "@keymanapp/kmc-model-info": "17.0.332",
+        "@keymanapp/kmc-package": "17.0.332",
+        "@keymanapp/models-types": "17.0.332",
         "@sentry/node": "^7.57.0",
         "chalk": "^2.4.2",
         "commander": "^10.0.0",
@@ -68,134 +69,134 @@
       }
     },
     "node_modules/@keymanapp/kmc-analyze": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-analyze/-/kmc-analyze-17.0.330.tgz",
-      "integrity": "sha512-4RQqZVL8x2qNO+AQW4pfPOZbORmICfa8j98Qfv5NoJXkq2Fsrc5w9AfF8RTOdlrof/47x6OyFxq0ZjA2NHbGMg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-analyze/-/kmc-analyze-17.0.332.tgz",
+      "integrity": "sha512-0leI1i6RMf8QTEJsyQYyORLKbql7FjQIsvn/XJDiGX6teoR3TA2a5BEYGF1oxriZE7TlOsZWRkDVd3Q2xKVGVw==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
-        "@keymanapp/developer-utils": "17.0.330",
-        "@keymanapp/kmc-kmn": "17.0.330"
+        "@keymanapp/common-types": "17.0.332",
+        "@keymanapp/developer-utils": "17.0.332",
+        "@keymanapp/kmc-kmn": "17.0.332"
       }
     },
     "node_modules/@keymanapp/kmc-keyboard-info": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-keyboard-info/-/kmc-keyboard-info-17.0.330.tgz",
-      "integrity": "sha512-EYIV1v0gwShrpVWplVe4GoIhMM7VDrqHreJmR4nkaIWIOa3/JrKiGH43+GmOZwxLHoUF0AHTRkH+nMm74y4W2g==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-keyboard-info/-/kmc-keyboard-info-17.0.332.tgz",
+      "integrity": "sha512-sIKmIK3qOyiAfqT5VpUmTV9PXrWZs5qZbmfsHhVNqZ3FrK/5k+la0ue4U2RGBVh5Z0Uye9XifUiQHPhDAoDe1Q==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
-        "@keymanapp/developer-utils": "17.0.330",
-        "@keymanapp/kmc-package": "17.0.330"
+        "@keymanapp/common-types": "17.0.332",
+        "@keymanapp/developer-utils": "17.0.332",
+        "@keymanapp/kmc-package": "17.0.332"
       }
     },
     "node_modules/@keymanapp/kmc-kmn": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-kmn/-/kmc-kmn-17.0.330.tgz",
-      "integrity": "sha512-e9aiLWAQmBH/8yBLkwLAT4r+Cr01oubkFT8hcBnQ1f7PeYsE+kvtXNhE4MW5Ui8dgJkO2Uhv3fdFW+lERV3gxg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-kmn/-/kmc-kmn-17.0.332.tgz",
+      "integrity": "sha512-RRk5lKObmUk1J60aMD6MdvdP+unbIZX+xtBqPLewGn3l5zrm5qpc2NHYtb9acjxbR/4JIHVmyWnVsdOOqUnnSQ==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/developer-utils": "17.0.330",
-        "@keymanapp/keyman-version": "17.0.330",
-        "@keymanapp/kmc-kmn": "17.0.330"
+        "@keymanapp/developer-utils": "17.0.332",
+        "@keymanapp/keyman-version": "17.0.332",
+        "@keymanapp/kmc-kmn": "17.0.332"
       }
     },
     "node_modules/@keymanapp/kmc-ldml": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-ldml/-/kmc-ldml-17.0.330.tgz",
-      "integrity": "sha512-g+L6jYBixNRkcUd0nA+nuOaqeWWTnqWr3eS5uh7jZWGKc6LgiUg6WM8H+AtP1c3NmHcIfMM0PayczJHERn7Faw==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-ldml/-/kmc-ldml-17.0.332.tgz",
+      "integrity": "sha512-ViX15x5BMZ1nJbKWzKg618EWStqDvaPI3mEfZ5EPeQDKcNAUt5ND4rKnqI6HLXlH6w4XFqIBufggvj1r7DCLPQ==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/keyman-version": "17.0.330",
-        "@keymanapp/kmc-kmn": "17.0.330",
-        "@keymanapp/ldml-keyboard-constants": "17.0.330",
+        "@keymanapp/keyman-version": "17.0.332",
+        "@keymanapp/kmc-kmn": "17.0.332",
+        "@keymanapp/ldml-keyboard-constants": "17.0.332",
         "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
         "semver": "^7.5.2"
       }
     },
     "node_modules/@keymanapp/kmc-model": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model/-/kmc-model-17.0.330.tgz",
-      "integrity": "sha512-Dgdr0chSTRk7kS/XDUxvn54Lq4vWUEOjiEEGkm48KYE7Wk2jSqrzfg7xubvRycnvPvjDH2tn8/R0rrPwZaDBGg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model/-/kmc-model-17.0.332.tgz",
+      "integrity": "sha512-mnqzK3ReURkddrRP+2djmGzAWWUoIUl5EIlvRXRpXmItNXdf5aX/jfFx6byMDj+EpWvzoZCAW44Dijn3h2SA1w==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
-        "@keymanapp/keyman-version": "17.0.330",
-        "@keymanapp/models-types": "17.0.330",
+        "@keymanapp/common-types": "17.0.332",
+        "@keymanapp/keyman-version": "17.0.332",
+        "@keymanapp/models-types": "17.0.332",
         "typescript": "^4.9.5"
       }
     },
     "node_modules/@keymanapp/kmc-model-info": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model-info/-/kmc-model-info-17.0.330.tgz",
-      "integrity": "sha512-hdDJhK3JputGhWLz03ywGJrwk4HKb9GAJt1NaoeMI544HWKR/GAmVcwBkTLy2S0m+VomyCc1MRz/AiodJvNAVg==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-model-info/-/kmc-model-info-17.0.332.tgz",
+      "integrity": "sha512-wTw+uU87hcxi+RwZ2pbf1pjO0ugyH9YJRCkfboEhtqv7Zhmve5d2rQPDxCjN4aOazN8sq/jshgU7xHUrLaNHSw==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
-        "@keymanapp/developer-utils": "17.0.330",
-        "@keymanapp/models-types": "17.0.330"
+        "@keymanapp/common-types": "17.0.332",
+        "@keymanapp/developer-utils": "17.0.332",
+        "@keymanapp/models-types": "17.0.332"
       }
     },
     "node_modules/@keymanapp/kmc-package": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-package/-/kmc-package-17.0.330.tgz",
-      "integrity": "sha512-pbYDeAJvp7PSsZpV4uJzjG6rrLhWtlghhfP/AZ70tmbMBuvNzwKrv4EXMsJvbOAFN67L91Wa0AP3ULLsHNovpw==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/kmc-package/-/kmc-package-17.0.332.tgz",
+      "integrity": "sha512-tYII3AcARQH2WyX0GhfALrgDSn0K4r+BYITpdN+9EShsIwd44kuaUnvch6BoIFRoOFH1q2eNb60nL80A/RaGuQ==",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "17.0.330",
+        "@keymanapp/common-types": "17.0.332",
         "jszip": "^3.7.0",
         "marked": "^7.0.0",
         "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js.git#535fe732dc408d697e0f847c944cc45f0baf0829"
       }
     },
     "node_modules/@keymanapp/ldml-keyboard-constants": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/ldml-keyboard-constants/-/ldml-keyboard-constants-17.0.330.tgz",
-      "integrity": "sha512-KVCKHHLFykOuKzzHzmXHXngBSymvObQJNqKmtanowthfIMfQKtGSTdo3sF4z2aZ1LDuU/U4a5ShhL6ikM8AATQ==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/ldml-keyboard-constants/-/ldml-keyboard-constants-17.0.332.tgz",
+      "integrity": "sha512-W3VkhJgVBDZVNFT7jzPlqxqN2pfYnzDj1SFjk57sw2LHROyO4K4SAjT99lQPqUpVNq00z4US6UOZe6X9QH22jg==",
       "license": "MIT"
     },
     "node_modules/@keymanapp/models-types": {
-      "version": "17.0.330",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-17.0.330.tgz",
-      "integrity": "sha512-1IseKfYG5f5ZUtjX69L+ocqAl5J+GWTaP6CQdAvbFe1tccmTfQWXSV7kcW0QiaXqwnmNeG23ubYwvKZcCbAvSQ==",
+      "version": "17.0.332",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-17.0.332.tgz",
+      "integrity": "sha512-LMX5ymrcrVVpatzyz/o8p0joV0ewxZbe0PB3I326vuqpG2OjjpsCn642lnObribguiNrjKOZB/WRWuGqH71Avw==",
       "license": "MIT"
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
-      "integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
-      "integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
-      "integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -203,37 +204,37 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.0.tgz",
-      "integrity": "sha512-9PFzN8xS6U0oZCflpVxS2SSIsHkCaj7qYBlsvHj4CTGWfao9ImwrU6+smy4qoG6oxwPfoVb5pOOMb4WpWOvXcQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.2.tgz",
+      "integrity": "sha512-TPNnqxh+Myooe4jTyRiXrzrM2SH08R4+nrmBls4T7lKp2E5R/3mDSe/YTn5rRcUt1k1hPx1NgO/taG0DoS5cXA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
-      "integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
-      "integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.119.0"
+        "@sentry/types": "7.119.2"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/keymanapp/keyboards#readme",
   "dependencies": {
-    "@keymanapp/kmc": "17.0.330"
+    "@keymanapp/kmc": "17.0.332"
   }
 }


### PR DESCRIPTION
This has been tested in #3143 -- the fix has addressed the build failure there, so this should be good to go. Relevant fixes in this build:

* keymanapp/keyman#12609
* keymanapp/keyman#12628
