### PR TITLE
[belgian_typewriter]: Fix missing layer in online help

### DIFF
--- a/release/b/belgian_typewriter/source/help/belgian_typewriter.php
+++ b/release/b/belgian_typewriter/source/help/belgian_typewriter.php
@@ -20,5 +20,5 @@
 </div>
 
 <h2>Mobile/Tablet Keyboard Layout</h2>
-<div id='osk-tablet' data-states='default shift symbol'>
+<div id='osk-tablet' data-states='default shift rightalt'>
 </div>


### PR DESCRIPTION
Fixes error about missing layer `symbol`

Online help updated to use `rightalt`
 