### PR TITLE
(sil-ipa) Add Unicode modifier letters to superscripts

### DIFF
--- a/release/sil/sil_ipa/source/sil_ipa.kmn
+++ b/release/sil/sil_ipa/source/sil_ipa.kmn
@@ -118,31 +118,48 @@ c store(lessK)  "ELOQR?.#!acdehjlnorstuz" "#<"
 
 c store(hatK)  "?gjnwlh" "0123456789-" "m" "n=" "n>"
    store(hatD)  "0123456789" \
-                "-"    "+"    "="    "("    ")"    U+01C3 \
-                U+0295 U+0294 "b"    U+03B2 "c"    U+0255 "d"    U+00F0 "f" \
-                "g"    U+0261 U+0263 "h"    U+0266 U+0265 "j"    U+029D \
-                U+025F "k" \
-                "l"    U+026D U+029F "m"    U+0271 "n"    U+0272 U+014B U+0273 U+0274 \
-                "p"    U+0278 "r"    U+0279 U+027B U+0281 "s"    U+0282 U+0283 \
-                "t"    U+0270 "v"    U+028B "w"    "x"    "z"    U+0291 U+0290 U+0292 \
-                U+03B8 \
-                "a"    U+0250 U+0251 U+0252 U+1D02 "e"    U+0259 U+025B U+025C \
-                "i"    U+0268 U+026A "o"    U+0153 U+0275 U+0254 \
-                "u"    U+0289 "y"    U+026F U+028C U+028A
+                "-"    "("    ")"    "+"    "="    "a" \
+                U+00E6 U+1D02 U+0250 U+0251 U+0252 "b" \
+                U+0299 U+0253 "c"    U+0255 "d"    U+00F0 \
+                U+0256 U+0257 "e"    U+0259 U+025B U+0258 \
+                U+025C U+025E U+0264 "f"    "g"    U+0261 \
+                U+0262 U+0260 U+029B U+0263 "h"    U+0127 \
+                U+029C U+0266 U+0267 "i"    U+026A U+0268 \
+                U+1D7B U+0269 "j"    U+029D U+025F U+0284 \
+                "k"   "l"     U+029F U+026C U+026D U+026E \
+                U+028E "m"    U+0271 "n"    U+0274 U+0272 \
+                U+0273 U+014B "o"    U+00F8 U+0153 U+0276 \
+                U+0254 U+0275 U+0277 "p"    U+0278 "q" \
+                "r"    U+0280 U+0279 U+027A U+027B U+027D \
+                U+027E U+0281 "s"    U+0282 U+0283 "t" \
+                U+0288 "u"    U+0289 U+0265 U+026F U+0270 \
+                U+028A "v"    U+028B U+028C "w"    U+028D \
+                "x"    "y"    U+028F "z"    U+0290 U+0291 \
+                U+0292 U+0294 U+0295 U+02A1 U+02A2 U+01C0 \
+                U+01C1 U+01C2 U+01C3 U+0298 U+03B2 U+03B8 \
+                U+03C7
 
    store(hatU)  U+2070 U+00B9 U+00B2 U+00B3 U+2074 U+2075 U+2076 U+2077 U+2078 U+2079 \
-                U+207B U+207A U+207C U+207D U+207E U+A71D \
-                U+02E4 U+02C0 U+1D47 U+1D5D U+1D9C U+1D9D U+1D48 U+1D9E U+1DA0 \
-                U+1D4D U+1Da2 U+02E0 U+02B0 U+02B1 U+1DA3 U+02B2 U+1DA8 \
-                U+1DA1 U+1D4F \
-                U+02E1 U+1DA9 U+1DAB U+1D50 U+1DAC U+207F U+1DAE U+1D51 U+1DAF U+1DB0 \
-                U+1D56 U+1DB2 U+02B3 U+02B4 U+02B5 U+02B6 U+02E2 U+1DB3 U+1DB4 \
-                U+1D57 U+1DAD U+1D5B U+1DB9 U+02B7 U+02E3 U+1DBB U+1DBD U+1DBC U+1DBE \
-                U+1DBF \
-                U+1D43 U+1D44 U+1D45 U+1D9B U+1D46 U+1D49 U+1D4A U+1D4B U+1D9F \
-                U+2071 U+1DA4 U+1DA6 U+1D52 U+A7F9 U+1DB1 U+1D53 \
-                U+1D58 U+1DB6 U+02B8 U+1D5A U+1DBA U+1DB7
-
+                U+207B U+207D U+207E U+207A U+207C U+1D43 \
+                U+10783 U+1D46 U+1D44 U+1D45 U+1D9B U+1D47 \
+                U+10784 U+10785 U+1D9C U+1D9D U+1D48 U+1D9E \
+                U+1078B U+1078C U+1D49 U+1D4A U+1D4B U+1078E \
+                U+1D9F U+1078F U+10791 U+1DA0 U+1D4D U+1DA2 \
+                U+10792 U+10793 U+10794 U+02E0 U+02B0 U+10795 \
+                U+10796 U+02B1 U+10797 U+2071 U+1DA6 U+1DA4 \
+                U+1DA7 U+1DA5 U+02B2 U+1DA8 U+1DA1 U+10798 \
+                U+1D4F U+02E1 U+1DAB U+1079B U+1DA9 U+1079E \
+                U+107A0 U+1D50 U+1DAC U+207F U+1DB0 U+1DAE \
+                U+1DAF U+1D51 U+1D52 U+107A2 U+A7F9 U+107A3 \
+                U+1D53 U+1DB1 U+107A4 U+1D56 U+1DB2 U+107A5 \
+                U+02B3 U+107AA U+02B4 U+107A6 U+02B5 U+107A8 \
+                U+107A9 U+02B6 U+02E2 U+1DB3 U+1DB4 U+1D57 \
+                U+107AF U+1D58 U+1DB6 U+1DA3 U+1D5A U+1DAD \
+                U+1DB7 U+1D5B U+1DB9 U+1DBA U+02B7 U+AB69 \
+                U+02E3 U+02B8 U+107B2 U+1DBB U+1DBC U+1DBD \
+                U+1DBE U+02C0 U+02E4 U+107B3 U+107B4 U+107B6 \
+                U+107B7 U+107B8 U+A71D U+107B5 U+1D5D U+1DBF \
+                U+1D61
    c subscript numerals get incorporated in the "_" rota
    store(subscriptD)  "0123456789"
 


### PR DESCRIPTION
This adds more superscript modifier letter characters to the hatD +"^" rule.