### PR TITLE
chore: fix typo in luo_lakeside.php

### DIFF
--- a/experimental/l/luo_lakeside/source/help/luo_lakeside.php
+++ b/experimental/l/luo_lakeside/source/help/luo_lakeside.php
@@ -1,5 +1,5 @@
 <?php
-$pagename = Luo Lakeside Keyboard Help';
+$pagename = 'Luo Lakeside Keyboard Help';
 $pagetitle = $pagename;
 // Header
 require_once('header.php');


### PR DESCRIPTION
Failed [deployment](https://github.com/keymanapp/help.keyman.com/actions/runs/14002922828/job/39212520637):

```
PHP Parse error:  syntax error, unexpected identifier "Lakeside" in ./keyboard/luo_lakeside/1.0/luo_lakeside.php on line 2
```