### PR TITLE
[fv_hailzaqvla] Fix layers in online help

### DIFF
--- a/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
+++ b/release/fv/fv_hailzaqvla/source/help/fv_hailzaqvla.php
@@ -25,7 +25,7 @@ require_once ('header.php');
 <br />
 
 <h2>Keyboard Layout (Desktop)</h2>
-<div id='osk' data-states='default shift alt shift-alt'></div>
+<div id='osk' data-states='default shift rightalt rightalt-shift'></div>
 
 <h3>Notes on desktop layout</h3>
 


### PR DESCRIPTION
Fixes: HELP-KEYMAN-COM-DPE

Error
> Keyboard Keyboard_fv_hailzaqvla does not have a layer with id alt

Update the osk layers to use `rightalt` and `rightalt-shift`

No change in version since this is only updating the online help file.
