### PR TITLE
[unifon] Fix missing layers in online help

### DIFF
--- a/experimental/u/unifon/source/help/unifon.php
+++ b/experimental/u/unifon/source/help/unifon.php
@@ -23,6 +23,6 @@ This keyboard is designed for the Unifon aphabet. It is using a custom encoding.
 <h2>Phone Keyboard Layout</h2>
 <p>Due to the size and number of keys, some characters are hidden in the long press. 
 	Press and hold on the key with a little dot on the top right to reveal and use them.</p>
-<div id='osk-phone' data-states='default shift numeric symbol currency'>
+<div id='osk-phone' data-states='default shift'>
 </div>
 


### PR DESCRIPTION
Fixes: HELP-KEYMAN-COM-DDZ

Error:
>Keyboard Keyboard_unifon does not have a layer with id numeric

Removes invalid layers in the online help file.

No version change since only updating online help
