### PR TITLE
[sil_nubian] Fix link to Sophia Nubian font in help docs

### DIFF
--- a/release/sil/sil_nubian/HISTORY.md
+++ b/release/sil/sil_nubian/HISTORY.md
@@ -1,6 +1,10 @@
 Nubian (SIL) Change History
 =======================
 
+1.2.6 (2025-01-17)
+------------------
+* Fix link to Sophia Nubian font in help docs
+
 1.2.5 (2023-11-30)
 ----------------
 * Use shared font instead of local

--- a/release/sil/sil_nubian/LICENSE.md
+++ b/release/sil/sil_nubian/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2008-2023 SIL International
+Copyright (c) 2008-2025 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil_nubian/source/help/sil_nubian.php
+++ b/release/sil/sil_nubian/source/help/sil_nubian.php
@@ -6,7 +6,7 @@
 
 <h2>Font</h2>
 <p style="text-align: justify;">
-The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
+The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/sophianubian" target=_blank>Sophia Nubian</a> 
 font. However, you can use this keyboard with any Coptic  
 Unicode font.  
 </p>

--- a/release/sil/sil_nubian/source/help/sil_nubian.php
+++ b/release/sil/sil_nubian/source/help/sil_nubian.php
@@ -6,7 +6,7 @@
 
 <h2>Font</h2>
 <p style="text-align: justify;">
-The "Nubian (SIL)" keyboard is designed to work with the  <A href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</A> 
+The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
 font. However, you can use this keyboard with any Coptic  
 Unicode font.  
 </p>

--- a/release/sil/sil_nubian/source/readme.htm
+++ b/release/sil/sil_nubian/source/readme.htm
@@ -18,7 +18,7 @@ style="PADDING-RIGHT: 25px; PADDING-LEFT: 25px; PADDING-BOTTOM: 25px; MARGIN: 0p
 <A name=intro></A>
       <H2>Introduction</H2>
       <P>This keyboard was developed for keyboarding Nubian languages in the Coptic Script. The 
-      "Nubian (SIL)" keyboard is designed to work with the  <A href="http://scripts.sil.org/SophiaNubian" target=_blank>Sophia Nubian</A> 
+      "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
       font. However, you can use this keyboard with any Coptic  
       Unicode font. </P><A name=kmn></A>
       

--- a/release/sil/sil_nubian/source/readme.htm
+++ b/release/sil/sil_nubian/source/readme.htm
@@ -18,7 +18,7 @@ style="PADDING-RIGHT: 25px; PADDING-LEFT: 25px; PADDING-BOTTOM: 25px; MARGIN: 0p
 <A name=intro></A>
       <H2>Introduction</H2>
       <P>This keyboard was developed for keyboarding Nubian languages in the Coptic Script. The 
-      "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
+      "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/sophianubian" target=_blank>Sophia Nubian</a> 
       font. However, you can use this keyboard with any Coptic  
       Unicode font. </P><A name=kmn></A>
       

--- a/release/sil/sil_nubian/source/sil_nubian.kmn
+++ b/release/sil/sil_nubian/source/sil_nubian.kmn
@@ -8,7 +8,7 @@ store(&TARGETS) 'any'
 store(&COPYRIGHT) '© SIL International'
 store(&MESSAGE) "The SIL Nubian Unicode keyboard is distributed under The MIT License (MIT)."
 c store(&ETHNOLOGUECODE) 'fia dgl xnz'
-store(&KEYBOARDVERSION) '1.2.5'
+store(&KEYBOARDVERSION) '1.2.6'
 store(&VISUALKEYBOARD) 'sil_nubian.kvks'
 store(&LAYOUTFILE) 'sil_nubian.keyman-touch-layout'
 

--- a/release/sil/sil_nubian/source/sil_nubian.kps
+++ b/release/sil/sil_nubian/source/sil_nubian.kps
@@ -32,7 +32,7 @@
     <WebSite URL="https://software.sil.org/SophiaNubian">https://software.sil.org/SophiaNubian</WebSite>
     <Description>This keyboard was developed for keyboarding Nubian languages in the
 Coptic Script. The \"SIL Nubian\" keyboard is designed to work with the
-[Sophia Nubian](http://scripts.sil.org/SophiaNubian) font. However, you
+[Sophia Nubian](https://software.sil.org/SophiaNubian) font. However, you
 can use this keyboard with any Coptic Unicode font.</Description>
   </Info>
   <Files>

--- a/release/sil/sil_nubian/source/sil_nubian.kps
+++ b/release/sil/sil_nubian/source/sil_nubian.kps
@@ -29,10 +29,10 @@
     <Copyright URL="">© 2008-2023 SIL International</Copyright>
     <Version URL=""></Version>
     <Author URL="">Lorna Priest Evans</Author>
-    <WebSite URL="https://software.sil.org/SophiaNubian">https://software.sil.org/SophiaNubian</WebSite>
+    <WebSite URL="https://software.sil.org/sophianubian">https://software.sil.org/sophianubian</WebSite>
     <Description>This keyboard was developed for keyboarding Nubian languages in the
 Coptic Script. The \"SIL Nubian\" keyboard is designed to work with the
-[Sophia Nubian](https://software.sil.org/SophiaNubian) font. However, you
+[Sophia Nubian](https://software.sil.org/sophianubian) font. However, you
 can use this keyboard with any Coptic Unicode font.</Description>
   </Info>
   <Files>

--- a/release/sil/sil_nubian/source/welcome/welcome.htm
+++ b/release/sil/sil_nubian/source/welcome/welcome.htm
@@ -7,7 +7,7 @@
 
 <h2>Font</h2>
 <p style="text-align: justify;">
-The "Nubian (SIL)" keyboard is designed to work with the  <A href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</A> 
+The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
 font. However, you can use this keyboard with any Coptic  
 Unicode font.  
 </p>

--- a/release/sil/sil_nubian/source/welcome/welcome.htm
+++ b/release/sil/sil_nubian/source/welcome/welcome.htm
@@ -7,7 +7,7 @@
 
 <h2>Font</h2>
 <p style="text-align: justify;">
-The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/SophiaNubian" target=_blank>Sophia Nubian</a> 
+The "Nubian (SIL)" keyboard is designed to work with the  <a href="https://software.sil.org/sophianubian" target=_blank>Sophia Nubian</a> 
 font. However, you can use this keyboard with any Coptic  
 Unicode font.  
 </p>


### PR DESCRIPTION
Fixes #3290 

Fixes the link to Sophia Nubian fonts in the help docs to `https://software.sil.org/sophianubian`