### PR TITLE
GFF Amharic v3.1.3

### DIFF
--- a/release/gff/gff_amharic/HISTORY.md
+++ b/release/gff/gff_amharic/HISTORY.md
@@ -6,7 +6,7 @@ gff_amharic Change History
 * mobile: removed accidental double U+2019 on an apostrophe longpress
 * mobile: added missing ‹ and › to apostrophe longpress
 * mobile: removed double quote from the double quote longpress
-* mobile: Added new layers: latin-punct-layer and eth-punct-layer
+* mobile: Added new layers: latin-punct-layer and ethio-punct-layer
 
 3.1.2 (29 Oct 2024)
 --------------------

--- a/release/gff/gff_amharic/HISTORY.md
+++ b/release/gff/gff_amharic/HISTORY.md
@@ -1,5 +1,12 @@
 gff_amharic Change History
 ==========================
+3.1.3 (04 Oct 2025)
+-------------------
+* mobile: Fixed K_J key nextlayer changes (from ደ to ጀ layer)
+* mobile: removed accidental double U+2019 on an apostrophe longpress
+* mobile: added missing ‹ and › to apostrophe longpress
+* mobile: removed double quote from the doublequote longpress
+* mobile: Added new layers: latin-punct-layer and eth-punct-layer
 
 3.1.2 (29 Oct 2024)
 --------------------

--- a/release/gff/gff_amharic/HISTORY.md
+++ b/release/gff/gff_amharic/HISTORY.md
@@ -1,11 +1,11 @@
 gff_amharic Change History
 ==========================
-3.1.3 (04 Oct 2025)
+3.1.3 (22 April 2025)
 -------------------
 * mobile: Fixed K_J key nextlayer changes (from ደ to ጀ layer)
 * mobile: removed accidental double U+2019 on an apostrophe longpress
 * mobile: added missing ‹ and › to apostrophe longpress
-* mobile: removed double quote from the doublequote longpress
+* mobile: removed double quote from the double quote longpress
 * mobile: Added new layers: latin-punct-layer and eth-punct-layer
 
 3.1.2 (29 Oct 2024)

--- a/release/gff/gff_amharic/LICENSE.md
+++ b/release/gff/gff_amharic/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 1997-2024 Geʾez Frontier Foundation
+Copyright (c) 1997-2025 Geʾez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_amharic/source/gff_amharic.css
+++ b/release/gff/gff_amharic/source/gff_amharic.css
@@ -17,8 +17,10 @@
 .phone div.kmw-key.kmw-key-default[id$='K_SPACE'], .tablet div.kmw-key.kmw-key-default[id$='K_SPACE']
   { background: #f4eee7 ; color: #f4eee7 ; } /* eceae4 */
 
-.phone div.kmw-key.kmw-key-default[id$='K_1+shift'], .tablet div.kmw-key.kmw-key-default[id$='K_1+shift'], /* ! */
-.phone div.kmw-key.kmw-key-default[id$='U_1362'],    .tablet div.kmw-key.kmw-key-default[id$='U_1362']        /* ። */
+.phone div.kmw-key.kmw-key-default[id$='K_1+shift'], .tablet div.kmw-key.kmw-key-default[id$='K_1+shift'],  /* ! */
+.phone div.kmw-key.kmw-key-default[id$='U_1362'],    .tablet div.kmw-key.kmw-key-default[id$='U_1362'],     /* ። */
+.phone div.kmw-key.kmw-key-default[id$='T_BANG'],                                                           /* ! */
+.phone div.kmw-key.kmw-key-default[id$='T_1362']                                                            /* ። */
   { background: #f4eee7 ; color: black ; }
 
 
@@ -124,7 +126,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1340'], .tablet div.kmw-key.kmw-key-default[id$='U_1340'],  /* ፀ */
 .phone div.kmw-key.kmw-key-default[id$='U_1348'], .tablet div.kmw-key.kmw-key-default[id$='U_1348'],  /* ፈ */
 .phone div.kmw-key.kmw-key-default[id$='U_1350'], .tablet div.kmw-key.kmw-key-default[id$='U_1350'],  /* ፐ */
-.phone div.kmw-key.kmw-key-default[id$='T_ግዕዝ'], .tablet div.kmw-key.kmw-key-default[id$='T_ግዕዝ']
+.phone div.kmw-key.kmw-key-default[id$='T_ግዕዝ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ግዕዝ'],   /* አ */
+.phone div.kmw-key.kmw-key-default[id$='K_2+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1360'] /* @, ፠ */
   { background:  #e2f0cb ; color: black; } /*#baed91 */
 
 /* default layer ካዕብ */
@@ -166,7 +169,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1341'], .tablet div.kmw-key.kmw-key-default[id$='U_1341'],  /* ፁ */
 .phone div.kmw-key.kmw-key-default[id$='U_1349'], .tablet div.kmw-key.kmw-key-default[id$='U_1349'],  /* ፉ */
 .phone div.kmw-key.kmw-key-default[id$='U_1351'], .tablet div.kmw-key.kmw-key-default[id$='U_1351'],  /* ፑ */
-.phone div.kmw-key.kmw-key-default[id$='T_ካዕብ'], .tablet div.kmw-key.kmw-key-default[id$='T_ካዕብ']
+.phone div.kmw-key.kmw-key-default[id$='T_ካዕብ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ካዕብ'],   /* ኡ */
+.phone div.kmw-key.kmw-key-default[id$='K_4+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1365'] /* $, ፥ */
   { background:  #ffffb5 ; color: black; } /* #faf884 */ 
 
 /* default layer ሣልስ */
@@ -208,7 +212,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1342'], .tablet div.kmw-key.kmw-key-default[id$='U_1342'],  /* ፂ */
 .phone div.kmw-key.kmw-key-default[id$='U_134A'], .tablet div.kmw-key.kmw-key-default[id$='U_134A'],  /* ፊ */
 .phone div.kmw-key.kmw-key-default[id$='U_1352'], .tablet div.kmw-key.kmw-key-default[id$='U_1352'],  /* ፒ */
-.phone div.kmw-key.kmw-key-default[id$='T_ሣልስ'], .tablet div.kmw-key.kmw-key-default[id$='T_ሣልስ']
+.phone div.kmw-key.kmw-key-default[id$='T_ሣልስ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ሣልስ'],  /* ኢ */
+.phone div.kmw-key.kmw-key-default[id$='T_00AB'], .phone div.kmw-key.kmw-key-default[id$='T_1366']   /* «, ፦ */
   { background:  #fea3aa  ; color: black; }
 
 /* default layer ራብዕ */
@@ -250,7 +255,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1343'], .tablet div.kmw-key.kmw-key-default[id$='U_1343'],  /* ፃ */
 .phone div.kmw-key.kmw-key-default[id$='U_134B'], .tablet div.kmw-key.kmw-key-default[id$='U_134B'],  /* ፋ */
 .phone div.kmw-key.kmw-key-default[id$='U_1353'], .tablet div.kmw-key.kmw-key-default[id$='U_1353'],  /* ፓ */
-.phone div.kmw-key.kmw-key-default[id$='T_ራብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ራብዕ']
+.phone div.kmw-key.kmw-key-default[id$='T_ራብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ራብዕ'],    /* ኣ */
+.phone div.kmw-key.kmw-key-default[id$='T_00BB'], .phone div.kmw-key.kmw-key-default[id$='T_1361'] /* », : */
   { background:  #ccf1ff  ; color: black; } /* #b2cefe */
 
 /* default layer ኃምስ */
@@ -292,7 +298,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1344'], .tablet div.kmw-key.kmw-key-default[id$='U_1344'],  /* ፄ */
 .phone div.kmw-key.kmw-key-default[id$='U_134C'], .tablet div.kmw-key.kmw-key-default[id$='U_134C'],  /* ፌ */
 .phone div.kmw-key.kmw-key-default[id$='U_1354'], .tablet div.kmw-key.kmw-key-default[id$='U_1354'],  /* ፔ */
-.phone div.kmw-key.kmw-key-default[id$='T_ኃምስ'], .tablet div.kmw-key.kmw-key-default[id$='T_ኃምስ']
+.phone div.kmw-key.kmw-key-default[id$='T_ኃምስ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ኃምስ'],  /* ኤ */
+.phone div.kmw-key.kmw-key-default[id$='K_SLASH'], .phone div.kmw-key.kmw-key-default[id$='T_1363']   /* /, ፣ */
   { background:  #e0d7ff  ; color: black; } /* #f2a2e8 */
 
 /* default layer ሳድስ - used primarily when a sadis letter appears in a popup or on the -extra layers */
@@ -374,8 +381,9 @@
 .phone div.kmw-key.kmw-key-default[id$='U_133E'], .tablet div.kmw-key.kmw-key-default[id$='U_133E'],  /* ጾ */
 .phone div.kmw-key.kmw-key-default[id$='U_1346'], .tablet div.kmw-key.kmw-key-default[id$='U_1346'],  /* ፆ */
 .phone div.kmw-key.kmw-key-default[id$='U_134E'], .tablet div.kmw-key.kmw-key-default[id$='U_134E'],  /* ፎ */
-.phone div.kmw-key.kmw-key-default[id$='U_1356'], .tablet div.kmw-key.kmw-key-default[id$='U_1356'],   /* ፖ */
-.phone div.kmw-key.kmw-key-default[id$='T_ሳብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ሳብዕ']
+.phone div.kmw-key.kmw-key-default[id$='U_1356'], .tablet div.kmw-key.kmw-key-default[id$='U_1356'],  /* ፖ */
+.phone div.kmw-key.kmw-key-default[id$='T_ሳብዕ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ሳብዕ'],   /* ኦ */
+.phone div.kmw-key.kmw-key-default[id$='K_SLASH+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1364']   /* ?, ፤︁ */
   { background:  #fad6b6  ; color: black; } /* f8b88b*/
 
 /* default layer ዘመደ-ራብዕ */
@@ -506,12 +514,18 @@
 .phone.ios div.kmw-key.kmw-key-default[id$='extra-U_1345'], .tablet.ios div.kmw-key.kmw-key-default[id$='extra-U_1345'],
 .phone.ios div.kmw-key.kmw-key-default[id$='extra-U_12E5'], .tablet.ios div.kmw-key.kmw-key-default[id$='extra-U_12E5'],
 .tablet.ios .kmw-keyboard-gff_amharic #punctuation-K_HYPHEN, .tablet.ios .kmw-keyboard-gff_amharic #punctuation-K_EQUAL,  
-.ios .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift
+.ios .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_2\+shift,  .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_2\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_SLASH\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_SLASH\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_4\+shift
   {background: #fdfdfe ; color: black ; }
 
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_1225'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_1225'],
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_1345'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_1345'],
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_12E5'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_12E5'],
 .tablet.android .kmw-keyboard-gff_amharic #punctuation-K_HYPHEN, .tablet.android .kmw-keyboard-gff_amharic #punctuation-K_EQUAL, 
-.android .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift
+.android .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_2\+shift,  .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_2\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_SLASH\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_SLASH\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_4\+shift
   {background: #777 ; color: white ; }

--- a/release/gff/gff_amharic/source/gff_amharic.keyman-touch-layout
+++ b/release/gff/gff_amharic/source/gff_amharic.keyman-touch-layout
@@ -1055,7 +1055,6 @@
                 "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "default",
                 "sk": [
                   {
                     "text": "?",
@@ -2405,10 +2404,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -2438,7 +2436,7 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
                 "nextlayer": "ethio-punct-layer",
                 "sk": [
@@ -3782,10 +3780,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -3815,7 +3812,7 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
                 "nextlayer": "ethio-punct-layer",
                 "sk": [
@@ -5135,10 +5132,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -5168,8 +5164,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -6487,10 +6484,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -6520,8 +6516,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -7839,10 +7836,9 @@
                 ]
               },
               {
-                "id": "K_1",
-                "nextlayer": "latin-punct-layer",
+                "id": "T_BANG",
                 "text": "!",
-                "layer": "shift",
+                "nextlayer": "latin-punct-layer",
                 "sk": [
                   {
                     "text": "?",
@@ -7872,8 +7868,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -9191,10 +9188,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "nextlayer": "latin-punct-layer",
                 "text": "!",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -9224,8 +9220,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -10543,10 +10540,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "nextlayer": "latin-punct-layer",
                 "text": "!",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -10576,8 +10572,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -11895,10 +11892,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "nextlayer": "latin-punct-layer",
                 "text": "!",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -11928,8 +11924,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -13247,10 +13244,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "nextlayer": "latin-punct-layer",
                 "text": "!",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -13280,8 +13276,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -14623,10 +14620,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -14656,8 +14652,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -15999,10 +15996,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -16032,8 +16028,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -17351,10 +17348,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -17384,8 +17380,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -18703,10 +18700,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -18736,8 +18732,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -20055,10 +20052,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -20088,8 +20084,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -21407,10 +21404,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -21440,8 +21436,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -22783,10 +22780,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -22816,8 +22812,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -24135,10 +24132,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -24168,8 +24164,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -25487,10 +25484,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -25520,8 +25516,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -26863,10 +26860,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -26896,8 +26892,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -28209,10 +28206,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -28242,8 +28238,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -29555,10 +29552,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -29588,8 +29584,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -30907,10 +30904,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -30940,8 +30936,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -32259,10 +32256,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -32292,8 +32288,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -33605,10 +33602,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -33638,8 +33634,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -34957,10 +34954,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -34990,8 +34986,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -36309,10 +36306,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -36342,8 +36338,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -37685,10 +37682,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -37718,8 +37714,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -39031,10 +39028,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -39064,8 +39060,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -40383,10 +40380,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -40416,8 +40412,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -41735,10 +41732,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -41768,8 +41764,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -43087,10 +43084,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -43120,8 +43116,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -44439,10 +44436,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -44472,8 +44468,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -45785,10 +45782,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -45818,8 +45814,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -47137,10 +47134,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -47170,8 +47166,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -48732,8 +48729,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -49378,8 +49376,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -50024,8 +50023,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -50785,8 +50785,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -51552,8 +51553,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -52343,8 +52345,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -53110,8 +53113,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -53901,8 +53905,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -54668,8 +54673,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -55458,8 +55464,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -56249,8 +56256,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -57010,8 +57018,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -57776,8 +57785,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "’",
@@ -58965,7 +58975,7 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
                 "nextlayer": "ethio-punct-layer",
                 "sk": [
@@ -59246,7 +59256,7 @@
                 "sp": 0
               },
               {
-                "id": "U_00BB",
+                "id": "T_00BB",
                 "text": "»",
                 "sk": [
                   {
@@ -59266,7 +59276,6 @@
               {
                 "id": "K_SLASH",
                 "text": "/",
-                "layer": "default",
                 "hint": "()",
                 "sk": [
                   {
@@ -60352,10 +60361,9 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
                 "nextlayer": "latin-punct-layer",
-                "layer": "shift",
                 "sk": [
                   {
                     "text": "?",
@@ -60387,6 +60395,7 @@
               {
                 "id": "U_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",

--- a/release/gff/gff_amharic/source/gff_amharic.keyman-touch-layout
+++ b/release/gff/gff_amharic/source/gff_amharic.keyman-touch-layout
@@ -77,7 +77,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -171,7 +171,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -418,7 +418,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -620,7 +619,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -891,8 +890,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -1025,7 +1023,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -1054,9 +1052,10 @@
                 ]
               },
               {
-                "id": "K_1",
+                "id": "T_BANG",
                 "text": "!",
-                "layer": "shift",
+                "nextlayer": "latin-punct-layer",
+                "layer": "default",
                 "sk": [
                   {
                     "text": "?",
@@ -1086,8 +1085,9 @@
                 ]
               },
               {
-                "id": "U_1362",
+                "id": "T_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -1298,8 +1298,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -1309,15 +1308,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "አ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኧ",
@@ -1327,47 +1322,34 @@
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -1448,7 +1430,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -1542,7 +1524,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -1789,7 +1771,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -1991,7 +1972,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -2262,8 +2243,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -2396,7 +2376,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -2427,6 +2407,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -2459,6 +2440,7 @@
               {
                 "id": "U_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -2669,8 +2651,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -2680,15 +2661,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ሀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኈ",
@@ -2699,8 +2676,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ሁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኍ",
@@ -2711,8 +2686,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ሂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኊ",
@@ -2723,15 +2696,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኋ",
@@ -2742,8 +2712,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ሄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኌ",
@@ -2753,16 +2721,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሆ",
-                "pad": "",
-                "width": ""
+                "text": "ሆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -2843,7 +2807,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -2937,7 +2901,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -3184,7 +3148,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -3386,7 +3349,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -3657,8 +3620,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -3791,7 +3753,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -3822,6 +3784,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -3854,6 +3817,7 @@
               {
                 "id": "U_1362",
                 "text": "።",
+                "nextlayer": "ethio-punct-layer",
                 "sk": [
                   {
                     "text": "፡",
@@ -4064,8 +4028,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -4075,40 +4038,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ለ",
-                "pad": "",
-                "width": ""
+                "text": "ለ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሉ",
-                "pad": "",
-                "width": ""
+                "text": "ሉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሊ",
-                "pad": "",
-                "width": ""
+                "text": "ሊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ላ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሏ",
@@ -4118,22 +4070,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሌ",
-                "pad": "",
-                "width": ""
+                "text": "ሌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሎ",
-                "pad": "",
-                "width": ""
+                "text": "ሎ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -4214,7 +4160,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -4308,7 +4254,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -4555,7 +4501,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -4757,7 +4702,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -5028,8 +4973,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -5162,7 +5106,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -5193,6 +5137,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -5435,8 +5380,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -5446,40 +5390,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሐ",
-                "pad": "",
-                "width": ""
+                "text": "ሐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሑ",
-                "pad": "",
-                "width": ""
+                "text": "ሑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሒ",
-                "pad": "",
-                "width": ""
+                "text": "ሒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሗ",
@@ -5489,22 +5422,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሔ",
-                "pad": "",
-                "width": ""
+                "text": "ሔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሖ",
-                "pad": "",
-                "width": ""
+                "text": "ሖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -5585,7 +5512,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -5679,7 +5606,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -5926,7 +5853,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -6128,7 +6054,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -6399,8 +6325,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -6533,7 +6458,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -6564,6 +6489,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -6806,8 +6732,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -6817,40 +6742,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "መ",
-                "pad": "",
-                "width": ""
+                "text": "መ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሙ",
-                "pad": "",
-                "width": ""
+                "text": "ሙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሚ",
-                "pad": "",
-                "width": ""
+                "text": "ሚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ማ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሟ",
@@ -6860,22 +6774,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሜ",
-                "pad": "",
-                "width": ""
+                "text": "ሜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሞ",
-                "pad": "",
-                "width": ""
+                "text": "ሞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -6956,7 +6864,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -7050,7 +6958,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -7297,7 +7205,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -7499,7 +7406,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -7770,8 +7677,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -7904,7 +7810,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -7934,6 +7840,7 @@
               },
               {
                 "id": "K_1",
+                "nextlayer": "latin-punct-layer",
                 "text": "!",
                 "layer": "shift",
                 "sk": [
@@ -8177,8 +8084,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -8188,40 +8094,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሠ",
-                "pad": "",
-                "width": ""
+                "text": "ሠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሡ",
-                "pad": "",
-                "width": ""
+                "text": "ሡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሢ",
-                "pad": "",
-                "width": ""
+                "text": "ሢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሣ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሧ",
@@ -8231,22 +8126,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሤ",
-                "pad": "",
-                "width": ""
+                "text": "ሤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሦ",
-                "pad": "",
-                "width": ""
+                "text": "ሦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -8421,7 +8310,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -8668,7 +8557,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -8870,7 +8758,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -9141,8 +9029,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -9275,7 +9162,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -9305,6 +9192,7 @@
               },
               {
                 "id": "K_1",
+                "nextlayer": "latin-punct-layer",
                 "text": "!",
                 "layer": "shift",
                 "sk": [
@@ -9548,8 +9436,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -9559,40 +9446,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ረ",
-                "pad": "",
-                "width": ""
+                "text": "ረ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሩ",
-                "pad": "",
-                "width": ""
+                "text": "ሩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሪ",
-                "pad": "",
-                "width": ""
+                "text": "ሪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ራ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሯ",
@@ -9602,22 +9478,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሬ",
-                "pad": "",
-                "width": ""
+                "text": "ሬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሮ",
-                "pad": "",
-                "width": ""
+                "text": "ሮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -9698,7 +9568,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -9792,7 +9662,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -10039,7 +9909,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -10241,7 +10110,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -10512,8 +10381,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -10646,7 +10514,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -10676,6 +10544,7 @@
               },
               {
                 "id": "K_1",
+                "nextlayer": "latin-punct-layer",
                 "text": "!",
                 "layer": "shift",
                 "sk": [
@@ -10919,8 +10788,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -10930,40 +10798,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሰ",
-                "pad": "",
-                "width": ""
+                "text": "ሰ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሱ",
-                "pad": "",
-                "width": ""
+                "text": "ሱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሲ",
-                "pad": "",
-                "width": ""
+                "text": "ሲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሳ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሷ",
@@ -10973,22 +10830,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሴ",
-                "pad": "",
-                "width": ""
+                "text": "ሴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሶ",
-                "pad": "",
-                "width": ""
+                "text": "ሶ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -11069,7 +10920,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -11163,7 +11014,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -11410,7 +11261,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -11612,7 +11462,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -11883,8 +11733,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -12017,7 +11866,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -12047,6 +11896,7 @@
               },
               {
                 "id": "K_1",
+                "nextlayer": "latin-punct-layer",
                 "text": "!",
                 "layer": "shift",
                 "sk": [
@@ -12290,8 +12140,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -12301,40 +12150,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሸ",
-                "pad": "",
-                "width": ""
+                "text": "ሸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሹ",
-                "pad": "",
-                "width": ""
+                "text": "ሹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሺ",
-                "pad": "",
-                "width": ""
+                "text": "ሺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሻ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሿ",
@@ -12344,22 +12182,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሼ",
-                "pad": "",
-                "width": ""
+                "text": "ሼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሾ",
-                "pad": "",
-                "width": ""
+                "text": "ሾ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -12440,7 +12272,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -12534,7 +12366,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -12781,7 +12613,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -12983,7 +12814,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -13254,8 +13085,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -13388,7 +13218,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -13418,6 +13248,7 @@
               },
               {
                 "id": "K_1",
+                "nextlayer": "latin-punct-layer",
                 "text": "!",
                 "layer": "shift",
                 "sk": [
@@ -13661,8 +13492,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -13672,15 +13502,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ቀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቈ",
@@ -13691,8 +13517,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ቁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቍ",
@@ -13703,8 +13527,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ቂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቊ",
@@ -13715,15 +13537,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቋ",
@@ -13734,8 +13553,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ቄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቌ",
@@ -13745,16 +13562,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቆ",
-                "pad": "",
-                "width": ""
+                "text": "ቆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -13835,7 +13648,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -13929,7 +13742,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -14176,7 +13989,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -14378,7 +14190,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -14649,8 +14461,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -14783,7 +14594,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -14814,6 +14625,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -15056,8 +14868,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -15067,15 +14878,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ቐ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቘ",
@@ -15086,8 +14893,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ቑ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቝ",
@@ -15098,8 +14903,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ቒ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቚ",
@@ -15110,15 +14913,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቛ",
@@ -15129,8 +14929,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ቔ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቜ",
@@ -15140,16 +14938,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቖ",
-                "pad": "",
-                "width": ""
+                "text": "ቖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -15230,7 +15024,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -15324,7 +15118,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -15571,7 +15365,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -15773,7 +15566,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -15829,7 +15622,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ሀ",
@@ -16044,8 +15837,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -16178,7 +15970,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -16209,6 +16001,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -16451,8 +16244,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -16462,40 +16254,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "በ",
-                "pad": "",
-                "width": ""
+                "text": "በ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቡ",
-                "pad": "",
-                "width": ""
+                "text": "ቡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቢ",
-                "pad": "",
-                "width": ""
+                "text": "ቢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ባ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቧ",
@@ -16505,22 +16286,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቤ",
-                "pad": "",
-                "width": ""
+                "text": "ቤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቦ",
-                "pad": "",
-                "width": ""
+                "text": "ቦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -16601,7 +16376,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -16695,7 +16470,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -16942,7 +16717,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -17144,7 +16918,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -17415,8 +17189,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -17549,7 +17322,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -17580,6 +17353,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -17822,8 +17596,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -17833,40 +17606,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ቨ",
-                "pad": "",
-                "width": ""
+                "text": "ቨ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቩ",
-                "pad": "",
-                "width": ""
+                "text": "ቩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቪ",
-                "pad": "",
-                "width": ""
+                "text": "ቪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቫ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቯ",
@@ -17876,22 +17638,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቬ",
-                "pad": "",
-                "width": ""
+                "text": "ቬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቮ",
-                "pad": "",
-                "width": ""
+                "text": "ቮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -17972,7 +17728,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -18066,7 +17822,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -18313,7 +18069,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -18515,7 +18270,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -18786,8 +18541,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -18920,7 +18674,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -18951,6 +18705,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -19193,8 +18948,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -19204,40 +18958,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ተ",
-                "pad": "",
-                "width": ""
+                "text": "ተ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቱ",
-                "pad": "",
-                "width": ""
+                "text": "ቱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቲ",
-                "pad": "",
-                "width": ""
+                "text": "ቲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ታ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቷ",
@@ -19247,22 +18990,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቴ",
-                "pad": "",
-                "width": ""
+                "text": "ቴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቶ",
-                "pad": "",
-                "width": ""
+                "text": "ቶ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -19343,7 +19080,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -19437,7 +19174,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -19684,7 +19421,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -19886,7 +19622,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -20157,8 +19893,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -20291,7 +20026,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -20322,6 +20057,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -20564,8 +20300,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -20575,40 +20310,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ቸ",
-                "pad": "",
-                "width": ""
+                "text": "ቸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቹ",
-                "pad": "",
-                "width": ""
+                "text": "ቹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቺ",
-                "pad": "",
-                "width": ""
+                "text": "ቺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቻ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቿ",
@@ -20618,22 +20342,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቼ",
-                "pad": "",
-                "width": ""
+                "text": "ቼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቾ",
-                "pad": "",
-                "width": ""
+                "text": "ቾ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -20714,7 +20432,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -20808,7 +20526,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -21055,7 +20773,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -21257,7 +20974,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -21528,8 +21245,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -21662,7 +21378,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -21693,6 +21409,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -21935,8 +21652,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -21946,15 +21662,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ኀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኈ",
@@ -21965,8 +21677,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኍ",
@@ -21977,8 +21687,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኊ",
@@ -21989,15 +21697,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ኃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኋ",
@@ -22008,8 +21713,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኌ",
@@ -22019,16 +21722,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኆ",
-                "pad": "",
-                "width": ""
+                "text": "ኆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -22109,7 +21808,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -22203,7 +21902,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -22305,8 +22004,8 @@
               {
                 "id": "K_C",
                 "text": "ጭ",
-                "layer": "shift",
                 "nextlayer": "ጨ-layer",
+                "layer": "shift",
                 "sk": [
                   {
                     "text": "ጨ",
@@ -22450,7 +22149,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -22652,7 +22350,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -22708,7 +22406,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ሀ",
@@ -22923,8 +22621,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -23057,7 +22754,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -23088,6 +22785,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -23330,8 +23028,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -23341,40 +23038,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ነ",
-                "pad": "",
-                "width": ""
+                "text": "ነ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኑ",
-                "pad": "",
-                "width": ""
+                "text": "ኑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኒ",
-                "pad": "",
-                "width": ""
+                "text": "ኒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ና",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኗ",
@@ -23384,22 +23070,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኔ",
-                "pad": "",
-                "width": ""
+                "text": "ኔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኖ",
-                "pad": "",
-                "width": ""
+                "text": "ኖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -23480,7 +23160,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -23574,7 +23254,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -23821,7 +23501,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -24023,7 +23702,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -24294,8 +23973,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -24428,7 +24106,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -24459,6 +24137,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -24701,8 +24380,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -24712,40 +24390,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ኘ",
-                "pad": "",
-                "width": ""
+                "text": "ኘ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኙ",
-                "pad": "",
-                "width": ""
+                "text": "ኙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኚ",
-                "pad": "",
-                "width": ""
+                "text": "ኚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ኛ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኟ",
@@ -24755,22 +24422,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኜ",
-                "pad": "",
-                "width": ""
+                "text": "ኜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኞ",
-                "pad": "",
-                "width": ""
+                "text": "ኞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -24851,7 +24512,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -24945,7 +24606,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -25192,7 +24853,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -25394,7 +25054,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -25665,8 +25325,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -25799,7 +25458,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -25830,6 +25489,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -26072,8 +25732,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -26083,15 +25742,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ከ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኰ",
@@ -26102,8 +25757,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኩ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኵ",
@@ -26114,8 +25767,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኪ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኲ",
@@ -26126,15 +25777,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ካ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኳ",
@@ -26145,8 +25793,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኬ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኴ",
@@ -26156,16 +25802,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኮ",
-                "pad": "",
-                "width": ""
+                "text": "ኮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -26246,7 +25888,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -26340,7 +25982,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -26587,7 +26229,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -26789,7 +26430,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -27060,8 +26701,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -27194,7 +26834,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -27225,6 +26865,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -27467,8 +27108,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -27478,59 +27118,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ወ",
-                "pad": "",
-                "width": ""
+                "text": "ወ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዉ",
-                "pad": "",
-                "width": ""
+                "text": "ዉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዊ",
-                "pad": "",
-                "width": ""
+                "text": "ዊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዋ",
-                "pad": "",
-                "width": ""
+                "text": "ዋ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዌ",
-                "pad": "",
-                "width": ""
+                "text": "ዌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዎ",
-                "pad": "",
-                "width": ""
+                "text": "ዎ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -27611,7 +27234,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -27705,7 +27328,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -27952,7 +27575,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -28154,7 +27776,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -28425,8 +28047,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -28559,7 +28180,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -28590,6 +28211,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -28832,8 +28454,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -28843,59 +28464,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዐ",
-                "pad": "",
-                "width": ""
+                "text": "ዐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዑ",
-                "pad": "",
-                "width": ""
+                "text": "ዑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዒ",
-                "pad": "",
-                "width": ""
+                "text": "ዒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዓ",
-                "pad": "",
-                "width": ""
+                "text": "ዓ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዔ",
-                "pad": "",
-                "width": ""
+                "text": "ዔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዖ",
-                "pad": "",
-                "width": ""
+                "text": "ዖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -28976,7 +28580,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -29070,7 +28674,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -29317,7 +28921,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -29519,7 +29122,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -29790,8 +29393,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -29924,7 +29526,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -29955,6 +29557,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -30197,8 +29800,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -30208,40 +29810,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዘ",
-                "pad": "",
-                "width": ""
+                "text": "ዘ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዙ",
-                "pad": "",
-                "width": ""
+                "text": "ዙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዚ",
-                "pad": "",
-                "width": ""
+                "text": "ዚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ዛ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዟ",
@@ -30251,22 +29842,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዜ",
-                "pad": "",
-                "width": ""
+                "text": "ዜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዞ",
-                "pad": "",
-                "width": ""
+                "text": "ዞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -30347,7 +29932,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -30441,7 +30026,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -30688,7 +30273,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -30890,7 +30474,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -31161,8 +30745,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -31295,7 +30878,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -31326,6 +30909,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -31568,8 +31152,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -31579,40 +31162,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዠ",
-                "pad": "",
-                "width": ""
+                "text": "ዠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዡ",
-                "pad": "",
-                "width": ""
+                "text": "ዡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዢ",
-                "pad": "",
-                "width": ""
+                "text": "ዢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ዣ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዧ",
@@ -31622,22 +31194,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዤ",
-                "pad": "",
-                "width": ""
+                "text": "ዤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዦ",
-                "pad": "",
-                "width": ""
+                "text": "ዦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -31718,7 +31284,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -31812,7 +31378,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -32059,7 +31625,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -32261,7 +31826,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -32532,8 +32097,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -32666,7 +32230,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -32697,6 +32261,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -32939,8 +32504,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -32950,59 +32514,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "የ",
-                "pad": "",
-                "width": ""
+                "text": "የ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዩ",
-                "pad": "",
-                "width": ""
+                "text": "ዩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዪ",
-                "pad": "",
-                "width": ""
+                "text": "ዪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ያ",
-                "pad": "",
-                "width": ""
+                "text": "ያ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዬ",
-                "pad": "",
-                "width": ""
+                "text": "ዬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዮ",
-                "pad": "",
-                "width": ""
+                "text": "ዮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -33083,7 +32630,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -33177,7 +32724,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -33424,7 +32971,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -33626,7 +33172,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -33897,8 +33443,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -34031,7 +33576,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -34062,6 +33607,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -34304,8 +33850,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -34315,40 +33860,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ደ",
-                "pad": "",
-                "width": ""
+                "text": "ደ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዱ",
-                "pad": "",
-                "width": ""
+                "text": "ዱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዲ",
-                "pad": "",
-                "width": ""
+                "text": "ዲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ዳ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዷ",
@@ -34358,22 +33892,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዴ",
-                "pad": "",
-                "width": ""
+                "text": "ዴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዶ",
-                "pad": "",
-                "width": ""
+                "text": "ዶ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -34454,7 +33982,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -34548,7 +34076,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -34795,7 +34323,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -34997,7 +34524,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -35268,8 +34795,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -35402,7 +34928,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -35433,6 +34959,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -35675,8 +35202,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -35686,40 +35212,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጀ",
-                "pad": "",
-                "width": ""
+                "text": "ጀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጁ",
-                "pad": "",
-                "width": ""
+                "text": "ጁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጂ",
-                "pad": "",
-                "width": ""
+                "text": "ጂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጇ",
@@ -35729,22 +35244,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጄ",
-                "pad": "",
-                "width": ""
+                "text": "ጄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጆ",
-                "pad": "",
-                "width": ""
+                "text": "ጆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -35825,7 +35334,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -35919,7 +35428,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -36166,7 +35675,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -36368,7 +35876,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -36639,8 +36147,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -36773,7 +36280,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -36804,6 +36311,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -37046,8 +36554,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -37057,15 +36564,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ገ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጐ",
@@ -37076,8 +36579,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ጉ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጕ",
@@ -37088,8 +36589,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ጊ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጒ",
@@ -37100,15 +36599,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጋ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጓ",
@@ -37119,8 +36615,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ጌ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጔ",
@@ -37130,16 +36624,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጎ",
-                "pad": "",
-                "width": ""
+                "text": "ጎ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -37220,7 +36710,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -37314,7 +36804,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -37561,7 +37051,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -37763,7 +37252,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -38034,8 +37523,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -38168,7 +37656,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -38199,6 +37687,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -38441,8 +37930,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -38452,59 +37940,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጘ",
-                "pad": "",
-                "width": ""
+                "text": "ጘ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጙ",
-                "pad": "",
-                "width": ""
+                "text": "ጙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጚ",
-                "pad": "",
-                "width": ""
+                "text": "ጚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጛ",
-                "pad": "",
-                "width": ""
+                "text": "ጛ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጜ",
-                "pad": "",
-                "width": ""
+                "text": "ጜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጞ",
-                "pad": "",
-                "width": ""
+                "text": "ጞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -38585,7 +38056,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -38679,7 +38150,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -38926,7 +38397,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -39128,7 +38598,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -39399,8 +38869,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -39533,7 +39002,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -39564,6 +39033,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -39806,8 +39276,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -39817,40 +39286,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጠ",
-                "pad": "",
-                "width": ""
+                "text": "ጠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጡ",
-                "pad": "",
-                "width": ""
+                "text": "ጡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጢ",
-                "pad": "",
-                "width": ""
+                "text": "ጢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጣ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጧ",
@@ -39860,22 +39318,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጤ",
-                "pad": "",
-                "width": ""
+                "text": "ጤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጦ",
-                "pad": "",
-                "width": ""
+                "text": "ጦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -39956,7 +39408,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -40050,7 +39502,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -40297,7 +39749,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -40499,7 +39950,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -40770,8 +40221,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -40904,7 +40354,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -40935,6 +40385,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -41177,8 +40628,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -41188,40 +40638,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጨ",
-                "pad": "",
-                "width": ""
+                "text": "ጨ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጩ",
-                "pad": "",
-                "width": ""
+                "text": "ጩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጪ",
-                "pad": "",
-                "width": ""
+                "text": "ጪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጫ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጯ",
@@ -41231,22 +40670,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጬ",
-                "pad": "",
-                "width": ""
+                "text": "ጬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጮ",
-                "pad": "",
-                "width": ""
+                "text": "ጮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -41327,7 +40760,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -41421,7 +40854,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -41668,7 +41101,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -41870,7 +41302,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -42141,8 +41573,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -42275,7 +41706,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -42306,6 +41737,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -42548,8 +41980,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -42559,40 +41990,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጰ",
-                "pad": "",
-                "width": ""
+                "text": "ጰ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጱ",
-                "pad": "",
-                "width": ""
+                "text": "ጱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጲ",
-                "pad": "",
-                "width": ""
+                "text": "ጲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጳ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጷ",
@@ -42602,22 +42022,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጴ",
-                "pad": "",
-                "width": ""
+                "text": "ጴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጶ",
-                "pad": "",
-                "width": ""
+                "text": "ጶ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -42698,7 +42112,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -42792,7 +42206,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -42894,8 +42308,8 @@
               {
                 "id": "K_C",
                 "text": "ጭ",
-                "layer": "shift",
                 "nextlayer": "ጨ-layer",
+                "layer": "shift",
                 "sk": [
                   {
                     "text": "ጨ",
@@ -43039,7 +42453,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -43241,7 +42654,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -43512,8 +42925,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -43646,7 +43058,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -43677,6 +43089,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -43919,8 +43332,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -43930,40 +43342,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጸ",
-                "pad": "",
-                "width": ""
+                "text": "ጸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጹ",
-                "pad": "",
-                "width": ""
+                "text": "ጹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጺ",
-                "pad": "",
-                "width": ""
+                "text": "ጺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጻ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጿ",
@@ -43973,22 +43374,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጼ",
-                "pad": "",
-                "width": ""
+                "text": "ጼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጾ",
-                "pad": "",
-                "width": ""
+                "text": "ጾ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -44069,7 +43464,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -44163,7 +43558,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -44410,7 +43805,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -44612,7 +44006,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -44883,8 +44277,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -45017,7 +44410,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -45048,6 +44441,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -45290,8 +44684,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -45301,59 +44694,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፀ",
-                "pad": "",
-                "width": ""
+                "text": "ፀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፁ",
-                "pad": "",
-                "width": ""
+                "text": "ፁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፂ",
-                "pad": "",
-                "width": ""
+                "text": "ፂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ፃ",
-                "pad": "",
-                "width": ""
+                "text": "ፃ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፄ",
-                "pad": "",
-                "width": ""
+                "text": "ፄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፆ",
-                "pad": "",
-                "width": ""
+                "text": "ፆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -45434,7 +44810,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -45528,7 +44904,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -45775,7 +45151,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -45977,7 +45352,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -46248,8 +45623,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -46382,7 +45756,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -46413,6 +45787,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -46655,8 +46030,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -46666,40 +46040,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፈ",
-                "pad": "",
-                "width": ""
+                "text": "ፈ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፉ",
-                "pad": "",
-                "width": ""
+                "text": "ፉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፊ",
-                "pad": "",
-                "width": ""
+                "text": "ፊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ፋ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ፏ",
@@ -46709,22 +46072,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፌ",
-                "pad": "",
-                "width": ""
+                "text": "ፌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፎ",
-                "pad": "",
-                "width": ""
+                "text": "ፎ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -46805,7 +46162,7 @@
               {
                 "id": "K_J",
                 "text": "ጅ",
-                "nextlayer": "ደ-layer",
+                "nextlayer": "ጀ-layer",
                 "sk": [
                   {
                     "text": "ጀ",
@@ -46899,7 +46256,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -47146,7 +46503,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -47348,7 +46704,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -47619,8 +46975,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "*123*",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               },
               {
@@ -47753,7 +47108,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -47784,6 +47139,7 @@
               {
                 "id": "K_1",
                 "text": "!",
+                "nextlayer": "latin-punct-layer",
                 "layer": "shift",
                 "sk": [
                   {
@@ -48026,8 +47382,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -48037,40 +47392,29 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፐ",
-                "pad": "",
-                "width": ""
+                "text": "ፐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፑ",
-                "pad": "",
-                "width": ""
+                "text": "ፑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፒ",
-                "pad": "",
-                "width": ""
+                "text": "ፒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ፓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ፗ",
@@ -48080,22 +47424,16 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፔ",
-                "pad": "",
-                "width": ""
+                "text": "ፔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፖ",
-                "pad": "",
-                "width": ""
+                "text": "ፖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -48110,7 +47448,6 @@
               {
                 "id": "K_1",
                 "text": "1",
-                "pad": "",
                 "sk": [
                   {
                     "text": "፩",
@@ -48144,7 +47481,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "፫",
@@ -48243,7 +47579,6 @@
               {
                 "id": "K_0",
                 "text": "0",
-                "pad": "",
                 "sk": [
                   {
                     "text": "°",
@@ -48305,8 +47640,7 @@
               },
               {
                 "id": "U_002C",
-                "text": ",",
-                "width": ""
+                "text": ","
               },
               {
                 "id": "U_003B",
@@ -48325,7 +47659,6 @@
               {
                 "id": "K_4",
                 "text": "$",
-                "pad": "",
                 "layer": "shift",
                 "sk": [
                   {
@@ -48368,8 +47701,15 @@
               {
                 "id": "U_0027",
                 "text": "'",
-                "width": "",
                 "sk": [
+                  {
+                    "text": "‹",
+                    "id": "U_2039"
+                  },
+                  {
+                    "text": "›",
+                    "id": "U_203A"
+                  },
                   {
                     "text": "`",
                     "id": "U_0060"
@@ -48379,7 +47719,7 @@
                     "id": "U_2018"
                   },
                   {
-                    "text": "’’",
+                    "text": "’",
                     "id": "U_2019"
                   }
                 ]
@@ -48408,11 +47748,6 @@
                   {
                     "text": "”",
                     "id": "U_201D"
-                  },
-                  {
-                    "text": "\"",
-                    "id": "K_QUOTE",
-                    "layer": "shift"
                   }
                 ]
               }
@@ -48424,8 +47759,8 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "punctuation-2",
                 "sk": [
                   {
@@ -48443,8 +47778,8 @@
               {
                 "id": "K_PERIOD",
                 "text": ".",
-                "pad": "70",
-                "width": "120",
+                "pad": 70,
+                "width": 120,
                 "layer": "default",
                 "sk": [
                   {
@@ -48456,18 +47791,18 @@
               {
                 "id": "U_003A",
                 "text": ":",
-                "width": "120"
+                "width": 120
               },
               {
                 "id": "K_2",
                 "text": "@",
-                "width": "120",
+                "width": 120,
                 "layer": "shift"
               },
               {
                 "id": "K_1",
                 "text": "!",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -48479,7 +47814,7 @@
               {
                 "id": "K_SLASH",
                 "text": "?",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -48491,9 +47826,9 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "pad": "65",
-                "width": "170",
-                "sp": "1"
+                "pad": 65,
+                "width": 170,
+                "sp": 1
               }
             ]
           },
@@ -48503,23 +47838,23 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "85",
-                "width": "630",
-                "sp": "0"
+                "pad": 85,
+                "width": 630,
+                "sp": 0
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "80",
-                "width": "170",
-                "sp": "1"
+                "pad": 80,
+                "width": 170,
+                "sp": 1
               }
             ]
           }
@@ -48542,7 +47877,6 @@
               {
                 "id": "K_LBRKT",
                 "text": "{",
-                "width": "",
                 "layer": "shift"
               },
               {
@@ -48619,8 +47953,7 @@
               },
               {
                 "id": "U_20AC",
-                "text": "€",
-                "pad": ""
+                "text": "€"
               },
               {
                 "id": "U_00A3",
@@ -48642,20 +47975,20 @@
               {
                 "id": "K_SHIFT",
                 "text": "፩",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "amharic-extra",
                 "sk": [
                   {
                     "text": "*123*",
                     "id": "K_SHIFT",
-                    "sp": "1",
+                    "sp": 1,
                     "nextlayer": "amharic-extra"
                   },
                   {
                     "text": "@$፩",
                     "id": "K_SHIFT",
-                    "sp": "1",
+                    "sp": 1,
                     "nextlayer": "punctuation"
                   }
                 ]
@@ -48663,8 +47996,8 @@
               {
                 "id": "K_PERIOD",
                 "text": ".",
-                "pad": "70",
-                "width": "120",
+                "pad": 70,
+                "width": 120,
                 "layer": "default",
                 "sk": [
                   {
@@ -48676,18 +48009,18 @@
               {
                 "id": "U_003A",
                 "text": ":",
-                "width": "120"
+                "width": 120
               },
               {
                 "id": "K_2",
                 "text": "@",
-                "width": "120",
+                "width": 120,
                 "layer": "shift"
               },
               {
                 "id": "K_1",
                 "text": "!",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -48699,7 +48032,7 @@
               {
                 "id": "K_SLASH",
                 "text": "?",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -48711,9 +48044,9 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "pad": "65",
-                "width": "170",
-                "sp": "1"
+                "pad": 65,
+                "width": 170,
+                "sp": 1
               }
             ]
           },
@@ -48723,23 +48056,23 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "85",
-                "width": "630",
-                "sp": "0"
+                "pad": 85,
+                "width": 630,
+                "sp": 0
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "80",
-                "width": "170",
-                "sp": "1"
+                "pad": 80,
+                "width": 170,
+                "sp": 1
               }
             ]
           }
@@ -48754,7 +48087,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -48910,8 +48243,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -48922,7 +48255,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -48941,7 +48274,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -48967,7 +48299,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -49022,7 +48354,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -49148,7 +48480,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -49204,7 +48536,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -49360,15 +48692,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -49452,8 +48783,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -49463,60 +48794,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "አ",
-                "pad": "",
-                "width": ""
+                "text": "አ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -49531,7 +48848,7 @@
               {
                 "id": "U_1373",
                 "text": "፳",
-                "pad": "55"
+                "pad": 55
               },
               {
                 "id": "U_1374",
@@ -49567,14 +48884,13 @@
               },
               {
                 "id": "U_137C",
-                "text": "፼",
-                "pad": ""
+                "text": "፼"
               },
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-tens-extra"
               }
             ]
@@ -49585,7 +48901,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -49604,7 +48920,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -49630,7 +48945,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -49685,7 +49000,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -49811,7 +49126,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -49867,7 +49182,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -50023,15 +49338,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -50115,8 +49429,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -50126,60 +49440,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "አ",
-                "pad": "",
-                "width": ""
+                "text": "አ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -50194,7 +49494,7 @@
               {
                 "id": "K_1",
                 "text": "1",
-                "pad": "55"
+                "pad": 55
               },
               {
                 "id": "K_2",
@@ -50235,8 +49535,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-extra"
               }
             ]
@@ -50247,7 +49547,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -50266,7 +49566,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -50292,7 +49591,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -50347,7 +49646,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -50473,7 +49772,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -50529,7 +49828,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -50685,15 +49984,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -50777,8 +50075,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -50788,60 +50086,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "አ",
-                "pad": "",
-                "width": ""
+                "text": "አ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -50856,7 +50140,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -51012,8 +50296,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -51024,7 +50308,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -51043,7 +50327,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -51069,7 +50352,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -51124,7 +50407,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -51250,7 +50533,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -51306,7 +50589,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -51462,15 +50745,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -51554,8 +50836,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -51565,41 +50847,32 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሠ",
-                "pad": "",
-                "width": ""
+                "text": "ሠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሡ",
-                "pad": "",
-                "width": ""
+                "text": "ሡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሢ",
-                "pad": "",
-                "width": ""
+                "text": "ሢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ሣ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ሧ",
@@ -51609,22 +50882,17 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሤ",
-                "pad": "",
-                "width": ""
+                "text": "ሤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሦ",
-                "pad": "",
-                "width": ""
+                "text": "ሦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -51639,7 +50907,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -51795,8 +51063,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -51807,7 +51075,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -51826,7 +51094,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -51852,7 +51119,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -51907,7 +51174,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -52033,7 +51300,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -52089,7 +51356,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -52245,15 +51512,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -52337,8 +51603,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -52348,16 +51614,14 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ቐ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቘ",
@@ -52368,8 +51632,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ቑ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቝ",
@@ -52380,8 +51642,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ቒ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቚ",
@@ -52392,15 +51652,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቛ",
@@ -52411,8 +51668,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ቔ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቜ",
@@ -52422,16 +51677,13 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቖ",
-                "pad": "",
-                "width": ""
+                "text": "ቖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -52446,7 +51698,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -52602,8 +51854,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -52614,7 +51866,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -52633,7 +51885,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -52659,7 +51910,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -52714,7 +51965,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -52840,7 +52091,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -52896,7 +52147,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -53052,15 +52303,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -53144,8 +52394,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -53155,41 +52405,32 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ቨ",
-                "pad": "",
-                "width": ""
+                "text": "ቨ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቩ",
-                "pad": "",
-                "width": ""
+                "text": "ቩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቪ",
-                "pad": "",
-                "width": ""
+                "text": "ቪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቫ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቯ",
@@ -53199,22 +52440,17 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቬ",
-                "pad": "",
-                "width": ""
+                "text": "ቬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቮ",
-                "pad": "",
-                "width": ""
+                "text": "ቮ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -53229,7 +52465,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -53385,8 +52621,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -53397,7 +52633,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -53416,7 +52652,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -53442,7 +52677,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -53497,7 +52732,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -53623,7 +52858,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -53679,7 +52914,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -53835,15 +53070,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -53927,8 +53161,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -53938,16 +53172,14 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ኀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኈ",
@@ -53958,8 +53190,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኍ",
@@ -53970,8 +53200,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኊ",
@@ -53982,15 +53210,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ኃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኋ",
@@ -54001,8 +53226,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኌ",
@@ -54012,16 +53235,13 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኆ",
-                "pad": "",
-                "width": ""
+                "text": "ኆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -54036,7 +53256,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -54192,8 +53412,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -54204,7 +53424,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -54223,7 +53443,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -54249,7 +53468,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -54304,7 +53523,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -54430,7 +53649,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -54486,7 +53705,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -54642,15 +53861,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -54734,8 +53952,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -54745,41 +53963,32 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዠ",
-                "pad": "",
-                "width": ""
+                "text": "ዠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዡ",
-                "pad": "",
-                "width": ""
+                "text": "ዡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዢ",
-                "pad": "",
-                "width": ""
+                "text": "ዢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ዣ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዧ",
@@ -54789,22 +53998,17 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዤ",
-                "pad": "",
-                "width": ""
+                "text": "ዤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዦ",
-                "pad": "",
-                "width": ""
+                "text": "ዦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -54819,7 +54023,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -54975,8 +54179,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -54987,7 +54191,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -55006,7 +54210,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -55032,7 +54235,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -55087,7 +54290,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -55213,7 +54416,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -55269,7 +54472,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -55425,15 +54628,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -55517,8 +54719,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -55528,16 +54730,14 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ኸ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዀ",
@@ -55548,8 +54748,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኹ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዅ",
@@ -55560,8 +54758,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኺ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዂ",
@@ -55572,15 +54768,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ኻ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዃ",
@@ -55591,8 +54784,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኼ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ዃ",
@@ -55602,16 +54793,13 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኾ",
-                "pad": "",
-                "width": ""
+                "text": "ኾ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -55626,7 +54814,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -55782,8 +54970,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -55794,7 +54982,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -55813,7 +55001,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -55839,7 +55026,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -55894,7 +55081,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -56020,7 +55207,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -56231,15 +55418,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -56323,8 +55509,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -56334,16 +55520,14 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ጘ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶓ",
@@ -56354,8 +55538,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ጙ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶖ",
@@ -56366,8 +55548,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ጚ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶔ",
@@ -56378,15 +55558,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጛ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጟ",
@@ -56397,8 +55574,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ጜ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶕ",
@@ -56408,16 +55583,13 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጞ",
-                "pad": "",
-                "width": ""
+                "text": "ጞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -56432,7 +55604,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -56588,8 +55760,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -56600,7 +55772,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -56619,7 +55791,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ፀ-extra",
                 "sk": [
                   {
@@ -56645,7 +55816,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -56700,7 +55871,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -56826,7 +55997,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -56882,7 +56053,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -57038,15 +56209,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -57130,8 +56300,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -57141,60 +56311,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፀ",
-                "pad": "",
-                "width": ""
+                "text": "ፀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፁ",
-                "pad": "",
-                "width": ""
+                "text": "ፁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፂ",
-                "pad": "",
-                "width": ""
+                "text": "ፂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ፃ",
-                "pad": "",
-                "width": ""
+                "text": "ፃ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፄ",
-                "pad": "",
-                "width": ""
+                "text": "ፄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፆ",
-                "pad": "",
-                "width": ""
+                "text": "ፆ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -57209,7 +56365,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -57365,8 +56521,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -57377,7 +56533,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -57396,7 +56552,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-extra",
                 "sk": [
                   {
@@ -57422,7 +56577,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -57477,7 +56632,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -57603,7 +56758,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -57659,7 +56814,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -57815,15 +56970,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -57907,8 +57061,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -57918,41 +57072,32 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፐ",
-                "pad": "",
-                "width": ""
+                "text": "ፐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፑ",
-                "pad": "",
-                "width": ""
+                "text": "ፑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፒ",
-                "pad": "",
-                "width": ""
+                "text": "ፒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ፓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ፗ",
@@ -57962,22 +57107,17 @@
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፔ",
-                "pad": "",
-                "width": ""
+                "text": "ፔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፖ",
-                "pad": "",
-                "width": ""
+                "text": "ፖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           }
@@ -57992,7 +57132,7 @@
               {
                 "id": "U_1369",
                 "text": "፩",
-                "pad": "55",
+                "pad": 55,
                 "sk": [
                   {
                     "text": "፲",
@@ -58148,8 +57288,8 @@
               {
                 "id": "T_MORE",
                 "text": "▶",
-                "width": "45",
-                "sp": "1",
+                "width": 45,
+                "sp": 1,
                 "nextlayer": "amharic-etens-extra"
               }
             ]
@@ -58160,7 +57300,7 @@
               {
                 "id": "U_00AB",
                 "text": "«",
-                "pad": "0",
+                "pad": 0,
                 "sk": [
                   {
                     "text": "‹",
@@ -58179,7 +57319,6 @@
               {
                 "id": "U_131D",
                 "text": "ጝ",
-                "pad": "",
                 "nextlayer": "ጘ-layer",
                 "sk": [
                   {
@@ -58205,7 +57344,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -58260,7 +57399,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -58385,7 +57524,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኸ",
@@ -58441,7 +57580,7 @@
                   {
                     "text": "",
                     "id": "T_SPACER",
-                    "sp": "10",
+                    "sp": 10,
                     "nextlayer": "ኀ-layer"
                   },
                   {
@@ -58597,15 +57736,14 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -58689,8 +57827,8 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
               }
             ]
           },
@@ -58700,60 +57838,2821 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "0",
-                "width": "155",
-                "sp": "1",
+                "pad": 0,
+                "width": 155,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "አ",
-                "pad": "",
-                "width": ""
+                "text": "አ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "160",
-                "sp": "1"
+                "width": 160,
+                "sp": 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "latin-punct-layer",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "U_12D5",
+                "text": "ዕ",
+                "nextlayer": "ዐ-layer",
+                "sk": [
+                  {
+                    "text": "ዐ",
+                    "id": "U_12D0"
+                  },
+                  {
+                    "text": "ዑ",
+                    "id": "U_12D1"
+                  },
+                  {
+                    "text": "ዒ",
+                    "id": "U_12D2"
+                  },
+                  {
+                    "text": "ዓ",
+                    "id": "U_12D3"
+                  },
+                  {
+                    "text": "ዔ",
+                    "id": "U_12D4"
+                  },
+                  {
+                    "text": "ዖ",
+                    "id": "U_12D6"
+                  }
+                ]
+              },
+              {
+                "id": "K_X",
+                "text": "ሽ",
+                "nextlayer": "ሸ-layer",
+                "sk": [
+                  {
+                    "text": "ሸ",
+                    "id": "U_1238"
+                  },
+                  {
+                    "text": "ሹ",
+                    "id": "U_1239"
+                  },
+                  {
+                    "text": "ሺ",
+                    "id": "U_123A"
+                  },
+                  {
+                    "text": "ሻ",
+                    "id": "U_123B"
+                  },
+                  {
+                    "text": "ሼ",
+                    "id": "U_123C"
+                  },
+                  {
+                    "text": "ሾ",
+                    "id": "U_123E"
+                  },
+                  {
+                    "text": "ሿ",
+                    "id": "U_123F"
+                  }
+                ]
+              },
+              {
+                "id": "K_J",
+                "text": "ጅ",
+                "nextlayer": "ጀ-layer",
+                "sk": [
+                  {
+                    "text": "ጀ",
+                    "id": "U_1300"
+                  },
+                  {
+                    "text": "ጁ",
+                    "id": "U_1301"
+                  },
+                  {
+                    "text": "ጂ",
+                    "id": "U_1302"
+                  },
+                  {
+                    "text": "ጃ",
+                    "id": "U_1303"
+                  },
+                  {
+                    "text": "ጄ",
+                    "id": "U_1304"
+                  },
+                  {
+                    "text": "ጆ",
+                    "id": "U_1306"
+                  },
+                  {
+                    "text": "ጇ",
+                    "id": "U_1307"
+                  }
+                ]
+              },
+              {
+                "id": "K_F",
+                "text": "ፍ",
+                "nextlayer": "ፈ-layer",
+                "sk": [
+                  {
+                    "text": "ፈ",
+                    "id": "U_1348"
+                  },
+                  {
+                    "text": "ፉ",
+                    "id": "U_1349"
+                  },
+                  {
+                    "text": "ፊ",
+                    "id": "U_134A"
+                  },
+                  {
+                    "text": "ፋ",
+                    "id": "U_134B"
+                  },
+                  {
+                    "text": "ፌ",
+                    "id": "U_134C"
+                  },
+                  {
+                    "text": "ፎ",
+                    "id": "U_134E"
+                  },
+                  {
+                    "text": "ፏ",
+                    "id": "U_134F"
+                  }
+                ]
+              },
+              {
+                "id": "K_Q",
+                "text": "ቅ",
+                "nextlayer": "ቀ-layer",
+                "sk": [
+                  {
+                    "text": "ቈ",
+                    "id": "U_1248"
+                  },
+                  {
+                    "text": "ቍ",
+                    "id": "U_124D"
+                  },
+                  {
+                    "text": "ቊ",
+                    "id": "U_124A"
+                  },
+                  {
+                    "text": "ቋ",
+                    "id": "U_124B"
+                  },
+                  {
+                    "text": "ቌ",
+                    "id": "U_124C"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ቀ",
+                    "id": "U_1240"
+                  },
+                  {
+                    "text": "ቁ",
+                    "id": "U_1241"
+                  },
+                  {
+                    "text": "ቂ",
+                    "id": "U_1242"
+                  },
+                  {
+                    "text": "ቃ",
+                    "id": "U_1243"
+                  },
+                  {
+                    "text": "ቄ",
+                    "id": "U_1244"
+                  },
+                  {
+                    "text": "ቆ",
+                    "id": "U_1246"
+                  }
+                ]
+              },
+              {
+                "id": "K_H",
+                "text": "ሕ",
+                "nextlayer": "ሐ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ሐ",
+                    "id": "U_1210"
+                  },
+                  {
+                    "text": "ሑ",
+                    "id": "U_1211"
+                  },
+                  {
+                    "text": "ሒ",
+                    "id": "U_1212"
+                  },
+                  {
+                    "text": "ሓ",
+                    "id": "U_1213"
+                  },
+                  {
+                    "text": "ሔ",
+                    "id": "U_1214"
+                  },
+                  {
+                    "text": "ሖ",
+                    "id": "U_1216"
+                  },
+                  {
+                    "text": "ሗ",
+                    "id": "U_1217"
+                  }
+                ]
+              },
+              {
+                "id": "K_C",
+                "text": "ች",
+                "nextlayer": "ቸ-layer",
+                "sk": [
+                  {
+                    "text": "ቸ",
+                    "id": "U_1278"
+                  },
+                  {
+                    "text": "ቹ",
+                    "id": "U_1279"
+                  },
+                  {
+                    "text": "ቺ",
+                    "id": "U_127A"
+                  },
+                  {
+                    "text": "ቻ",
+                    "id": "U_127B"
+                  },
+                  {
+                    "text": "ቼ",
+                    "id": "U_127C"
+                  },
+                  {
+                    "text": "ቾ",
+                    "id": "U_127E"
+                  },
+                  {
+                    "text": "ቿ",
+                    "id": "U_127F"
+                  }
+                ]
+              },
+              {
+                "id": "K_C",
+                "text": "ጭ",
+                "nextlayer": "ጨ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ጨ",
+                    "id": "U_1328"
+                  },
+                  {
+                    "text": "ጩ",
+                    "id": "U_1329"
+                  },
+                  {
+                    "text": "ጪ",
+                    "id": "U_132A"
+                  },
+                  {
+                    "text": "ጫ",
+                    "id": "U_132B"
+                  },
+                  {
+                    "text": "ጬ",
+                    "id": "U_132C"
+                  },
+                  {
+                    "text": "ጮ",
+                    "id": "U_132E"
+                  },
+                  {
+                    "text": "ጯ",
+                    "id": "U_132F"
+                  }
+                ]
+              },
+              {
+                "id": "K_Y",
+                "text": "ይ",
+                "nextlayer": "የ-layer",
+                "sk": [
+                  {
+                    "text": "የ",
+                    "id": "U_12E8"
+                  },
+                  {
+                    "text": "ዩ",
+                    "id": "U_12E9"
+                  },
+                  {
+                    "text": "ዪ",
+                    "id": "U_12EA"
+                  },
+                  {
+                    "text": "ያ",
+                    "id": "U_12EB"
+                  },
+                  {
+                    "text": "ዬ",
+                    "id": "U_12EC"
+                  },
+                  {
+                    "text": "ዮ",
+                    "id": "U_12EE"
+                  }
+                ]
+              },
+              {
+                "id": "K_P",
+                "text": "ጵ",
+                "nextlayer": "ጰ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ፐ",
+                    "id": "U_1350"
+                  },
+                  {
+                    "text": "ፑ",
+                    "id": "U_1351"
+                  },
+                  {
+                    "text": "ፒ",
+                    "id": "U_1352"
+                  },
+                  {
+                    "text": "ፓ",
+                    "id": "U_1353"
+                  },
+                  {
+                    "text": "ፔ",
+                    "id": "U_1354"
+                  },
+                  {
+                    "text": "ፕ",
+                    "id": "U_1355",
+                    "nextlayer": "ፐ-layer"
+                  },
+                  {
+                    "text": "ፖ",
+                    "id": "U_1356"
+                  },
+                  {
+                    "text": "ፗ",
+                    "id": "U_1357"
+                  },
+                  {
+                    "text": "ጰ",
+                    "id": "U_1330"
+                  },
+                  {
+                    "text": "ጱ",
+                    "id": "U_1331"
+                  },
+                  {
+                    "text": "ጲ",
+                    "id": "U_1332"
+                  },
+                  {
+                    "text": "ጳ",
+                    "id": "U_1333"
+                  },
+                  {
+                    "text": "ጴ",
+                    "id": "U_1334"
+                  },
+                  {
+                    "text": "ጵ",
+                    "id": "U_1335"
+                  },
+                  {
+                    "text": "ጶ",
+                    "id": "U_1336"
+                  },
+                  {
+                    "text": "ጷ",
+                    "id": "U_1337"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "U_12A5",
+                "text": "እ",
+                "nextlayer": "default",
+                "sk": [
+                  {
+                    "text": "አ",
+                    "id": "U_12A0"
+                  },
+                  {
+                    "text": "ኡ",
+                    "id": "U_12A1"
+                  },
+                  {
+                    "text": "ኢ",
+                    "id": "U_12A2"
+                  },
+                  {
+                    "text": "ኣ",
+                    "id": "U_12A3"
+                  },
+                  {
+                    "text": "ኤ",
+                    "id": "U_12A4"
+                  },
+                  {
+                    "text": "ኦ",
+                    "id": "U_12A6"
+                  },
+                  {
+                    "text": "ኧ",
+                    "id": "U_12A7"
+                  }
+                ]
+              },
+              {
+                "id": "K_S",
+                "text": "ስ",
+                "nextlayer": "ሰ-layer",
+                "sk": [
+                  {
+                    "text": "ሠ",
+                    "id": "U_1220"
+                  },
+                  {
+                    "text": "ሡ",
+                    "id": "U_1221"
+                  },
+                  {
+                    "text": "ሢ",
+                    "id": "U_1222"
+                  },
+                  {
+                    "text": "ሣ",
+                    "id": "U_1223"
+                  },
+                  {
+                    "text": "ሤ",
+                    "id": "U_1224"
+                  },
+                  {
+                    "text": "ሥ",
+                    "id": "U_1225",
+                    "nextlayer": "ሠ-layer"
+                  },
+                  {
+                    "text": "ሦ",
+                    "id": "U_1226"
+                  },
+                  {
+                    "text": "ሧ",
+                    "id": "U_1227"
+                  },
+                  {
+                    "text": "ሰ",
+                    "id": "U_1230"
+                  },
+                  {
+                    "text": "ሱ",
+                    "id": "U_1231"
+                  },
+                  {
+                    "text": "ሲ",
+                    "id": "U_1232"
+                  },
+                  {
+                    "text": "ሳ",
+                    "id": "U_1233"
+                  },
+                  {
+                    "text": "ሴ",
+                    "id": "U_1234"
+                  },
+                  {
+                    "text": "ስ",
+                    "id": "U_1235"
+                  },
+                  {
+                    "text": "ሶ",
+                    "id": "U_1236"
+                  },
+                  {
+                    "text": "ሷ",
+                    "id": "U_1237"
+                  }
+                ]
+              },
+              {
+                "id": "K_D",
+                "text": "ድ",
+                "nextlayer": "ደ-layer",
+                "sk": [
+                  {
+                    "text": "ደ",
+                    "id": "U_12F0"
+                  },
+                  {
+                    "text": "ዱ",
+                    "id": "U_12F1"
+                  },
+                  {
+                    "text": "ዲ",
+                    "id": "U_12F2"
+                  },
+                  {
+                    "text": "ዳ",
+                    "id": "U_12F3"
+                  },
+                  {
+                    "text": "ዴ",
+                    "id": "U_12F4"
+                  },
+                  {
+                    "text": "ዶ",
+                    "id": "U_12F6"
+                  },
+                  {
+                    "text": "ዷ",
+                    "id": "U_12F7"
+                  }
+                ]
+              },
+              {
+                "id": "K_R",
+                "text": "ር",
+                "nextlayer": "ረ-layer",
+                "sk": [
+                  {
+                    "text": "ረ",
+                    "id": "U_1228"
+                  },
+                  {
+                    "text": "ሩ",
+                    "id": "U_1229"
+                  },
+                  {
+                    "text": "ሪ",
+                    "id": "U_122A"
+                  },
+                  {
+                    "text": "ራ",
+                    "id": "U_122B"
+                  },
+                  {
+                    "text": "ሬ",
+                    "id": "U_122C"
+                  },
+                  {
+                    "text": "ሮ",
+                    "id": "U_122E"
+                  },
+                  {
+                    "text": "ሯ",
+                    "id": "U_122F"
+                  }
+                ]
+              },
+              {
+                "id": "K_K",
+                "text": "ክ",
+                "nextlayer": "ከ-layer",
+                "sk": [
+                  {
+                    "text": "ኰ",
+                    "id": "U_12B0"
+                  },
+                  {
+                    "text": "ኵ",
+                    "id": "U_12B5"
+                  },
+                  {
+                    "text": "ኲ",
+                    "id": "U_12B2"
+                  },
+                  {
+                    "text": "ኳ",
+                    "id": "U_12B3"
+                  },
+                  {
+                    "text": "ኴ",
+                    "id": "U_12B4"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ከ",
+                    "id": "U_12A8"
+                  },
+                  {
+                    "text": "ኩ",
+                    "id": "U_12A9"
+                  },
+                  {
+                    "text": "ኪ",
+                    "id": "U_12AA"
+                  },
+                  {
+                    "text": "ካ",
+                    "id": "U_12AB"
+                  },
+                  {
+                    "text": "ኬ",
+                    "id": "U_12AC"
+                  },
+                  {
+                    "text": "ኮ",
+                    "id": "U_12AE"
+                  }
+                ]
+              },
+              {
+                "id": "K_H",
+                "text": "ህ",
+                "nextlayer": "ሀ-layer",
+                "sk": [
+                  {
+                    "text": "ኈ",
+                    "id": "U_1288"
+                  },
+                  {
+                    "text": "ኍ",
+                    "id": "U_128D"
+                  },
+                  {
+                    "text": "ኊ",
+                    "id": "U_128A"
+                  },
+                  {
+                    "text": "ኋ",
+                    "id": "U_128B"
+                  },
+                  {
+                    "text": "ኌ",
+                    "id": "U_128C"
+                  },
+                  {
+                    "text": "ኅ",
+                    "id": "U_1285",
+                    "nextlayer": "ኀ-layer"
+                  },
+                  {
+                    "text": "ሀ",
+                    "id": "U_1200"
+                  },
+                  {
+                    "text": "ሁ",
+                    "id": "U_1201"
+                  },
+                  {
+                    "text": "ሂ",
+                    "id": "U_1202"
+                  },
+                  {
+                    "text": "ሃ",
+                    "id": "U_1203"
+                  },
+                  {
+                    "text": "ሄ",
+                    "id": "U_1204"
+                  },
+                  {
+                    "text": "ሆ",
+                    "id": "U_1206"
+                  }
+                ]
+              },
+              {
+                "id": "K_T",
+                "text": "ት",
+                "nextlayer": "ተ-layer",
+                "sk": [
+                  {
+                    "text": "ተ",
+                    "id": "U_1270"
+                  },
+                  {
+                    "text": "ቱ",
+                    "id": "U_1271"
+                  },
+                  {
+                    "text": "ቲ",
+                    "id": "U_1272"
+                  },
+                  {
+                    "text": "ታ",
+                    "id": "U_1273"
+                  },
+                  {
+                    "text": "ቴ",
+                    "id": "U_1274"
+                  },
+                  {
+                    "text": "ቶ",
+                    "id": "U_1276"
+                  },
+                  {
+                    "text": "ቷ",
+                    "id": "U_1277"
+                  }
+                ]
+              },
+              {
+                "id": "K_T",
+                "text": "ጥ",
+                "nextlayer": "ጠ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ጠ",
+                    "id": "U_1320"
+                  },
+                  {
+                    "text": "ጡ",
+                    "id": "U_1321"
+                  },
+                  {
+                    "text": "ጢ",
+                    "id": "U_1322"
+                  },
+                  {
+                    "text": "ጣ",
+                    "id": "U_1323"
+                  },
+                  {
+                    "text": "ጤ",
+                    "id": "U_1324"
+                  },
+                  {
+                    "text": "ጦ",
+                    "id": "U_1326"
+                  },
+                  {
+                    "text": "ጧ",
+                    "id": "U_1327"
+                  }
+                ]
+              },
+              {
+                "id": "K_L",
+                "text": "ል",
+                "nextlayer": "ለ-layer",
+                "sk": [
+                  {
+                    "text": "ለ",
+                    "id": "U_1208"
+                  },
+                  {
+                    "text": "ሉ",
+                    "id": "U_1209"
+                  },
+                  {
+                    "text": "ሊ",
+                    "id": "U_120A"
+                  },
+                  {
+                    "text": "ላ",
+                    "id": "U_120B"
+                  },
+                  {
+                    "text": "ሌ",
+                    "id": "U_120C"
+                  },
+                  {
+                    "text": "ሎ",
+                    "id": "U_120E"
+                  },
+                  {
+                    "text": "ሏ",
+                    "id": "U_120F"
+                  }
+                ]
+              },
+              {
+                "id": "K_S",
+                "text": "ጽ",
+                "nextlayer": "ጸ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ፀ",
+                    "id": "U_1340"
+                  },
+                  {
+                    "text": "ፁ",
+                    "id": "U_1341"
+                  },
+                  {
+                    "text": "ፂ",
+                    "id": "U_1342"
+                  },
+                  {
+                    "text": "ፃ",
+                    "id": "U_1343"
+                  },
+                  {
+                    "text": "ፄ",
+                    "id": "U_1344"
+                  },
+                  {
+                    "text": "ፅ",
+                    "id": "U_1345",
+                    "nextlayer": "ፀ-layer"
+                  },
+                  {
+                    "text": "ፆ",
+                    "id": "U_1346"
+                  },
+                  {
+                    "text": " ",
+                    "id": "U_0020"
+                  },
+                  {
+                    "text": "ጸ",
+                    "id": "U_1338"
+                  },
+                  {
+                    "text": "ጹ",
+                    "id": "U_1339"
+                  },
+                  {
+                    "text": "ጺ",
+                    "id": "U_133A"
+                  },
+                  {
+                    "text": "ጻ",
+                    "id": "U_133B"
+                  },
+                  {
+                    "text": "ጼ",
+                    "id": "U_133C"
+                  },
+                  {
+                    "text": "ጽ",
+                    "id": "U_133D"
+                  },
+                  {
+                    "text": "ጾ",
+                    "id": "U_133E"
+                  },
+                  {
+                    "text": "ጿ",
+                    "id": "U_133F"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_SHIFT",
+                "text": "*123*",
+                "sp": 1,
+                "nextlayer": "punctuation"
+              },
+              {
+                "id": "K_Z",
+                "text": "ዝ",
+                "nextlayer": "ዘ-layer",
+                "sk": [
+                  {
+                    "text": "ዠ",
+                    "id": "U_12E0"
+                  },
+                  {
+                    "text": "ዡ",
+                    "id": "U_12E1"
+                  },
+                  {
+                    "text": "ዢ",
+                    "id": "U_12E2"
+                  },
+                  {
+                    "text": "ዣ",
+                    "id": "U_12E3"
+                  },
+                  {
+                    "text": "ዤ",
+                    "id": "U_12E4"
+                  },
+                  {
+                    "text": "ዥ",
+                    "id": "U_12E5",
+                    "nextlayer": "ዠ-layer"
+                  },
+                  {
+                    "text": "ዦ",
+                    "id": "U_12E6"
+                  },
+                  {
+                    "text": "ዧ",
+                    "id": "U_12E7"
+                  },
+                  {
+                    "text": "ዘ",
+                    "id": "U_12D8"
+                  },
+                  {
+                    "text": "ዙ",
+                    "id": "U_12D9"
+                  },
+                  {
+                    "text": "ዚ",
+                    "id": "U_12DA"
+                  },
+                  {
+                    "text": "ዛ",
+                    "id": "U_12DB"
+                  },
+                  {
+                    "text": "ዜ",
+                    "id": "U_12DC"
+                  },
+                  {
+                    "text": "ዝ",
+                    "id": "U_12DD"
+                  },
+                  {
+                    "text": "ዞ",
+                    "id": "U_12DE"
+                  },
+                  {
+                    "text": "ዟ",
+                    "id": "U_12DF"
+                  }
+                ]
+              },
+              {
+                "id": "K_W",
+                "text": "ው",
+                "nextlayer": "ወ-layer",
+                "sk": [
+                  {
+                    "text": "ወ",
+                    "id": "U_12C8"
+                  },
+                  {
+                    "text": "ዉ",
+                    "id": "U_12C9"
+                  },
+                  {
+                    "text": "ዊ",
+                    "id": "U_12CA"
+                  },
+                  {
+                    "text": "ዋ",
+                    "id": "U_12CB"
+                  },
+                  {
+                    "text": "ዌ",
+                    "id": "U_12CC"
+                  },
+                  {
+                    "text": "ዎ",
+                    "id": "U_12CE"
+                  }
+                ]
+              },
+              {
+                "id": "K_G",
+                "text": "ግ",
+                "nextlayer": "ገ-layer",
+                "sk": [
+                  {
+                    "text": "ጐ",
+                    "id": "U_1310"
+                  },
+                  {
+                    "text": "ጕ",
+                    "id": "U_1315"
+                  },
+                  {
+                    "text": "ጒ",
+                    "id": "U_1312"
+                  },
+                  {
+                    "text": "ጓ",
+                    "id": "U_1313"
+                  },
+                  {
+                    "text": "ጔ",
+                    "id": "U_1314"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ገ",
+                    "id": "U_1308"
+                  },
+                  {
+                    "text": "ጉ",
+                    "id": "U_1309"
+                  },
+                  {
+                    "text": "ጊ",
+                    "id": "U_130A"
+                  },
+                  {
+                    "text": "ጋ",
+                    "id": "U_130B"
+                  },
+                  {
+                    "text": "ጌ",
+                    "id": "U_130C"
+                  },
+                  {
+                    "text": "ጎ",
+                    "id": "U_130E"
+                  }
+                ]
+              },
+              {
+                "id": "K_1",
+                "text": "!",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "?",
+                    "id": "K_SLASH",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "/",
+                    "id": "K_SLASH"
+                  },
+                  {
+                    "text": ".",
+                    "id": "U_002E"
+                  },
+                  {
+                    "text": ",",
+                    "id": "U_002C"
+                  },
+                  {
+                    "text": ":",
+                    "id": "U_003A"
+                  },
+                  {
+                    "text": "’",
+                    "id": "U_2019"
+                  }
+                ]
+              },
+              {
+                "id": "U_1362",
+                "text": "።",
+                "nextlayer": "ethio-punct-layer",
+                "sk": [
+                  {
+                    "text": "፡",
+                    "id": "K_COLON",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "፣",
+                    "id": "K_COMMA"
+                  },
+                  {
+                    "text": "፤",
+                    "id": "K_COLON"
+                  },
+                  {
+                    "text": "፦",
+                    "id": "U_1366"
+                  },
+                  {
+                    "text": "«",
+                    "id": "U_00AB"
+                  },
+                  {
+                    "text": "»",
+                    "id": "U_00BB"
+                  }
+                ]
+              },
+              {
+                "id": "K_B",
+                "text": "ብ",
+                "nextlayer": "በ-layer",
+                "sk": [
+                  {
+                    "text": "ቨ",
+                    "id": "U_1268"
+                  },
+                  {
+                    "text": "ቩ",
+                    "id": "U_1269"
+                  },
+                  {
+                    "text": "ቪ",
+                    "id": "U_126A"
+                  },
+                  {
+                    "text": "ቫ",
+                    "id": "U_126B"
+                  },
+                  {
+                    "text": "ቬ",
+                    "id": "U_126C"
+                  },
+                  {
+                    "text": "ቭ",
+                    "id": "U_126D",
+                    "nextlayer": "ቨ-layer"
+                  },
+                  {
+                    "text": "ቮ",
+                    "id": "U_126E"
+                  },
+                  {
+                    "text": "ቯ",
+                    "id": "U_126F"
+                  },
+                  {
+                    "text": "በ",
+                    "id": "U_1260"
+                  },
+                  {
+                    "text": "ቡ",
+                    "id": "U_1261"
+                  },
+                  {
+                    "text": "ቢ",
+                    "id": "U_1262"
+                  },
+                  {
+                    "text": "ባ",
+                    "id": "U_1263"
+                  },
+                  {
+                    "text": "ቤ",
+                    "id": "U_1264"
+                  },
+                  {
+                    "text": "ብ",
+                    "id": "U_1265"
+                  },
+                  {
+                    "text": "ቦ",
+                    "id": "U_1266"
+                  },
+                  {
+                    "text": "ቧ",
+                    "id": "U_1267"
+                  }
+                ]
+              },
+              {
+                "id": "K_N",
+                "text": "ን/ኝ",
+                "nextlayer": "ነ-layer",
+                "sk": [
+                  {
+                    "text": "ኘ",
+                    "id": "U_1298"
+                  },
+                  {
+                    "text": "ኙ",
+                    "id": "U_1299"
+                  },
+                  {
+                    "text": "ኚ",
+                    "id": "U_129A"
+                  },
+                  {
+                    "text": "ኛ",
+                    "id": "U_129B"
+                  },
+                  {
+                    "text": "ኜ",
+                    "id": "U_129C"
+                  },
+                  {
+                    "text": "ኝ",
+                    "id": "U_129D",
+                    "nextlayer": "ኘ-layer"
+                  },
+                  {
+                    "text": "ኞ",
+                    "id": "U_129E"
+                  },
+                  {
+                    "text": "ኟ",
+                    "id": "U_129F"
+                  },
+                  {
+                    "text": "ነ",
+                    "id": "U_1290"
+                  },
+                  {
+                    "text": "ኑ",
+                    "id": "U_1291"
+                  },
+                  {
+                    "text": "ኒ",
+                    "id": "U_1292"
+                  },
+                  {
+                    "text": "ና",
+                    "id": "U_1293"
+                  },
+                  {
+                    "text": "ኔ",
+                    "id": "U_1294"
+                  },
+                  {
+                    "text": "ን",
+                    "id": "U_1295"
+                  },
+                  {
+                    "text": "ኖ",
+                    "id": "U_1296"
+                  },
+                  {
+                    "text": "ኗ",
+                    "id": "U_1297"
+                  }
+                ]
+              },
+              {
+                "id": "K_M",
+                "text": "ም",
+                "nextlayer": "መ-layer",
+                "sk": [
+                  {
+                    "text": "መ",
+                    "id": "U_1218"
+                  },
+                  {
+                    "text": "ሙ",
+                    "id": "U_1219"
+                  },
+                  {
+                    "text": "ሚ",
+                    "id": "U_121A"
+                  },
+                  {
+                    "text": "ማ",
+                    "id": "U_121B"
+                  },
+                  {
+                    "text": "ሜ",
+                    "id": "U_121C"
+                  },
+                  {
+                    "text": "ሞ",
+                    "id": "U_121E"
+                  },
+                  {
+                    "text": "ሟ",
+                    "id": "U_121F"
+                  }
+                ]
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "sp": 1
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "sp": 1
+              },
+              {
+                "id": "K_2",
+                "text": "@",
+                "layer": "shift",
+                "hint": "#",
+                "sk": [
+                  {
+                    "text": "#",
+                    "id": "K_3",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": ":",
+                    "id": "K_COLON",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_4",
+                "text": "$",
+                "layer": "shift",
+                "hint": "%",
+                "sk": [
+                  {
+                    "text": "%",
+                    "id": "K_5",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "T_00AB",
+                "text": "«",
+                "sk": [
+                  {
+                    "text": "‹",
+                    "id": "T_2039"
+                  },
+                  {
+                    "text": "‘",
+                    "id": "T_2018"
+                  },
+                  {
+                    "text": "“",
+                    "id": "T_201C"
+                  }
+                ]
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": 215,
+                "sp": 0
+              },
+              {
+                "id": "U_00BB",
+                "text": "»",
+                "sk": [
+                  {
+                    "text": "›",
+                    "id": "T_203A"
+                  },
+                  {
+                    "text": "’",
+                    "id": "T_2019"
+                  },
+                  {
+                    "text": "”",
+                    "id": "T_201D"
+                  }
+                ]
+              },
+              {
+                "id": "K_SLASH",
+                "text": "/",
+                "layer": "default",
+                "hint": "()",
+                "sk": [
+                  {
+                    "text": "(",
+                    "id": "K_9",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": ")",
+                    "id": "K_0",
+                    "layer": "shift"
+                  }
+                ]
+              },
+              {
+                "id": "K_SLASH",
+                "text": "?",
+                "layer": "shift",
+                "hint": ".",
+                "sk": [
+                  {
+                    "text": ".",
+                    "id": "K_PERIOD"
+                  }
+                ]
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "sp": 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ethio-punct-layer",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "U_12D5",
+                "text": "ዕ",
+                "nextlayer": "ዐ-layer",
+                "sk": [
+                  {
+                    "text": "ዐ",
+                    "id": "U_12D0"
+                  },
+                  {
+                    "text": "ዑ",
+                    "id": "U_12D1"
+                  },
+                  {
+                    "text": "ዒ",
+                    "id": "U_12D2"
+                  },
+                  {
+                    "text": "ዓ",
+                    "id": "U_12D3"
+                  },
+                  {
+                    "text": "ዔ",
+                    "id": "U_12D4"
+                  },
+                  {
+                    "text": "ዖ",
+                    "id": "U_12D6"
+                  }
+                ]
+              },
+              {
+                "id": "K_X",
+                "text": "ሽ",
+                "nextlayer": "ሸ-layer",
+                "sk": [
+                  {
+                    "text": "ሸ",
+                    "id": "U_1238"
+                  },
+                  {
+                    "text": "ሹ",
+                    "id": "U_1239"
+                  },
+                  {
+                    "text": "ሺ",
+                    "id": "U_123A"
+                  },
+                  {
+                    "text": "ሻ",
+                    "id": "U_123B"
+                  },
+                  {
+                    "text": "ሼ",
+                    "id": "U_123C"
+                  },
+                  {
+                    "text": "ሾ",
+                    "id": "U_123E"
+                  },
+                  {
+                    "text": "ሿ",
+                    "id": "U_123F"
+                  }
+                ]
+              },
+              {
+                "id": "K_J",
+                "text": "ጅ",
+                "nextlayer": "ጀ-layer",
+                "sk": [
+                  {
+                    "text": "ጀ",
+                    "id": "U_1300"
+                  },
+                  {
+                    "text": "ጁ",
+                    "id": "U_1301"
+                  },
+                  {
+                    "text": "ጂ",
+                    "id": "U_1302"
+                  },
+                  {
+                    "text": "ጃ",
+                    "id": "U_1303"
+                  },
+                  {
+                    "text": "ጄ",
+                    "id": "U_1304"
+                  },
+                  {
+                    "text": "ጆ",
+                    "id": "U_1306"
+                  },
+                  {
+                    "text": "ጇ",
+                    "id": "U_1307"
+                  }
+                ]
+              },
+              {
+                "id": "K_F",
+                "text": "ፍ",
+                "nextlayer": "ፈ-layer",
+                "sk": [
+                  {
+                    "text": "ፈ",
+                    "id": "U_1348"
+                  },
+                  {
+                    "text": "ፉ",
+                    "id": "U_1349"
+                  },
+                  {
+                    "text": "ፊ",
+                    "id": "U_134A"
+                  },
+                  {
+                    "text": "ፋ",
+                    "id": "U_134B"
+                  },
+                  {
+                    "text": "ፌ",
+                    "id": "U_134C"
+                  },
+                  {
+                    "text": "ፎ",
+                    "id": "U_134E"
+                  },
+                  {
+                    "text": "ፏ",
+                    "id": "U_134F"
+                  }
+                ]
+              },
+              {
+                "id": "K_Q",
+                "text": "ቅ",
+                "nextlayer": "ቀ-layer",
+                "sk": [
+                  {
+                    "text": "ቈ",
+                    "id": "U_1248"
+                  },
+                  {
+                    "text": "ቍ",
+                    "id": "U_124D"
+                  },
+                  {
+                    "text": "ቊ",
+                    "id": "U_124A"
+                  },
+                  {
+                    "text": "ቋ",
+                    "id": "U_124B"
+                  },
+                  {
+                    "text": "ቌ",
+                    "id": "U_124C"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ቀ",
+                    "id": "U_1240"
+                  },
+                  {
+                    "text": "ቁ",
+                    "id": "U_1241"
+                  },
+                  {
+                    "text": "ቂ",
+                    "id": "U_1242"
+                  },
+                  {
+                    "text": "ቃ",
+                    "id": "U_1243"
+                  },
+                  {
+                    "text": "ቄ",
+                    "id": "U_1244"
+                  },
+                  {
+                    "text": "ቆ",
+                    "id": "U_1246"
+                  }
+                ]
+              },
+              {
+                "id": "K_H",
+                "text": "ሕ",
+                "nextlayer": "ሐ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ሐ",
+                    "id": "U_1210"
+                  },
+                  {
+                    "text": "ሑ",
+                    "id": "U_1211"
+                  },
+                  {
+                    "text": "ሒ",
+                    "id": "U_1212"
+                  },
+                  {
+                    "text": "ሓ",
+                    "id": "U_1213"
+                  },
+                  {
+                    "text": "ሔ",
+                    "id": "U_1214"
+                  },
+                  {
+                    "text": "ሖ",
+                    "id": "U_1216"
+                  },
+                  {
+                    "text": "ሗ",
+                    "id": "U_1217"
+                  }
+                ]
+              },
+              {
+                "id": "K_C",
+                "text": "ች",
+                "nextlayer": "ቸ-layer",
+                "sk": [
+                  {
+                    "text": "ቸ",
+                    "id": "U_1278"
+                  },
+                  {
+                    "text": "ቹ",
+                    "id": "U_1279"
+                  },
+                  {
+                    "text": "ቺ",
+                    "id": "U_127A"
+                  },
+                  {
+                    "text": "ቻ",
+                    "id": "U_127B"
+                  },
+                  {
+                    "text": "ቼ",
+                    "id": "U_127C"
+                  },
+                  {
+                    "text": "ቾ",
+                    "id": "U_127E"
+                  },
+                  {
+                    "text": "ቿ",
+                    "id": "U_127F"
+                  }
+                ]
+              },
+              {
+                "id": "K_C",
+                "text": "ጭ",
+                "nextlayer": "ጨ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ጨ",
+                    "id": "U_1328"
+                  },
+                  {
+                    "text": "ጩ",
+                    "id": "U_1329"
+                  },
+                  {
+                    "text": "ጪ",
+                    "id": "U_132A"
+                  },
+                  {
+                    "text": "ጫ",
+                    "id": "U_132B"
+                  },
+                  {
+                    "text": "ጬ",
+                    "id": "U_132C"
+                  },
+                  {
+                    "text": "ጮ",
+                    "id": "U_132E"
+                  },
+                  {
+                    "text": "ጯ",
+                    "id": "U_132F"
+                  }
+                ]
+              },
+              {
+                "id": "K_Y",
+                "text": "ይ",
+                "nextlayer": "የ-layer",
+                "sk": [
+                  {
+                    "text": "የ",
+                    "id": "U_12E8"
+                  },
+                  {
+                    "text": "ዩ",
+                    "id": "U_12E9"
+                  },
+                  {
+                    "text": "ዪ",
+                    "id": "U_12EA"
+                  },
+                  {
+                    "text": "ያ",
+                    "id": "U_12EB"
+                  },
+                  {
+                    "text": "ዬ",
+                    "id": "U_12EC"
+                  },
+                  {
+                    "text": "ዮ",
+                    "id": "U_12EE"
+                  }
+                ]
+              },
+              {
+                "id": "K_P",
+                "text": "ጵ",
+                "nextlayer": "ጰ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ፐ",
+                    "id": "U_1350"
+                  },
+                  {
+                    "text": "ፑ",
+                    "id": "U_1351"
+                  },
+                  {
+                    "text": "ፒ",
+                    "id": "U_1352"
+                  },
+                  {
+                    "text": "ፓ",
+                    "id": "U_1353"
+                  },
+                  {
+                    "text": "ፔ",
+                    "id": "U_1354"
+                  },
+                  {
+                    "text": "ፕ",
+                    "id": "U_1355",
+                    "nextlayer": "ፐ-layer"
+                  },
+                  {
+                    "text": "ፖ",
+                    "id": "U_1356"
+                  },
+                  {
+                    "text": "ፗ",
+                    "id": "U_1357"
+                  },
+                  {
+                    "text": "ጰ",
+                    "id": "U_1330"
+                  },
+                  {
+                    "text": "ጱ",
+                    "id": "U_1331"
+                  },
+                  {
+                    "text": "ጲ",
+                    "id": "U_1332"
+                  },
+                  {
+                    "text": "ጳ",
+                    "id": "U_1333"
+                  },
+                  {
+                    "text": "ጴ",
+                    "id": "U_1334"
+                  },
+                  {
+                    "text": "ጵ",
+                    "id": "U_1335"
+                  },
+                  {
+                    "text": "ጶ",
+                    "id": "U_1336"
+                  },
+                  {
+                    "text": "ጷ",
+                    "id": "U_1337"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "key": [
+              {
+                "id": "U_12A5",
+                "text": "እ",
+                "nextlayer": "default",
+                "sk": [
+                  {
+                    "text": "አ",
+                    "id": "U_12A0"
+                  },
+                  {
+                    "text": "ኡ",
+                    "id": "U_12A1"
+                  },
+                  {
+                    "text": "ኢ",
+                    "id": "U_12A2"
+                  },
+                  {
+                    "text": "ኣ",
+                    "id": "U_12A3"
+                  },
+                  {
+                    "text": "ኤ",
+                    "id": "U_12A4"
+                  },
+                  {
+                    "text": "ኦ",
+                    "id": "U_12A6"
+                  },
+                  {
+                    "text": "ኧ",
+                    "id": "U_12A7"
+                  }
+                ]
+              },
+              {
+                "id": "K_S",
+                "text": "ስ",
+                "nextlayer": "ሰ-layer",
+                "sk": [
+                  {
+                    "text": "ሠ",
+                    "id": "U_1220"
+                  },
+                  {
+                    "text": "ሡ",
+                    "id": "U_1221"
+                  },
+                  {
+                    "text": "ሢ",
+                    "id": "U_1222"
+                  },
+                  {
+                    "text": "ሣ",
+                    "id": "U_1223"
+                  },
+                  {
+                    "text": "ሤ",
+                    "id": "U_1224"
+                  },
+                  {
+                    "text": "ሥ",
+                    "id": "U_1225",
+                    "nextlayer": "ሠ-layer"
+                  },
+                  {
+                    "text": "ሦ",
+                    "id": "U_1226"
+                  },
+                  {
+                    "text": "ሧ",
+                    "id": "U_1227"
+                  },
+                  {
+                    "text": "ሰ",
+                    "id": "U_1230"
+                  },
+                  {
+                    "text": "ሱ",
+                    "id": "U_1231"
+                  },
+                  {
+                    "text": "ሲ",
+                    "id": "U_1232"
+                  },
+                  {
+                    "text": "ሳ",
+                    "id": "U_1233"
+                  },
+                  {
+                    "text": "ሴ",
+                    "id": "U_1234"
+                  },
+                  {
+                    "text": "ስ",
+                    "id": "U_1235"
+                  },
+                  {
+                    "text": "ሶ",
+                    "id": "U_1236"
+                  },
+                  {
+                    "text": "ሷ",
+                    "id": "U_1237"
+                  }
+                ]
+              },
+              {
+                "id": "K_D",
+                "text": "ድ",
+                "nextlayer": "ደ-layer",
+                "sk": [
+                  {
+                    "text": "ደ",
+                    "id": "U_12F0"
+                  },
+                  {
+                    "text": "ዱ",
+                    "id": "U_12F1"
+                  },
+                  {
+                    "text": "ዲ",
+                    "id": "U_12F2"
+                  },
+                  {
+                    "text": "ዳ",
+                    "id": "U_12F3"
+                  },
+                  {
+                    "text": "ዴ",
+                    "id": "U_12F4"
+                  },
+                  {
+                    "text": "ዶ",
+                    "id": "U_12F6"
+                  },
+                  {
+                    "text": "ዷ",
+                    "id": "U_12F7"
+                  }
+                ]
+              },
+              {
+                "id": "K_R",
+                "text": "ር",
+                "nextlayer": "ረ-layer",
+                "sk": [
+                  {
+                    "text": "ረ",
+                    "id": "U_1228"
+                  },
+                  {
+                    "text": "ሩ",
+                    "id": "U_1229"
+                  },
+                  {
+                    "text": "ሪ",
+                    "id": "U_122A"
+                  },
+                  {
+                    "text": "ራ",
+                    "id": "U_122B"
+                  },
+                  {
+                    "text": "ሬ",
+                    "id": "U_122C"
+                  },
+                  {
+                    "text": "ሮ",
+                    "id": "U_122E"
+                  },
+                  {
+                    "text": "ሯ",
+                    "id": "U_122F"
+                  }
+                ]
+              },
+              {
+                "id": "K_K",
+                "text": "ክ",
+                "nextlayer": "ከ-layer",
+                "sk": [
+                  {
+                    "text": "ኰ",
+                    "id": "U_12B0"
+                  },
+                  {
+                    "text": "ኵ",
+                    "id": "U_12B5"
+                  },
+                  {
+                    "text": "ኲ",
+                    "id": "U_12B2"
+                  },
+                  {
+                    "text": "ኳ",
+                    "id": "U_12B3"
+                  },
+                  {
+                    "text": "ኴ",
+                    "id": "U_12B4"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ከ",
+                    "id": "U_12A8"
+                  },
+                  {
+                    "text": "ኩ",
+                    "id": "U_12A9"
+                  },
+                  {
+                    "text": "ኪ",
+                    "id": "U_12AA"
+                  },
+                  {
+                    "text": "ካ",
+                    "id": "U_12AB"
+                  },
+                  {
+                    "text": "ኬ",
+                    "id": "U_12AC"
+                  },
+                  {
+                    "text": "ኮ",
+                    "id": "U_12AE"
+                  }
+                ]
+              },
+              {
+                "id": "K_H",
+                "text": "ህ",
+                "nextlayer": "ሀ-layer",
+                "sk": [
+                  {
+                    "text": "ኈ",
+                    "id": "U_1288"
+                  },
+                  {
+                    "text": "ኍ",
+                    "id": "U_128D"
+                  },
+                  {
+                    "text": "ኊ",
+                    "id": "U_128A"
+                  },
+                  {
+                    "text": "ኋ",
+                    "id": "U_128B"
+                  },
+                  {
+                    "text": "ኌ",
+                    "id": "U_128C"
+                  },
+                  {
+                    "text": "ኅ",
+                    "id": "U_1285",
+                    "nextlayer": "ኀ-layer"
+                  },
+                  {
+                    "text": "ሀ",
+                    "id": "U_1200"
+                  },
+                  {
+                    "text": "ሁ",
+                    "id": "U_1201"
+                  },
+                  {
+                    "text": "ሂ",
+                    "id": "U_1202"
+                  },
+                  {
+                    "text": "ሃ",
+                    "id": "U_1203"
+                  },
+                  {
+                    "text": "ሄ",
+                    "id": "U_1204"
+                  },
+                  {
+                    "text": "ሆ",
+                    "id": "U_1206"
+                  }
+                ]
+              },
+              {
+                "id": "K_T",
+                "text": "ት",
+                "nextlayer": "ተ-layer",
+                "sk": [
+                  {
+                    "text": "ተ",
+                    "id": "U_1270"
+                  },
+                  {
+                    "text": "ቱ",
+                    "id": "U_1271"
+                  },
+                  {
+                    "text": "ቲ",
+                    "id": "U_1272"
+                  },
+                  {
+                    "text": "ታ",
+                    "id": "U_1273"
+                  },
+                  {
+                    "text": "ቴ",
+                    "id": "U_1274"
+                  },
+                  {
+                    "text": "ቶ",
+                    "id": "U_1276"
+                  },
+                  {
+                    "text": "ቷ",
+                    "id": "U_1277"
+                  }
+                ]
+              },
+              {
+                "id": "K_T",
+                "text": "ጥ",
+                "nextlayer": "ጠ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ጠ",
+                    "id": "U_1320"
+                  },
+                  {
+                    "text": "ጡ",
+                    "id": "U_1321"
+                  },
+                  {
+                    "text": "ጢ",
+                    "id": "U_1322"
+                  },
+                  {
+                    "text": "ጣ",
+                    "id": "U_1323"
+                  },
+                  {
+                    "text": "ጤ",
+                    "id": "U_1324"
+                  },
+                  {
+                    "text": "ጦ",
+                    "id": "U_1326"
+                  },
+                  {
+                    "text": "ጧ",
+                    "id": "U_1327"
+                  }
+                ]
+              },
+              {
+                "id": "K_L",
+                "text": "ል",
+                "nextlayer": "ለ-layer",
+                "sk": [
+                  {
+                    "text": "ለ",
+                    "id": "U_1208"
+                  },
+                  {
+                    "text": "ሉ",
+                    "id": "U_1209"
+                  },
+                  {
+                    "text": "ሊ",
+                    "id": "U_120A"
+                  },
+                  {
+                    "text": "ላ",
+                    "id": "U_120B"
+                  },
+                  {
+                    "text": "ሌ",
+                    "id": "U_120C"
+                  },
+                  {
+                    "text": "ሎ",
+                    "id": "U_120E"
+                  },
+                  {
+                    "text": "ሏ",
+                    "id": "U_120F"
+                  }
+                ]
+              },
+              {
+                "id": "K_S",
+                "text": "ጽ",
+                "nextlayer": "ጸ-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "ፀ",
+                    "id": "U_1340"
+                  },
+                  {
+                    "text": "ፁ",
+                    "id": "U_1341"
+                  },
+                  {
+                    "text": "ፂ",
+                    "id": "U_1342"
+                  },
+                  {
+                    "text": "ፃ",
+                    "id": "U_1343"
+                  },
+                  {
+                    "text": "ፄ",
+                    "id": "U_1344"
+                  },
+                  {
+                    "text": "ፅ",
+                    "id": "U_1345",
+                    "nextlayer": "ፀ-layer"
+                  },
+                  {
+                    "text": "ፆ",
+                    "id": "U_1346"
+                  },
+                  {
+                    "text": " ",
+                    "id": "U_0020"
+                  },
+                  {
+                    "text": "ጸ",
+                    "id": "U_1338"
+                  },
+                  {
+                    "text": "ጹ",
+                    "id": "U_1339"
+                  },
+                  {
+                    "text": "ጺ",
+                    "id": "U_133A"
+                  },
+                  {
+                    "text": "ጻ",
+                    "id": "U_133B"
+                  },
+                  {
+                    "text": "ጼ",
+                    "id": "U_133C"
+                  },
+                  {
+                    "text": "ጽ",
+                    "id": "U_133D"
+                  },
+                  {
+                    "text": "ጾ",
+                    "id": "U_133E"
+                  },
+                  {
+                    "text": "ጿ",
+                    "id": "U_133F"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 3,
+            "key": [
+              {
+                "id": "K_SHIFT",
+                "text": "*123*",
+                "sp": 1,
+                "nextlayer": "punctuation"
+              },
+              {
+                "id": "K_Z",
+                "text": "ዝ",
+                "nextlayer": "ዘ-layer",
+                "sk": [
+                  {
+                    "text": "ዠ",
+                    "id": "U_12E0"
+                  },
+                  {
+                    "text": "ዡ",
+                    "id": "U_12E1"
+                  },
+                  {
+                    "text": "ዢ",
+                    "id": "U_12E2"
+                  },
+                  {
+                    "text": "ዣ",
+                    "id": "U_12E3"
+                  },
+                  {
+                    "text": "ዤ",
+                    "id": "U_12E4"
+                  },
+                  {
+                    "text": "ዥ",
+                    "id": "U_12E5",
+                    "nextlayer": "ዠ-layer"
+                  },
+                  {
+                    "text": "ዦ",
+                    "id": "U_12E6"
+                  },
+                  {
+                    "text": "ዧ",
+                    "id": "U_12E7"
+                  },
+                  {
+                    "text": "ዘ",
+                    "id": "U_12D8"
+                  },
+                  {
+                    "text": "ዙ",
+                    "id": "U_12D9"
+                  },
+                  {
+                    "text": "ዚ",
+                    "id": "U_12DA"
+                  },
+                  {
+                    "text": "ዛ",
+                    "id": "U_12DB"
+                  },
+                  {
+                    "text": "ዜ",
+                    "id": "U_12DC"
+                  },
+                  {
+                    "text": "ዝ",
+                    "id": "U_12DD"
+                  },
+                  {
+                    "text": "ዞ",
+                    "id": "U_12DE"
+                  },
+                  {
+                    "text": "ዟ",
+                    "id": "U_12DF"
+                  }
+                ]
+              },
+              {
+                "id": "K_W",
+                "text": "ው",
+                "nextlayer": "ወ-layer",
+                "sk": [
+                  {
+                    "text": "ወ",
+                    "id": "U_12C8"
+                  },
+                  {
+                    "text": "ዉ",
+                    "id": "U_12C9"
+                  },
+                  {
+                    "text": "ዊ",
+                    "id": "U_12CA"
+                  },
+                  {
+                    "text": "ዋ",
+                    "id": "U_12CB"
+                  },
+                  {
+                    "text": "ዌ",
+                    "id": "U_12CC"
+                  },
+                  {
+                    "text": "ዎ",
+                    "id": "U_12CE"
+                  }
+                ]
+              },
+              {
+                "id": "K_G",
+                "text": "ግ",
+                "nextlayer": "ገ-layer",
+                "sk": [
+                  {
+                    "text": "ጐ",
+                    "id": "U_1310"
+                  },
+                  {
+                    "text": "ጕ",
+                    "id": "U_1315"
+                  },
+                  {
+                    "text": "ጒ",
+                    "id": "U_1312"
+                  },
+                  {
+                    "text": "ጓ",
+                    "id": "U_1313"
+                  },
+                  {
+                    "text": "ጔ",
+                    "id": "U_1314"
+                  },
+                  {
+                    "id": "T_SPACER",
+                    "sp": 10
+                  },
+                  {
+                    "text": "ገ",
+                    "id": "U_1308"
+                  },
+                  {
+                    "text": "ጉ",
+                    "id": "U_1309"
+                  },
+                  {
+                    "text": "ጊ",
+                    "id": "U_130A"
+                  },
+                  {
+                    "text": "ጋ",
+                    "id": "U_130B"
+                  },
+                  {
+                    "text": "ጌ",
+                    "id": "U_130C"
+                  },
+                  {
+                    "text": "ጎ",
+                    "id": "U_130E"
+                  }
+                ]
+              },
+              {
+                "id": "K_1",
+                "text": "!",
+                "nextlayer": "latin-punct-layer",
+                "layer": "shift",
+                "sk": [
+                  {
+                    "text": "?",
+                    "id": "K_SLASH",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "/",
+                    "id": "K_SLASH"
+                  },
+                  {
+                    "text": ".",
+                    "id": "U_002E"
+                  },
+                  {
+                    "text": ",",
+                    "id": "U_002C"
+                  },
+                  {
+                    "text": ":",
+                    "id": "U_003A"
+                  },
+                  {
+                    "text": "’",
+                    "id": "U_2019"
+                  }
+                ]
+              },
+              {
+                "id": "U_1362",
+                "text": "።",
+                "sk": [
+                  {
+                    "text": "፡",
+                    "id": "K_COLON",
+                    "layer": "shift"
+                  },
+                  {
+                    "text": "፣",
+                    "id": "K_COMMA"
+                  },
+                  {
+                    "text": "፤",
+                    "id": "K_COLON"
+                  },
+                  {
+                    "text": "፦",
+                    "id": "U_1366"
+                  },
+                  {
+                    "text": "«",
+                    "id": "U_00AB"
+                  },
+                  {
+                    "text": "»",
+                    "id": "U_00BB"
+                  }
+                ]
+              },
+              {
+                "id": "K_B",
+                "text": "ብ",
+                "nextlayer": "በ-layer",
+                "sk": [
+                  {
+                    "text": "ቨ",
+                    "id": "U_1268"
+                  },
+                  {
+                    "text": "ቩ",
+                    "id": "U_1269"
+                  },
+                  {
+                    "text": "ቪ",
+                    "id": "U_126A"
+                  },
+                  {
+                    "text": "ቫ",
+                    "id": "U_126B"
+                  },
+                  {
+                    "text": "ቬ",
+                    "id": "U_126C"
+                  },
+                  {
+                    "text": "ቭ",
+                    "id": "U_126D",
+                    "nextlayer": "ቨ-layer"
+                  },
+                  {
+                    "text": "ቮ",
+                    "id": "U_126E"
+                  },
+                  {
+                    "text": "ቯ",
+                    "id": "U_126F"
+                  },
+                  {
+                    "text": "በ",
+                    "id": "U_1260"
+                  },
+                  {
+                    "text": "ቡ",
+                    "id": "U_1261"
+                  },
+                  {
+                    "text": "ቢ",
+                    "id": "U_1262"
+                  },
+                  {
+                    "text": "ባ",
+                    "id": "U_1263"
+                  },
+                  {
+                    "text": "ቤ",
+                    "id": "U_1264"
+                  },
+                  {
+                    "text": "ብ",
+                    "id": "U_1265"
+                  },
+                  {
+                    "text": "ቦ",
+                    "id": "U_1266"
+                  },
+                  {
+                    "text": "ቧ",
+                    "id": "U_1267"
+                  }
+                ]
+              },
+              {
+                "id": "K_N",
+                "text": "ን/ኝ",
+                "nextlayer": "ነ-layer",
+                "sk": [
+                  {
+                    "text": "ኘ",
+                    "id": "U_1298"
+                  },
+                  {
+                    "text": "ኙ",
+                    "id": "U_1299"
+                  },
+                  {
+                    "text": "ኚ",
+                    "id": "U_129A"
+                  },
+                  {
+                    "text": "ኛ",
+                    "id": "U_129B"
+                  },
+                  {
+                    "text": "ኜ",
+                    "id": "U_129C"
+                  },
+                  {
+                    "text": "ኝ",
+                    "id": "U_129D",
+                    "nextlayer": "ኘ-layer"
+                  },
+                  {
+                    "text": "ኞ",
+                    "id": "U_129E"
+                  },
+                  {
+                    "text": "ኟ",
+                    "id": "U_129F"
+                  },
+                  {
+                    "text": "ነ",
+                    "id": "U_1290"
+                  },
+                  {
+                    "text": "ኑ",
+                    "id": "U_1291"
+                  },
+                  {
+                    "text": "ኒ",
+                    "id": "U_1292"
+                  },
+                  {
+                    "text": "ና",
+                    "id": "U_1293"
+                  },
+                  {
+                    "text": "ኔ",
+                    "id": "U_1294"
+                  },
+                  {
+                    "text": "ን",
+                    "id": "U_1295"
+                  },
+                  {
+                    "text": "ኖ",
+                    "id": "U_1296"
+                  },
+                  {
+                    "text": "ኗ",
+                    "id": "U_1297"
+                  }
+                ]
+              },
+              {
+                "id": "K_M",
+                "text": "ም",
+                "nextlayer": "መ-layer",
+                "sk": [
+                  {
+                    "text": "መ",
+                    "id": "U_1218"
+                  },
+                  {
+                    "text": "ሙ",
+                    "id": "U_1219"
+                  },
+                  {
+                    "text": "ሚ",
+                    "id": "U_121A"
+                  },
+                  {
+                    "text": "ማ",
+                    "id": "U_121B"
+                  },
+                  {
+                    "text": "ሜ",
+                    "id": "U_121C"
+                  },
+                  {
+                    "text": "ሞ",
+                    "id": "U_121E"
+                  },
+                  {
+                    "text": "ሟ",
+                    "id": "U_121F"
+                  }
+                ]
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "sp": 1
+              }
+            ]
+          },
+          {
+            "id": 4,
+            "key": [
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "sp": 1
+              },
+              {
+                "id": "T_1360",
+                "text": "፠",
+                "hint": "፨",
+                "sk": [
+                  {
+                    "text": "፨",
+                    "id": "T_1368"
+                  }
+                ]
+              },
+              {
+                "id": "T_1365",
+                "text": "፥",
+                "hint": ""
+              },
+              {
+                "id": "T_1366",
+                "text": "፦",
+                "hint": ""
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": 215,
+                "sp": 0
+              },
+              {
+                "id": "T_1361",
+                "text": "፡"
+              },
+              {
+                "id": "T_1363",
+                "text": "፣"
+              },
+              {
+                "id": "T_1364",
+                "text": "፤",
+                "hint": ""
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "sp": 1
               }
             ]
           }
@@ -58816,7 +60715,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -59003,8 +60901,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -59014,7 +60911,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -59206,7 +61103,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -59446,9 +61343,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -59458,7 +61355,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -59494,7 +61390,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -59659,7 +61554,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -59851,7 +61746,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -59912,7 +61806,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -59943,9 +61837,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -59955,7 +61847,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -59988,7 +61880,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -60115,7 +62006,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -60251,7 +62142,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -60385,9 +62275,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -60397,15 +62287,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "አ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኧ",
@@ -60415,46 +62301,34 @@
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -60512,7 +62386,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -60699,8 +62572,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -60710,7 +62582,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -60902,7 +62774,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -61142,9 +63014,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -61154,7 +63026,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -61190,7 +63061,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -61355,7 +63225,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -61547,7 +63417,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -61608,7 +63477,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -61639,9 +63508,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -61651,7 +63518,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -61684,7 +63551,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -61811,7 +63677,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -61947,7 +63813,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -62081,9 +63946,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -62093,58 +63958,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሀ",
-                "pad": "",
-                "width": ""
+                "text": "ሀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሁ",
-                "pad": "",
-                "width": ""
+                "text": "ሁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሂ",
-                "pad": "",
-                "width": ""
+                "text": "ሂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ሃ",
-                "pad": "",
-                "width": ""
+                "text": "ሃ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሄ",
-                "pad": "",
-                "width": ""
+                "text": "ሄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሆ",
-                "pad": "",
-                "width": ""
+                "text": "ሆ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -62202,7 +64051,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -62389,8 +64237,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -62400,7 +64247,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -62592,7 +64439,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -62832,9 +64679,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -62844,7 +64691,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -62880,7 +64726,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -63045,7 +64890,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -63237,7 +65082,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -63298,7 +65142,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -63329,9 +65173,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -63341,7 +65183,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -63374,7 +65216,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -63501,7 +65342,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -63637,7 +65478,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -63771,9 +65611,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -63783,63 +65623,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ለ",
-                "pad": "",
-                "width": ""
+                "text": "ለ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሉ",
-                "pad": "",
-                "width": ""
+                "text": "ሉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሊ",
-                "pad": "",
-                "width": ""
+                "text": "ሊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ላ",
-                "pad": "",
-                "width": ""
+                "text": "ላ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሌ",
-                "pad": "",
-                "width": ""
+                "text": "ሌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሎ",
-                "pad": "",
-                "width": ""
+                "text": "ሎ"
               },
               {
                 "id": "T_WWA",
-                "text": "ሏ",
-                "width": ""
+                "text": "ሏ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -63897,7 +65720,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -64084,8 +65906,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -64095,7 +65916,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -64287,7 +66108,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -64527,9 +66348,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -64539,7 +66360,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -64575,7 +66395,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -64740,7 +66559,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -64932,7 +66751,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -64993,7 +66811,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -65024,9 +66842,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -65036,7 +66852,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -65069,7 +66885,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -65196,7 +67011,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -65332,7 +67147,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -65466,9 +67280,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -65478,52 +67292,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሐ",
-                "pad": "",
-                "width": ""
+                "text": "ሐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሑ",
-                "pad": "",
-                "width": ""
+                "text": "ሑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሒ",
-                "pad": "",
-                "width": ""
+                "text": "ሒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ሓ",
-                "pad": "",
-                "width": ""
+                "text": "ሓ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሔ",
-                "pad": "",
-                "width": ""
+                "text": "ሔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሖ",
-                "pad": "",
-                "width": ""
+                "text": "ሖ"
               },
               {
                 "id": "T_WWA",
@@ -65532,8 +67331,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -65591,7 +67389,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -65778,8 +67575,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -65789,7 +67585,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -65981,7 +67777,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -66221,9 +68017,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -66233,7 +68029,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -66269,7 +68064,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -66434,7 +68228,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -66626,7 +68420,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -66687,7 +68480,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -66718,9 +68511,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -66730,7 +68521,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -66763,7 +68554,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -66890,7 +68680,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -67026,7 +68816,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -67160,9 +68949,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -67172,52 +68961,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "መ",
-                "pad": "",
-                "width": ""
+                "text": "መ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሙ",
-                "pad": "",
-                "width": ""
+                "text": "ሙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሚ",
-                "pad": "",
-                "width": ""
+                "text": "ሚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ማ",
-                "pad": "",
-                "width": ""
+                "text": "ማ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሜ",
-                "pad": "",
-                "width": ""
+                "text": "ሜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሞ",
-                "pad": "",
-                "width": ""
+                "text": "ሞ"
               },
               {
                 "id": "T_WWA",
@@ -67226,8 +69000,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -67285,7 +69058,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -67472,8 +69244,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -67483,7 +69254,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -67675,7 +69446,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -67915,9 +69686,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -67927,7 +69698,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -67963,7 +69733,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -68128,7 +69897,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -68320,7 +70089,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -68381,7 +70149,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -68412,9 +70180,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -68424,7 +70190,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -68457,7 +70223,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -68584,7 +70349,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -68720,7 +70485,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -68854,9 +70618,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -68866,52 +70630,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሠ",
-                "pad": "",
-                "width": ""
+                "text": "ሠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሡ",
-                "pad": "",
-                "width": ""
+                "text": "ሡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሢ",
-                "pad": "",
-                "width": ""
+                "text": "ሢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ሣ",
-                "pad": "",
-                "width": ""
+                "text": "ሣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሤ",
-                "pad": "",
-                "width": ""
+                "text": "ሤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሦ",
-                "pad": "",
-                "width": ""
+                "text": "ሦ"
               },
               {
                 "id": "T_WWA",
@@ -68920,8 +70669,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -68979,7 +70727,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -69166,8 +70913,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -69177,7 +70923,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -69369,7 +71115,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -69609,9 +71355,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -69621,7 +71367,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -69657,7 +71402,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -69822,7 +71566,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -70014,7 +71758,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -70075,7 +71818,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -70106,9 +71849,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -70118,7 +71859,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -70151,7 +71892,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -70278,7 +72018,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -70414,7 +72154,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -70548,9 +72287,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -70560,52 +72299,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ረ",
-                "pad": "",
-                "width": ""
+                "text": "ረ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሩ",
-                "pad": "",
-                "width": ""
+                "text": "ሩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሪ",
-                "pad": "",
-                "width": ""
+                "text": "ሪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ራ",
-                "pad": "",
-                "width": ""
+                "text": "ራ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሬ",
-                "pad": "",
-                "width": ""
+                "text": "ሬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሮ",
-                "pad": "",
-                "width": ""
+                "text": "ሮ"
               },
               {
                 "id": "T_WWA",
@@ -70614,8 +72338,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -70673,7 +72396,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -70860,8 +72582,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -70871,7 +72592,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -71063,7 +72784,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -71303,9 +73024,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -71315,7 +73036,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -71351,7 +73071,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -71516,7 +73235,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -71708,7 +73427,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -71769,7 +73487,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -71800,9 +73518,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -71812,7 +73528,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -71845,7 +73561,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -71972,7 +73687,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -72108,7 +73823,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -72242,9 +73956,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -72254,52 +73968,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሰ",
-                "pad": "",
-                "width": ""
+                "text": "ሰ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሱ",
-                "pad": "",
-                "width": ""
+                "text": "ሱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሲ",
-                "pad": "",
-                "width": ""
+                "text": "ሲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ሳ",
-                "pad": "",
-                "width": ""
+                "text": "ሳ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሴ",
-                "pad": "",
-                "width": ""
+                "text": "ሴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሶ",
-                "pad": "",
-                "width": ""
+                "text": "ሶ"
               },
               {
                 "id": "T_WWA",
@@ -72308,8 +74007,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -72367,7 +74065,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -72554,8 +74251,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -72565,7 +74261,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -72757,7 +74453,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -72997,9 +74693,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -73009,7 +74705,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -73045,7 +74740,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -73210,7 +74904,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -73402,7 +75096,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -73463,7 +75156,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -73494,9 +75187,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -73506,7 +75197,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -73539,7 +75230,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -73666,7 +75356,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -73802,7 +75492,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -73936,9 +75625,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -73948,63 +75637,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ሸ",
-                "pad": "",
-                "width": ""
+                "text": "ሸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ሹ",
-                "pad": "",
-                "width": ""
+                "text": "ሹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ሺ",
-                "pad": "",
-                "width": ""
+                "text": "ሺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ሻ",
-                "pad": "",
-                "width": ""
+                "text": "ሻ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ሼ",
-                "pad": "",
-                "width": ""
+                "text": "ሼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ሾ",
-                "pad": "",
-                "width": ""
+                "text": "ሾ"
               },
               {
                 "id": "T_WWA",
-                "text": "ሿ",
-                "width": ""
+                "text": "ሿ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -74062,7 +75734,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -74249,8 +75920,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -74260,7 +75930,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -74452,7 +76122,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -74692,9 +76362,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -74704,7 +76374,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -74740,7 +76409,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -74905,7 +76573,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -75097,7 +76765,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -75158,7 +76825,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -75189,9 +76856,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -75201,7 +76866,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -75234,7 +76899,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -75361,7 +77025,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -75497,7 +77161,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -75631,9 +77294,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -75643,15 +77306,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ቀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቈ",
@@ -75662,8 +77321,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ቁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቍ",
@@ -75674,8 +77331,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ቂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቊ",
@@ -75686,15 +77341,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቋ",
@@ -75705,8 +77357,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ቄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቌ",
@@ -75716,15 +77366,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቆ",
-                "pad": "",
-                "width": ""
+                "text": "ቆ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -75782,7 +77429,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -75969,8 +77615,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -75980,7 +77625,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -76172,7 +77817,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -76412,9 +78057,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -76424,7 +78069,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -76460,7 +78104,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -76625,7 +78268,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -76817,7 +78460,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -76878,7 +78520,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -76909,9 +78551,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -76921,7 +78561,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -76954,7 +78594,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -77081,7 +78720,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -77217,7 +78856,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -77351,9 +78989,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -77363,52 +79001,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "በ",
-                "pad": "",
-                "width": ""
+                "text": "በ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቡ",
-                "pad": "",
-                "width": ""
+                "text": "ቡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቢ",
-                "pad": "",
-                "width": ""
+                "text": "ቢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ባ",
-                "pad": "",
-                "width": ""
+                "text": "ባ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቤ",
-                "pad": "",
-                "width": ""
+                "text": "ቤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቦ",
-                "pad": "",
-                "width": ""
+                "text": "ቦ"
               },
               {
                 "id": "T_WWA",
@@ -77417,8 +79040,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -77476,7 +79098,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -77663,8 +79284,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -77674,7 +79294,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -77866,7 +79486,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -78106,9 +79726,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -78118,7 +79738,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -78154,7 +79773,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -78319,7 +79937,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -78511,7 +80129,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -78572,7 +80189,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -78603,9 +80220,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -78615,7 +80230,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -78648,7 +80263,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -78775,7 +80389,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -78911,7 +80525,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -79045,9 +80658,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -79057,52 +80670,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ቨ",
-                "pad": "",
-                "width": ""
+                "text": "ቨ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቩ",
-                "pad": "",
-                "width": ""
+                "text": "ቩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቪ",
-                "pad": "",
-                "width": ""
+                "text": "ቪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ቫ",
-                "pad": "",
-                "width": ""
+                "text": "ቫ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቬ",
-                "pad": "",
-                "width": ""
+                "text": "ቬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቮ",
-                "pad": "",
-                "width": ""
+                "text": "ቮ"
               },
               {
                 "id": "T_WWA",
@@ -79111,8 +80709,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -79170,7 +80767,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -79357,8 +80953,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -79368,7 +80963,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -79560,7 +81155,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -79800,9 +81395,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -79812,7 +81407,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -79848,7 +81442,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -80013,7 +81606,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -80099,7 +81692,6 @@
               {
                 "id": "K_T",
                 "text": "ት",
-                "width": "",
                 "nextlayer": "ተ-layer",
                 "sk": [
                   {
@@ -80206,7 +81798,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -80267,7 +81858,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -80298,9 +81889,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -80310,7 +81899,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -80343,7 +81932,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -80470,7 +82058,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -80606,7 +82194,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -80740,9 +82327,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -80752,52 +82339,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ተ",
-                "pad": "",
-                "width": ""
+                "text": "ተ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቱ",
-                "pad": "",
-                "width": ""
+                "text": "ቱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቲ",
-                "pad": "",
-                "width": ""
+                "text": "ቲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ታ",
-                "pad": "",
-                "width": ""
+                "text": "ታ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቴ",
-                "pad": "",
-                "width": ""
+                "text": "ቴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቶ",
-                "pad": "",
-                "width": ""
+                "text": "ቶ"
               },
               {
                 "id": "T_WWA",
@@ -80806,8 +82378,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -80865,7 +82436,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -81052,8 +82622,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -81063,7 +82632,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -81255,7 +82824,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -81495,9 +83064,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -81507,7 +83076,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -81543,7 +83111,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -81708,7 +83275,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -81900,7 +83467,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -81961,7 +83527,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -81992,9 +83558,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -82004,7 +83568,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -82037,7 +83601,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -82164,7 +83727,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -82300,7 +83863,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -82434,9 +83996,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -82446,63 +84008,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ቸ",
-                "pad": "",
-                "width": ""
+                "text": "ቸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ቹ",
-                "pad": "",
-                "width": ""
+                "text": "ቹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ቺ",
-                "pad": "",
-                "width": ""
+                "text": "ቺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ቻ",
-                "pad": "",
-                "width": ""
+                "text": "ቻ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ቼ",
-                "pad": "",
-                "width": ""
+                "text": "ቼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቾ",
-                "pad": "",
-                "width": ""
+                "text": "ቾ"
               },
               {
                 "id": "T_WWA",
-                "text": "ቿ",
-                "width": ""
+                "text": "ቿ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -82560,7 +84105,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -82747,8 +84291,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -82758,7 +84301,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -82950,7 +84493,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -83190,9 +84733,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -83202,7 +84745,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -83238,7 +84780,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -83403,7 +84944,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -83595,7 +85136,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -83656,7 +85196,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -83687,9 +85227,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -83699,7 +85237,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -83732,7 +85270,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -83859,7 +85396,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -83995,7 +85532,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -84129,9 +85665,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -84141,15 +85677,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ኀ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኈ",
@@ -84160,8 +85692,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኁ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኍ",
@@ -84172,8 +85702,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኂ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኊ",
@@ -84184,15 +85712,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ኃ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኋ",
@@ -84203,8 +85728,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኄ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኌ",
@@ -84214,15 +85737,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኆ",
-                "pad": "",
-                "width": ""
+                "text": "ኆ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -84280,7 +85800,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -84467,8 +85986,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -84478,7 +85996,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -84670,7 +86188,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -84910,9 +86428,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -84922,7 +86440,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -84958,7 +86475,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -85123,7 +86639,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -85315,7 +86831,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -85376,7 +86891,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -85407,9 +86922,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -85419,7 +86932,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -85452,7 +86965,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -85579,7 +87091,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -85715,7 +87227,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -85849,9 +87360,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -85861,63 +87372,46 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ነ",
-                "pad": "",
-                "width": ""
+                "text": "ነ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኑ",
-                "pad": "",
-                "width": ""
+                "text": "ኑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኒ",
-                "pad": "",
-                "width": ""
+                "text": "ኒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ና",
-                "pad": "",
-                "width": ""
+                "text": "ና"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኔ",
-                "pad": "",
-                "width": ""
+                "text": "ኔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኖ",
-                "pad": "",
-                "width": ""
+                "text": "ኖ"
               },
               {
                 "id": "T_WWA",
-                "text": "ኗ",
-                "width": ""
+                "text": "ኗ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -85975,7 +87469,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -86162,8 +87655,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -86173,7 +87665,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -86365,7 +87857,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -86605,9 +88097,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -86617,7 +88109,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -86653,7 +88144,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -86818,7 +88308,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -87010,7 +88500,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -87071,7 +88560,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -87102,9 +88591,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -87114,7 +88601,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -87147,7 +88634,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -87274,7 +88760,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -87410,7 +88896,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -87544,9 +89029,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -87556,52 +89041,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ኘ",
-                "pad": "",
-                "width": ""
+                "text": "ኘ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኙ",
-                "pad": "",
-                "width": ""
+                "text": "ኙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኚ",
-                "pad": "",
-                "width": ""
+                "text": "ኚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኛ",
-                "pad": "",
-                "width": ""
+                "text": "ኛ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኜ",
-                "pad": "",
-                "width": ""
+                "text": "ኜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኞ",
-                "pad": "",
-                "width": ""
+                "text": "ኞ"
               },
               {
                 "id": "T_WWA",
@@ -87610,8 +89080,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -87669,7 +89138,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -87856,8 +89324,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -87867,7 +89334,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -88059,7 +89526,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -88299,9 +89766,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -88311,7 +89778,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -88347,7 +89813,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -88512,7 +89977,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -88704,7 +90169,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -88765,7 +90229,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -88796,9 +90260,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -88808,7 +90270,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -88841,7 +90303,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -88968,7 +90429,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -89104,7 +90565,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -89238,9 +90698,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -89250,15 +90710,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ከ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኰ",
@@ -89269,8 +90725,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ኩ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኵ",
@@ -89281,8 +90735,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ኪ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኲ",
@@ -89293,15 +90745,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ካ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኳ",
@@ -89312,8 +90761,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ኬ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ኴ",
@@ -89323,15 +90770,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኮ",
-                "pad": "",
-                "width": ""
+                "text": "ኮ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -89389,7 +90833,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -89576,8 +91019,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -89587,7 +91029,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -89779,7 +91221,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -90019,9 +91461,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -90031,7 +91473,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -90067,7 +91508,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -90232,7 +91672,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -90424,7 +91864,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -90485,7 +91924,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -90516,9 +91955,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -90528,7 +91965,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -90561,7 +91998,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -90688,7 +92124,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -90824,7 +92260,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -90958,9 +92393,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -90970,58 +92405,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ኸ",
-                "pad": "",
-                "width": ""
+                "text": "ኸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኹ",
-                "pad": "",
-                "width": ""
+                "text": "ኹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኺ",
-                "pad": "",
-                "width": ""
+                "text": "ኺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኻ",
-                "pad": "",
-                "width": ""
+                "text": "ኻ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኼ",
-                "pad": "",
-                "width": ""
+                "text": "ኼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኾ",
-                "pad": "",
-                "width": ""
+                "text": "ኾ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -91079,7 +92498,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -91266,8 +92684,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -91277,7 +92694,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -91469,7 +92886,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -91709,9 +93126,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -91721,7 +93138,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -91757,7 +93173,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -91922,7 +93337,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -92114,7 +93529,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -92175,7 +93589,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -92206,9 +93620,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -92218,7 +93630,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -92251,7 +93663,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -92378,7 +93789,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -92514,7 +93925,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -92648,9 +94058,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -92660,58 +94070,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ወ",
-                "pad": "",
-                "width": ""
+                "text": "ወ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዉ",
-                "pad": "",
-                "width": ""
+                "text": "ዉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዊ",
-                "pad": "",
-                "width": ""
+                "text": "ዊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዋ",
-                "pad": "",
-                "width": ""
+                "text": "ዋ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዌ",
-                "pad": "",
-                "width": ""
+                "text": "ዌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዎ",
-                "pad": "",
-                "width": ""
+                "text": "ዎ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -92769,7 +94163,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -92956,8 +94349,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -92967,7 +94359,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -93159,7 +94551,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -93399,9 +94791,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -93411,7 +94803,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -93447,7 +94838,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -93612,7 +95002,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -93804,7 +95194,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -93865,7 +95254,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -93896,9 +95285,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -93908,7 +95295,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -93941,7 +95328,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -94068,7 +95454,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -94204,7 +95590,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -94338,9 +95723,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -94350,58 +95735,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዐ",
-                "pad": "",
-                "width": ""
+                "text": "ዐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዑ",
-                "pad": "",
-                "width": ""
+                "text": "ዑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዒ",
-                "pad": "",
-                "width": ""
+                "text": "ዒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዓ",
-                "pad": "",
-                "width": ""
+                "text": "ዓ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዔ",
-                "pad": "",
-                "width": ""
+                "text": "ዔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዖ",
-                "pad": "",
-                "width": ""
+                "text": "ዖ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -94459,7 +95828,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -94646,8 +96014,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -94657,7 +96024,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -94849,7 +96216,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -95089,9 +96456,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -95101,7 +96468,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -95137,7 +96503,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -95302,7 +96667,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -95494,7 +96859,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -95555,7 +96919,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -95586,9 +96950,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -95598,7 +96960,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -95631,7 +96993,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -95758,7 +97119,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -95894,7 +97255,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -96028,9 +97388,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -96040,52 +97400,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዘ",
-                "pad": "",
-                "width": ""
+                "text": "ዘ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዙ",
-                "pad": "",
-                "width": ""
+                "text": "ዙ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዚ",
-                "pad": "",
-                "width": ""
+                "text": "ዚ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዛ",
-                "pad": "",
-                "width": ""
+                "text": "ዛ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዜ",
-                "pad": "",
-                "width": ""
+                "text": "ዜ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዞ",
-                "pad": "",
-                "width": ""
+                "text": "ዞ"
               },
               {
                 "id": "T_WWA",
@@ -96094,8 +97439,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -96153,7 +97497,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -96340,8 +97683,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -96351,7 +97693,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -96543,7 +97885,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -96783,9 +98125,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -96795,7 +98137,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -96831,7 +98172,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -96996,7 +98336,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -97188,7 +98528,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -97249,7 +98588,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -97280,9 +98619,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -97292,7 +98629,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -97325,7 +98662,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -97452,7 +98788,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -97588,7 +98924,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -97722,9 +99057,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -97734,52 +99069,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ዠ",
-                "pad": "",
-                "width": ""
+                "text": "ዠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዡ",
-                "pad": "",
-                "width": ""
+                "text": "ዡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዢ",
-                "pad": "",
-                "width": ""
+                "text": "ዢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዣ",
-                "pad": "",
-                "width": ""
+                "text": "ዣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዤ",
-                "pad": "",
-                "width": ""
+                "text": "ዤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዦ",
-                "pad": "",
-                "width": ""
+                "text": "ዦ"
               },
               {
                 "id": "T_WWA",
@@ -97788,8 +99108,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -97847,7 +99166,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -98034,8 +99352,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -98045,7 +99362,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -98237,7 +99554,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -98477,9 +99794,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -98489,7 +99806,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -98525,7 +99841,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -98690,7 +100005,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -98882,7 +100197,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -98943,7 +100257,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -98974,9 +100288,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -98986,7 +100298,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -99019,7 +100331,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -99146,7 +100457,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -99282,7 +100593,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -99416,9 +100726,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -99428,58 +100738,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "የ",
-                "pad": "",
-                "width": ""
+                "text": "የ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዩ",
-                "pad": "",
-                "width": ""
+                "text": "ዩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዪ",
-                "pad": "",
-                "width": ""
+                "text": "ዪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ያ",
-                "pad": "",
-                "width": ""
+                "text": "ያ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዬ",
-                "pad": "",
-                "width": ""
+                "text": "ዬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዮ",
-                "pad": "",
-                "width": ""
+                "text": "ዮ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -99537,7 +100831,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -99724,8 +101017,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -99735,7 +101027,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -99927,7 +101219,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -100167,9 +101459,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -100179,7 +101471,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -100215,7 +101506,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -100380,7 +101670,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -100572,7 +101862,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -100633,7 +101922,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -100664,9 +101953,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -100676,7 +101963,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -100709,7 +101996,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -100836,7 +102122,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -100972,7 +102258,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -101106,9 +102391,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -101118,52 +102403,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ደ",
-                "pad": "",
-                "width": ""
+                "text": "ደ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ዱ",
-                "pad": "",
-                "width": ""
+                "text": "ዱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ዲ",
-                "pad": "",
-                "width": ""
+                "text": "ዲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ዳ",
-                "pad": "",
-                "width": ""
+                "text": "ዳ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ዴ",
-                "pad": "",
-                "width": ""
+                "text": "ዴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ዶ",
-                "pad": "",
-                "width": ""
+                "text": "ዶ"
               },
               {
                 "id": "T_WWA",
@@ -101172,8 +102442,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -101231,7 +102500,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -101418,8 +102686,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -101429,7 +102696,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -101621,7 +102888,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -101861,9 +103128,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -101873,7 +103140,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -101909,7 +103175,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -102074,7 +103339,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -102266,7 +103531,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -102327,7 +103591,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -102358,9 +103622,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -102370,7 +103632,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -102403,7 +103665,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -102530,7 +103791,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -102666,7 +103927,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -102800,9 +104060,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -102812,52 +104072,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጀ",
-                "pad": "",
-                "width": ""
+                "text": "ጀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጁ",
-                "pad": "",
-                "width": ""
+                "text": "ጁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጂ",
-                "pad": "",
-                "width": ""
+                "text": "ጂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጃ",
-                "pad": "",
-                "width": ""
+                "text": "ጃ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጄ",
-                "pad": "",
-                "width": ""
+                "text": "ጄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጆ",
-                "pad": "",
-                "width": ""
+                "text": "ጆ"
               },
               {
                 "id": "T_WWA",
@@ -102866,8 +104111,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -102925,7 +104169,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -103112,8 +104355,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -103123,7 +104365,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -103315,7 +104557,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -103555,9 +104797,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -103567,7 +104809,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -103603,7 +104844,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -103768,7 +105008,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -103960,7 +105200,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -104021,7 +105260,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -104052,9 +105291,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -104064,7 +105301,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -104097,7 +105334,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -104224,7 +105460,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -104360,7 +105596,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -104494,9 +105729,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -104506,15 +105741,11 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ገ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጐ",
@@ -104525,8 +105756,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ጉ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጕ",
@@ -104537,8 +105766,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ጊ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጒ",
@@ -104549,15 +105776,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጋ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጓ",
@@ -104568,8 +105792,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ጌ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጔ",
@@ -104579,15 +105801,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጎ",
-                "pad": "",
-                "width": ""
+                "text": "ጎ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -104645,7 +105864,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -104832,8 +106050,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -104843,7 +106060,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -105035,7 +106252,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -105275,9 +106492,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -105287,7 +106504,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -105323,7 +106539,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -105488,7 +106703,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -105680,7 +106895,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -105741,7 +106955,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -105772,9 +106986,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -105784,7 +106996,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -105817,7 +107029,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -105944,7 +107155,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -106080,7 +107291,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -106214,9 +107424,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -106226,52 +107436,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጠ",
-                "pad": "",
-                "width": ""
+                "text": "ጠ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጡ",
-                "pad": "",
-                "width": ""
+                "text": "ጡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጢ",
-                "pad": "",
-                "width": ""
+                "text": "ጢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጣ",
-                "pad": "",
-                "width": ""
+                "text": "ጣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጤ",
-                "pad": "",
-                "width": ""
+                "text": "ጤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጦ",
-                "pad": "",
-                "width": ""
+                "text": "ጦ"
               },
               {
                 "id": "T_WWA",
@@ -106280,8 +107475,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -106339,7 +107533,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -106526,8 +107719,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -106537,7 +107729,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -106729,7 +107921,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -106969,9 +108161,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -106981,7 +108173,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -107017,7 +108208,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -107182,7 +108372,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -107374,7 +108564,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -107435,7 +108624,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -107466,9 +108655,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -107478,7 +108665,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -107511,7 +108698,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -107638,7 +108824,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -107774,7 +108960,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -107908,9 +109093,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -107920,52 +109105,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጨ",
-                "pad": "",
-                "width": ""
+                "text": "ጨ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጩ",
-                "pad": "",
-                "width": ""
+                "text": "ጩ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጪ",
-                "pad": "",
-                "width": ""
+                "text": "ጪ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጫ",
-                "pad": "",
-                "width": ""
+                "text": "ጫ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጬ",
-                "pad": "",
-                "width": ""
+                "text": "ጬ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጮ",
-                "pad": "",
-                "width": ""
+                "text": "ጮ"
               },
               {
                 "id": "T_WWA",
@@ -107974,8 +109144,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -108033,7 +109202,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -108220,8 +109388,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -108231,7 +109398,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -108423,7 +109590,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -108663,9 +109830,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -108675,7 +109842,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -108711,7 +109877,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -108876,7 +110041,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -109068,7 +110233,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -109129,7 +110293,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -109160,9 +110324,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -109172,7 +110334,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -109205,7 +110367,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -109332,7 +110493,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -109468,7 +110629,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -109602,9 +110762,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -109614,52 +110774,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጰ",
-                "pad": "",
-                "width": ""
+                "text": "ጰ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጱ",
-                "pad": "",
-                "width": ""
+                "text": "ጱ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጲ",
-                "pad": "",
-                "width": ""
+                "text": "ጲ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጳ",
-                "pad": "",
-                "width": ""
+                "text": "ጳ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጴ",
-                "pad": "",
-                "width": ""
+                "text": "ጴ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጶ",
-                "pad": "",
-                "width": ""
+                "text": "ጶ"
               },
               {
                 "id": "T_WWA",
@@ -109668,8 +110813,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -109727,7 +110871,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -109914,8 +111057,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -109925,7 +111067,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -110117,7 +111259,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -110357,9 +111499,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -110369,7 +111511,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -110405,7 +111546,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -110570,7 +111710,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -110762,7 +111902,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -110823,7 +111962,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -110854,9 +111993,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -110866,7 +112003,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -110899,7 +112036,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -111026,7 +112162,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -111162,7 +112298,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -111296,9 +112431,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -111308,52 +112443,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ጸ",
-                "pad": "",
-                "width": ""
+                "text": "ጸ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ጹ",
-                "pad": "",
-                "width": ""
+                "text": "ጹ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ጺ",
-                "pad": "",
-                "width": ""
+                "text": "ጺ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ጻ",
-                "pad": "",
-                "width": ""
+                "text": "ጻ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ጼ",
-                "pad": "",
-                "width": ""
+                "text": "ጼ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጾ",
-                "pad": "",
-                "width": ""
+                "text": "ጾ"
               },
               {
                 "id": "T_WWA",
@@ -111362,8 +112482,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -111421,7 +112540,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -111608,8 +112726,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -111619,7 +112736,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -111811,7 +112928,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -112051,9 +113168,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -112063,7 +113180,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -112099,7 +113215,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -112264,7 +113379,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -112456,7 +113571,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -112517,7 +113631,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -112548,9 +113662,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -112560,7 +113672,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -112593,7 +113705,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -112720,7 +113831,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -112856,7 +113967,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -112990,9 +114100,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -113002,58 +114112,42 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፀ",
-                "pad": "",
-                "width": ""
+                "text": "ፀ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፁ",
-                "pad": "",
-                "width": ""
+                "text": "ፁ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፂ",
-                "pad": "",
-                "width": ""
+                "text": "ፂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "560",
-                "sp": "0"
+                "width": 560,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ፃ",
-                "pad": "",
-                "width": ""
+                "text": "ፃ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፄ",
-                "pad": "",
-                "width": ""
+                "text": "ፄ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፆ",
-                "pad": "",
-                "width": ""
+                "text": "ፆ"
               },
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -113111,7 +114205,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -113298,8 +114391,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -113309,7 +114401,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -113501,7 +114593,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -113741,9 +114833,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -113753,7 +114845,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -113789,7 +114880,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -113954,7 +115044,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -114146,7 +115236,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -114207,7 +115296,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -114238,9 +115327,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -114250,7 +115337,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -114283,7 +115370,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -114410,7 +115496,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -114546,7 +115632,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -114680,9 +115765,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -114692,52 +115777,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፈ",
-                "pad": "",
-                "width": ""
+                "text": "ፈ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፉ",
-                "pad": "",
-                "width": ""
+                "text": "ፉ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፊ",
-                "pad": "",
-                "width": ""
+                "text": "ፊ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ፋ",
-                "pad": "",
-                "width": ""
+                "text": "ፋ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፌ",
-                "pad": "",
-                "width": ""
+                "text": "ፌ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፎ",
-                "pad": "",
-                "width": ""
+                "text": "ፎ"
               },
               {
                 "id": "T_WWA",
@@ -114746,8 +115816,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -114805,7 +115874,6 @@
               {
                 "id": "K_3",
                 "text": "3",
-                "width": "",
                 "sk": [
                   {
                     "text": "#",
@@ -114992,8 +116060,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -115003,7 +116070,7 @@
               {
                 "id": "U_1345",
                 "text": "ፅ",
-                "pad": "70",
+                "pad": 70,
                 "nextlayer": "ፀ-layer",
                 "sk": [
                   {
@@ -115195,7 +116262,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቀ",
@@ -115364,7 +116431,6 @@
               {
                 "id": "K_P",
                 "text": "ጵ",
-                "width": "",
                 "nextlayer": "ጰ-layer",
                 "layer": "shift",
                 "sk": [
@@ -115436,9 +116502,9 @@
               {
                 "id": "T_new_1373",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -115448,7 +116514,6 @@
               {
                 "id": "U_1225",
                 "text": "ሥ",
-                "pad": "",
                 "nextlayer": "ሠ-layer",
                 "sk": [
                   {
@@ -115484,7 +116549,6 @@
               {
                 "id": "U_12A5",
                 "text": "እ",
-                "pad": "",
                 "nextlayer": "default",
                 "sk": [
                   {
@@ -115649,7 +116713,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ከ",
@@ -115841,7 +116905,6 @@
               {
                 "id": "K_S",
                 "text": "ጽ",
-                "width": "",
                 "nextlayer": "ጸ-layer",
                 "layer": "shift",
                 "sk": [
@@ -115902,7 +116965,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ኀ",
@@ -115933,9 +116996,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -115945,7 +117006,7 @@
               {
                 "id": "K_1",
                 "text": "!",
-                "pad": "70",
+                "pad": 70,
                 "layer": "shift",
                 "sk": [
                   {
@@ -115978,7 +117039,6 @@
               {
                 "id": "K_Z",
                 "text": "ዥ",
-                "pad": "",
                 "nextlayer": "ዠ-layer",
                 "layer": "shift",
                 "sk": [
@@ -116105,7 +117165,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ገ",
@@ -116241,7 +117301,6 @@
               {
                 "id": "K_M",
                 "text": "ም",
-                "pad": "",
                 "nextlayer": "መ-layer",
                 "sk": [
                   {
@@ -116375,9 +117434,9 @@
               {
                 "id": "T_new_1620",
                 "text": "",
-                "pad": "40",
-                "width": "20",
-                "sp": "10"
+                "pad": 40,
+                "width": 20,
+                "sp": 10
               }
             ]
           },
@@ -116387,52 +117446,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "ፐ",
-                "pad": "",
-                "width": ""
+                "text": "ፐ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ፑ",
-                "pad": "",
-                "width": ""
+                "text": "ፑ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ፒ",
-                "pad": "",
-                "width": ""
+                "text": "ፒ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "445",
-                "sp": "0"
+                "width": 445,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ፓ",
-                "pad": "",
-                "width": ""
+                "text": "ፓ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ፔ",
-                "pad": "",
-                "width": ""
+                "text": "ፔ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ፖ",
-                "pad": "",
-                "width": ""
+                "text": "ፖ"
               },
               {
                 "id": "T_WWA",
@@ -116441,8 +117485,7 @@
               {
                 "id": "K_SHIFT",
                 "text": "@",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "punctuation"
               }
             ]
@@ -116482,7 +117525,6 @@
               {
                 "id": "K_LBRKT",
                 "text": "{",
-                "width": "",
                 "layer": "shift"
               },
               {
@@ -116540,8 +117582,7 @@
               },
               {
                 "id": "U_20AC",
-                "text": "€",
-                "pad": ""
+                "text": "€"
               },
               {
                 "id": "K_QUOTE",
@@ -116611,8 +117652,7 @@
               },
               {
                 "id": "U_002C",
-                "text": ",",
-                "width": ""
+                "text": ","
               },
               {
                 "id": "K_SLASH",
@@ -116631,7 +117671,6 @@
               {
                 "id": "K_4",
                 "text": "$",
-                "pad": "",
                 "layer": "shift",
                 "sk": [
                   {
@@ -116663,8 +117702,15 @@
               {
                 "id": "U_0027",
                 "text": "'",
-                "width": "",
                 "sk": [
+                  {
+                    "text": "‹",
+                    "id": "U_2039"
+                  },
+                  {
+                    "text": "›",
+                    "id": "U_203A"
+                  },
                   {
                     "text": "`",
                     "id": "U_0060"
@@ -116674,7 +117720,7 @@
                     "id": "U_2018"
                   },
                   {
-                    "text": "’’",
+                    "text": "’",
                     "id": "U_2019"
                   }
                 ]
@@ -116696,8 +117742,8 @@
               {
                 "id": "K_SHIFT",
                 "text": "፩፪፫",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "amharic-extra",
                 "sk": [
                   {
@@ -116710,8 +117756,8 @@
               {
                 "id": "K_PERIOD",
                 "text": ".",
-                "pad": "70",
-                "width": "120",
+                "pad": 70,
+                "width": 120,
                 "sk": [
                   {
                     "text": "…",
@@ -116722,18 +117768,18 @@
               {
                 "id": "U_003A",
                 "text": ":",
-                "width": "120"
+                "width": 120
               },
               {
                 "id": "K_2",
                 "text": "@",
-                "width": "120",
+                "width": 120,
                 "layer": "shift"
               },
               {
                 "id": "K_1",
                 "text": "!",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -116745,7 +117791,7 @@
               {
                 "id": "K_SLASH",
                 "text": "?",
-                "width": "120",
+                "width": 120,
                 "layer": "shift",
                 "sk": [
                   {
@@ -116757,9 +117803,9 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "pad": "65",
-                "width": "170",
-                "sp": "1"
+                "pad": 65,
+                "width": 170,
+                "sp": 1
               }
             ]
           },
@@ -116769,23 +117815,23 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "width": "170",
-                "sp": "1",
+                "width": 170,
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "85",
-                "width": "630",
-                "sp": "0"
+                "pad": 85,
+                "width": 630,
+                "sp": 0
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "80",
-                "width": "170",
-                "sp": "1"
+                "pad": 80,
+                "width": 170,
+                "sp": 1
               }
             ]
           }
@@ -116799,8 +117845,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -116808,8 +117853,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -116846,8 +117890,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -116917,7 +117960,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -116972,7 +118015,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -117231,14 +118274,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -117297,8 +118338,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -117308,60 +118348,43 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "አ",
-                "pad": "",
-                "width": ""
+                "text": "አ"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "ኡ",
-                "pad": "",
-                "width": ""
+                "text": "ኡ"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "ኢ",
-                "pad": "",
-                "width": ""
+                "text": "ኢ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "ኣ",
-                "pad": "",
-                "width": ""
+                "text": "ኣ"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "ኤ",
-                "pad": "",
-                "width": ""
+                "text": "ኤ"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ኦ",
-                "pad": "",
-                "width": ""
+                "text": "ኦ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -117375,8 +118398,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -117421,8 +118443,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -117430,8 +118451,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -117493,7 +118513,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -117548,7 +118568,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -117807,14 +118827,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -117873,8 +118891,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -117884,16 +118901,12 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ቐ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቘ",
@@ -117904,8 +118917,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ቑ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቝ",
@@ -117916,8 +118927,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ቒ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቚ",
@@ -117928,15 +118937,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ቓ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቛ",
@@ -117947,8 +118953,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ቔ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ቜ",
@@ -117958,16 +118962,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ቖ",
-                "pad": "",
-                "width": ""
+                "text": "ቖ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -117981,8 +118981,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -118027,8 +119026,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -118036,8 +119034,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -118099,7 +119096,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -118154,7 +119151,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -118413,14 +119410,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -118479,8 +119474,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -118490,16 +119484,12 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
                 "text": "ጘ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶓ",
@@ -118510,8 +119500,6 @@
               {
                 "id": "T_ካዕብ",
                 "text": "ጙ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶖ",
@@ -118522,8 +119510,6 @@
               {
                 "id": "T_ሣልስ",
                 "text": "ጚ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶔ",
@@ -118534,15 +119520,12 @@
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
                 "text": "ጛ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ጟ",
@@ -118553,8 +119536,6 @@
               {
                 "id": "T_ኃምስ",
                 "text": "ጜ",
-                "pad": "",
-                "width": "",
                 "sk": [
                   {
                     "text": "ⶕ",
@@ -118564,16 +119545,12 @@
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "ጞ",
-                "pad": "",
-                "width": ""
+                "text": "ጞ"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -118587,8 +119564,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -118633,8 +119609,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -118642,8 +119617,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -118705,7 +119679,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -118760,7 +119734,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -119019,14 +119993,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -119085,8 +120057,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -119096,60 +120067,43 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "T_ግዕዝ",
-                "text": "𞟠",
-                "pad": "",
-                "width": ""
+                "text": "𞟠"
               },
               {
                 "id": "T_ካዕብ",
-                "text": "𞟡",
-                "pad": "",
-                "width": ""
+                "text": "𞟡"
               },
               {
                 "id": "T_ሣልስ",
-                "text": "𞟢",
-                "pad": "",
-                "width": ""
+                "text": "𞟢"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "T_ራብዕ",
-                "text": "𞟣",
-                "pad": "",
-                "width": ""
+                "text": "𞟣"
               },
               {
                 "id": "T_ኃምስ",
-                "text": "𞟤",
-                "pad": "",
-                "width": ""
+                "text": "𞟤"
               },
               {
                 "id": "T_ሳብዕ",
-                "text": "𞟦",
-                "pad": "",
-                "width": ""
+                "text": "𞟦"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -119163,8 +120117,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -119209,8 +120162,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -119218,8 +120170,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -119281,7 +120232,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -119336,7 +120287,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -119595,14 +120546,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -119661,8 +120610,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -119672,61 +120620,43 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_12C0",
-                "text": "ዀ",
-                "pad": "",
-                "width": ""
+                "text": "ዀ"
               },
               {
                 "id": "U_12C5",
-                "text": "ዅ",
-                "pad": "",
-                "width": ""
+                "text": "ዅ"
               },
               {
                 "id": "U_12C2",
-                "text": "ዂ",
-                "pad": "",
-                "width": ""
+                "text": "ዂ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "U_12C3",
-                "text": "ዃ",
-                "pad": "",
-                "width": ""
+                "text": "ዃ"
               },
               {
                 "id": "U_12C4",
-                "text": "ዄ",
-                "pad": "",
-                "width": ""
+                "text": "ዄ"
               },
               {
-                "id": "",
                 "text": "",
-                "pad": "",
-                "width": "",
-                "sp": "9"
+                "sp": 9
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -119740,8 +120670,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -119786,8 +120715,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -119795,8 +120723,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -119858,7 +120785,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -119913,7 +120840,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -120172,14 +121099,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1E7F5",
-                "text": "𞟵",
-                "pad": ""
+                "text": "𞟵"
               },
               {
                 "id": "U_1E7F6",
@@ -120212,7 +121137,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -120222,60 +121147,43 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1E7E9",
-                "text": "𞟩",
-                "pad": "",
-                "width": ""
+                "text": "𞟩"
               },
               {
                 "id": "U_1E7EA",
-                "text": "𞟪",
-                "pad": "",
-                "width": ""
+                "text": "𞟪"
               },
               {
                 "id": "U_1E7EB",
-                "text": "𞟫",
-                "pad": "",
-                "width": ""
+                "text": "𞟫"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "215",
-                "sp": "0"
+                "width": 215,
+                "sp": 0
               },
               {
                 "id": "U_1E7F0",
-                "text": "𞟰",
-                "pad": "",
-                "width": ""
+                "text": "𞟰"
               },
               {
                 "id": "U_1E7F1",
-                "text": "𞟱",
-                "pad": "",
-                "width": ""
+                "text": "𞟱"
               },
               {
                 "id": "U_1E7F2",
-                "text": "𞟲",
-                "pad": "",
-                "width": ""
+                "text": "𞟲"
               },
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -120289,8 +121197,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -120335,8 +121242,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -120344,8 +121250,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -120407,7 +121312,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -120462,7 +121367,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -120721,14 +121626,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -120787,8 +121690,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -120798,53 +121700,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1E7ED",
-                "text": "𞟭",
-                "pad": "",
-                "width": ""
+                "text": "𞟭"
               },
               {
                 "id": "U_1E7EE",
-                "text": "𞟮",
-                "pad": "",
-                "width": ""
+                "text": "𞟮"
               },
               {
                 "id": "U_1383",
-                "text": "ᎃ",
-                "pad": "",
-                "width": ""
+                "text": "ᎃ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "",
-                "sp": "0"
+                "sp": 0
               },
               {
                 "id": "U_1384",
-                "text": "ᎄ",
-                "pad": "",
-                "width": ""
+                "text": "ᎄ"
               },
               {
                 "id": "U_1E7F3",
-                "text": "𞟳",
-                "pad": "",
-                "width": ""
+                "text": "𞟳"
               },
               {
                 "id": "U_1E7F4",
-                "text": "𞟴",
-                "pad": "",
-                "width": ""
+                "text": "𞟴"
               },
               {
                 "id": "U_1387",
@@ -120853,9 +121739,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }
@@ -120869,8 +121753,7 @@
             "key": [
               {
                 "id": "U_1372",
-                "text": "፲",
-                "pad": ""
+                "text": "፲"
               },
               {
                 "id": "U_1373",
@@ -120915,8 +121798,7 @@
             "key": [
               {
                 "id": "U_1369",
-                "text": "፩",
-                "pad": ""
+                "text": "፩"
               },
               {
                 "id": "U_136A",
@@ -120924,8 +121806,7 @@
               },
               {
                 "id": "U_136B",
-                "text": "፫",
-                "width": ""
+                "text": "፫"
               },
               {
                 "id": "U_136C",
@@ -120987,7 +121868,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ቐ",
@@ -121042,7 +121923,7 @@
                   },
                   {
                     "id": "T_SPACER",
-                    "sp": "10"
+                    "sp": 10
                   },
                   {
                     "text": "ጘ",
@@ -121301,14 +122182,12 @@
               {
                 "id": "K_SHIFT",
                 "text": "ሀለሐ",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1368",
-                "text": "፨",
-                "pad": ""
+                "text": "፨"
               },
               {
                 "id": "U_1360",
@@ -121324,8 +122203,7 @@
               },
               {
                 "id": "U_1364",
-                "text": "፤",
-                "width": ""
+                "text": "፤"
               },
               {
                 "id": "U_1363",
@@ -121368,8 +122246,7 @@
               {
                 "id": "K_BKSP",
                 "text": "*BkSp*",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           },
@@ -121379,53 +122256,37 @@
               {
                 "id": "K_LOPT",
                 "text": "*Menu*",
-                "pad": "",
-                "width": "",
-                "sp": "1",
+                "sp": 1,
                 "nextlayer": "default"
               },
               {
                 "id": "U_1E7FB",
-                "text": "𞟻",
-                "pad": "",
-                "width": ""
+                "text": "𞟻"
               },
               {
                 "id": "U_1E7FC",
-                "text": "𞟼",
-                "pad": "",
-                "width": ""
+                "text": "𞟼"
               },
               {
                 "id": "U_138B",
-                "text": "ᎋ",
-                "pad": "",
-                "width": ""
+                "text": "ᎋ"
               },
               {
                 "id": "K_SPACE",
                 "text": "",
-                "pad": "",
-                "width": "",
-                "sp": "0"
+                "sp": 0
               },
               {
                 "id": "U_138C",
-                "text": "ᎌ",
-                "pad": "",
-                "width": ""
+                "text": "ᎌ"
               },
               {
                 "id": "U_1E7FD",
-                "text": "𞟽",
-                "pad": "",
-                "width": ""
+                "text": "𞟽"
               },
               {
                 "id": "U_1E7FE",
-                "text": "𞟾",
-                "pad": "",
-                "width": ""
+                "text": "𞟾"
               },
               {
                 "id": "U_138F",
@@ -121434,9 +122295,7 @@
               {
                 "id": "K_ENTER",
                 "text": "*Enter*",
-                "pad": "",
-                "width": "",
-                "sp": "1"
+                "sp": 1
               }
             ]
           }

--- a/release/gff/gff_amharic/source/gff_amharic.kmn
+++ b/release/gff/gff_amharic/source/gff_amharic.kmn
@@ -457,10 +457,18 @@ c Punctuation Layer Handling
 
   + [T_BANG] > '!' deadkey(2)
   '!' deadkey(2) + any(latinPunctIn) > index(latinPunctOut,3)
+c  + any(latinPunctIn) > index(latinPunctOut,1)
+  + [T_00AB] > '«'
+  + [T_2039] > '‹'
+  + [T_201C] > '‘'
+  + [T_2018] > '“'
+  + [T_2019] > '”'
+  + [T_201D] > '’'
+  + [T_203A] > '›'
+  + [T_00BB] > '»'
 
   + [T_1362] > '።' deadkey(2)
   '።' deadkey(2) + any(ethioPunctIn) > index(ethioPunctOut,3)
-
   + any(ethioPunctIn) > index(ethioPunctOut,1)
 c ---------------------Extensions for Touch Layout----------------------------------------------
 

--- a/release/gff/gff_amharic/source/gff_amharic.kmn
+++ b/release/gff/gff_amharic/source/gff_amharic.kmn
@@ -147,7 +147,7 @@ c =====================End Data Section=========================================
 
 c =====================Begin Functional Section=================================================
 c 
-store(&KEYBOARDVERSION) '3.1.2'
+store(&KEYBOARDVERSION) '3.1.3'
 
   begin Unicode > use(main)
   group(main) using keys
@@ -446,6 +446,22 @@ c 'QKG'
   any(TouchExtended፡ካዕብ፡ልዩ)   + any(ራብዕ-key) > index(TouchExtended፡ዘመደ፡ራብዕ,1)
 $keymanonly:   any(TouchExtended፡ካዕብ፡ልዩ)   + any(ኃምስ-key) > index(TouchExtended፡ዘመደ፡ኃምስ,1)
   any(TouchExtended፡ዘመደ፡ሣልስ)  + any(ግዕዝ-key) > index(TouchExtended፡ዘመደ፡ኃምስ,1)
+
+
+c Punctuation Layer Handling
+  store(latinPunctIn)  '@#:$%/()?.' [T_00AB][T_2039][T_201C][T_2018][T_2019][T_201D][T_203A][T_00BB]
+  store(latinPunctOut) '@#:$%/()?.«‹‘“”’›»'
+  store(ethioPunctIn)  [T_1360][T_1361][T_1363][T_1364][T_1365][T_1366][T_1368]
+  store(ethioPunctOut) '፠፡፣፤፥፦፨'
+
+
+  + [T_BANG] > '!' deadkey(2)
+  '!' deadkey(2) + any(latinPunctIn) > index(latinPunctOut,3)
+
+  + [T_1362] > '።' deadkey(2)
+  '።' deadkey(2) + any(ethioPunctIn) > index(ethioPunctOut,3)
+
+  + any(ethioPunctIn) > index(ethioPunctOut,1)
 c ---------------------Extensions for Touch Layout----------------------------------------------
 
 

--- a/release/gff/gff_amharic/source/help/kb.css
+++ b/release/gff/gff_amharic/source/help/kb.css
@@ -17,8 +17,10 @@
 .phone div.kmw-key.kmw-key-default[id$='K_SPACE'], .tablet div.kmw-key.kmw-key-default[id$='K_SPACE']
   { background: #f4eee7 ; color: #f4eee7 ; } /* eceae4 */
 
-.phone div.kmw-key.kmw-key-default[id$='K_1+shift'], .tablet div.kmw-key.kmw-key-default[id$='K_1+shift'], /* ! */
-.phone div.kmw-key.kmw-key-default[id$='U_1362'],    .tablet div.kmw-key.kmw-key-default[id$='U_1362']        /* ። */
+.phone div.kmw-key.kmw-key-default[id$='K_1+shift'], .tablet div.kmw-key.kmw-key-default[id$='K_1+shift'],  /* ! */
+.phone div.kmw-key.kmw-key-default[id$='U_1362'],    .tablet div.kmw-key.kmw-key-default[id$='U_1362'],     /* ። */
+.phone div.kmw-key.kmw-key-default[id$='T_BANG'],                                                           /* ! */
+.phone div.kmw-key.kmw-key-default[id$='T_1362']                                                            /* ። */
   { background: #f4eee7 ; color: black ; }
 
 
@@ -124,7 +126,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1340'], .tablet div.kmw-key.kmw-key-default[id$='U_1340'],  /* ፀ */
 .phone div.kmw-key.kmw-key-default[id$='U_1348'], .tablet div.kmw-key.kmw-key-default[id$='U_1348'],  /* ፈ */
 .phone div.kmw-key.kmw-key-default[id$='U_1350'], .tablet div.kmw-key.kmw-key-default[id$='U_1350'],  /* ፐ */
-.phone div.kmw-key.kmw-key-default[id$='T_ግዕዝ'], .tablet div.kmw-key.kmw-key-default[id$='T_ግዕዝ']
+.phone div.kmw-key.kmw-key-default[id$='T_ግዕዝ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ግዕዝ'],   /* አ */
+.phone div.kmw-key.kmw-key-default[id$='K_2+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1360'] /* @, ፠ */
   { background:  #e2f0cb ; color: black; } /*#baed91 */
 
 /* default layer ካዕብ */
@@ -166,7 +169,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1341'], .tablet div.kmw-key.kmw-key-default[id$='U_1341'],  /* ፁ */
 .phone div.kmw-key.kmw-key-default[id$='U_1349'], .tablet div.kmw-key.kmw-key-default[id$='U_1349'],  /* ፉ */
 .phone div.kmw-key.kmw-key-default[id$='U_1351'], .tablet div.kmw-key.kmw-key-default[id$='U_1351'],  /* ፑ */
-.phone div.kmw-key.kmw-key-default[id$='T_ካዕብ'], .tablet div.kmw-key.kmw-key-default[id$='T_ካዕብ']
+.phone div.kmw-key.kmw-key-default[id$='T_ካዕብ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ካዕብ'],   /* ኡ */
+.phone div.kmw-key.kmw-key-default[id$='K_4+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1365'] /* $, ፥ */
   { background:  #ffffb5 ; color: black; } /* #faf884 */ 
 
 /* default layer ሣልስ */
@@ -208,7 +212,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1342'], .tablet div.kmw-key.kmw-key-default[id$='U_1342'],  /* ፂ */
 .phone div.kmw-key.kmw-key-default[id$='U_134A'], .tablet div.kmw-key.kmw-key-default[id$='U_134A'],  /* ፊ */
 .phone div.kmw-key.kmw-key-default[id$='U_1352'], .tablet div.kmw-key.kmw-key-default[id$='U_1352'],  /* ፒ */
-.phone div.kmw-key.kmw-key-default[id$='T_ሣልስ'], .tablet div.kmw-key.kmw-key-default[id$='T_ሣልስ']
+.phone div.kmw-key.kmw-key-default[id$='T_ሣልስ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ሣልስ'],  /* ኢ */
+.phone div.kmw-key.kmw-key-default[id$='T_00AB'], .phone div.kmw-key.kmw-key-default[id$='T_1366']   /* «, ፦ */
   { background:  #fea3aa  ; color: black; }
 
 /* default layer ራብዕ */
@@ -250,7 +255,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1343'], .tablet div.kmw-key.kmw-key-default[id$='U_1343'],  /* ፃ */
 .phone div.kmw-key.kmw-key-default[id$='U_134B'], .tablet div.kmw-key.kmw-key-default[id$='U_134B'],  /* ፋ */
 .phone div.kmw-key.kmw-key-default[id$='U_1353'], .tablet div.kmw-key.kmw-key-default[id$='U_1353'],  /* ፓ */
-.phone div.kmw-key.kmw-key-default[id$='T_ራብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ራብዕ']
+.phone div.kmw-key.kmw-key-default[id$='T_ራብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ራብዕ'],    /* ኣ */
+.phone div.kmw-key.kmw-key-default[id$='T_00BB'], .phone div.kmw-key.kmw-key-default[id$='T_1361'] /* », : */
   { background:  #ccf1ff  ; color: black; } /* #b2cefe */
 
 /* default layer ኃምስ */
@@ -292,7 +298,8 @@
 .phone div.kmw-key.kmw-key-default[id$='U_1344'], .tablet div.kmw-key.kmw-key-default[id$='U_1344'],  /* ፄ */
 .phone div.kmw-key.kmw-key-default[id$='U_134C'], .tablet div.kmw-key.kmw-key-default[id$='U_134C'],  /* ፌ */
 .phone div.kmw-key.kmw-key-default[id$='U_1354'], .tablet div.kmw-key.kmw-key-default[id$='U_1354'],  /* ፔ */
-.phone div.kmw-key.kmw-key-default[id$='T_ኃምስ'], .tablet div.kmw-key.kmw-key-default[id$='T_ኃምስ']
+.phone div.kmw-key.kmw-key-default[id$='T_ኃምስ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ኃምስ'],  /* ኤ */
+.phone div.kmw-key.kmw-key-default[id$='K_SLASH'], .phone div.kmw-key.kmw-key-default[id$='T_1363']   /* /, ፣ */
   { background:  #e0d7ff  ; color: black; } /* #f2a2e8 */
 
 /* default layer ሳድስ - used primarily when a sadis letter appears in a popup or on the -extra layers */
@@ -374,8 +381,9 @@
 .phone div.kmw-key.kmw-key-default[id$='U_133E'], .tablet div.kmw-key.kmw-key-default[id$='U_133E'],  /* ጾ */
 .phone div.kmw-key.kmw-key-default[id$='U_1346'], .tablet div.kmw-key.kmw-key-default[id$='U_1346'],  /* ፆ */
 .phone div.kmw-key.kmw-key-default[id$='U_134E'], .tablet div.kmw-key.kmw-key-default[id$='U_134E'],  /* ፎ */
-.phone div.kmw-key.kmw-key-default[id$='U_1356'], .tablet div.kmw-key.kmw-key-default[id$='U_1356'],   /* ፖ */
-.phone div.kmw-key.kmw-key-default[id$='T_ሳብዕ'], .tablet div.kmw-key.kmw-key-default[id$='T_ሳብዕ']
+.phone div.kmw-key.kmw-key-default[id$='U_1356'], .tablet div.kmw-key.kmw-key-default[id$='U_1356'],  /* ፖ */
+.phone div.kmw-key.kmw-key-default[id$='T_ሳብዕ'],  .tablet div.kmw-key.kmw-key-default[id$='T_ሳብዕ'],   /* ኦ */
+.phone div.kmw-key.kmw-key-default[id$='K_SLASH+shift'], .phone div.kmw-key.kmw-key-default[id$='T_1364']   /* ?, ፤︁ */
   { background:  #fad6b6  ; color: black; } /* f8b88b*/
 
 /* default layer ዘመደ-ራብዕ */
@@ -506,12 +514,18 @@
 .phone.ios div.kmw-key.kmw-key-default[id$='extra-U_1345'], .tablet.ios div.kmw-key.kmw-key-default[id$='extra-U_1345'],
 .phone.ios div.kmw-key.kmw-key-default[id$='extra-U_12E5'], .tablet.ios div.kmw-key.kmw-key-default[id$='extra-U_12E5'],
 .tablet.ios .kmw-keyboard-gff_amharic #punctuation-K_HYPHEN, .tablet.ios .kmw-keyboard-gff_amharic #punctuation-K_EQUAL,  
-.ios .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift
+.ios .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_2\+shift,  .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_2\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_SLASH\+shift, .phone.ios .kmw-keyboard-gff_amharic #punctuation-2-K_SLASH\+shift,
+.ios .kmw-keyboard-gff_amharic #punctuation-K_4\+shift
   {background: #fdfdfe ; color: black ; }
 
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_1225'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_1225'],
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_1345'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_1345'],
 .phone.android div.kmw-key.kmw-key-default[id$='extra-U_12E5'], .tablet.android div.kmw-key.kmw-key-default[id$='extra-U_12E5'],
 .tablet.android .kmw-keyboard-gff_amharic #punctuation-K_HYPHEN, .tablet.android .kmw-keyboard-gff_amharic #punctuation-K_EQUAL, 
-.android .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift
+.android .kmw-keyboard-gff_amharic #punctuation-K_1\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_1\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_2\+shift,  .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_2\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_SLASH\+shift, .phone.android .kmw-keyboard-gff_amharic #punctuation-2-K_SLASH\+shift,
+.android .kmw-keyboard-gff_amharic #punctuation-K_4\+shift
   {background: #777 ; color: white ; }


### PR DESCRIPTION
This is the GFF Amharic Keyboard v3.1.3 which provides the following refinements and additions:

* mobile: Fixed K_J key nextlayer changes (from ደ to ጀ layer)
* mobile: removed accidental double U+2019 on an apostrophe longpress
* mobile: added missing ‹ and › to apostrophe longpress
* mobile: removed double quote from the double quote longpress
* mobile: Added new layers: latin-punct-layer and ethio-punct-layer