### PR TITLE
fix: add missing comma in tengwar.keyboard_info

### DIFF
--- a/legacy/t/tengwar/tengwar.keyboard_info
+++ b/legacy/t/tengwar/tengwar.keyboard_info
@@ -14,7 +14,7 @@
   ],
   "version": "1.0",
   "minKeymanVersion": "5.0",
-  "helpLink": "https://help.keyman.com/keyboard/tengwar"
+  "helpLink": "https://help.keyman.com/keyboard/tengwar",
   "platformSupport": {
     "windows": "full",
     "macos": "full"


### PR DESCRIPTION
The patch in #3336 missed a comma, which broke the release build. (The files in legacy/ are more fragile and do not have many build checks, as they generally do not get modified.)

Fixes: #3333
Emerging-From: #3336