### PR TITLE
[sil_tepehuan] Fix whitespace in help file

### DIFF
--- a/release/sil/sil_tepehuan/source/help/sil_tepehuan.php
+++ b/release/sil/sil_tepehuan/source/help/sil_tepehuan.php
@@ -1,42 +1,42 @@
 <?php
   $pagename = 'Tepehuan (SIL) Keyboard Help';
-$pagetitle = $pagename;
-$pagestyle = <<<END
-	p { font: 10pt Tahoma }
-	h1 { font: bold 16pt Tahoma; color: #4444cc }
-	h2 { font: bold 12pt Tahoma; color: #4444cc }
-	table.display tr .gap { width: 16px; border: none; }
-	table.display tr td { font: 10pt "HI Keawe Unicode"; border: solid 1px #ccccff; padding: 4px }
-	table.display tr th { font: bold 10pt Tahoma; border: solid 1px #ccccff; padding: 4px; text-align: left }
-	table.display { border-collapse: collapse; }
-	table.tableizer-table {
-		font-size: 12px;
-		border: 1px solid #CCC; 
-		font-family: Arial, Helvetica, sans-serif;
-	} 
-	.tableizer-table td {
-		padding: 4px;
-		margin: 3px;
-		border: 1px solid #CCC;
-	}
-	.tableizer-table th {
-		background-color: #104E8B; 
-		color: #FFF;
-		font-weight: bold;
-	}
-	kbd {
-    background-color: #eee;
-    border-radius: 3px;
-    border: 1px solid #b4b4b4;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
-    color: #333;
-    display: inline-block;
-    font-size: .85em;
-    font-weight: 700;
-    line-height: 1;
-    padding: 2px 4px;
-    white-space: nowrap; }
-	END;
+  $pagetitle = $pagename;
+  $pagestyle = <<<END
+      p { font: 10pt Tahoma }
+      h1 { font: bold 16pt Tahoma; color: #4444cc }
+      h2 { font: bold 12pt Tahoma; color: #4444cc }
+      table.display tr .gap { width: 16px; border: none; }
+      table.display tr td { font: 10pt "HI Keawe Unicode"; border: solid 1px #ccccff; padding: 4px }
+      table.display tr th { font: bold 10pt Tahoma; border: solid 1px #ccccff; padding: 4px; text-align: left }
+      table.display { border-collapse: collapse; }
+      table.tableizer-table {
+          font-size: 12px;
+          border: 1px solid #CCC; 
+          font-family: Arial, Helvetica, sans-serif;
+      } 
+      .tableizer-table td {
+          padding: 4px;
+          margin: 3px;
+          border: 1px solid #CCC;
+      }
+      .tableizer-table th {
+          background-color: #104E8B; 
+          color: #FFF;
+          font-weight: bold;
+      }
+      kbd {
+          background-color: #eee;
+          border-radius: 3px;
+          border: 1px solid #b4b4b4;
+          box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+          color: #333;
+          display: inline-block;
+          font-size: .85em;
+          font-weight: 700;
+          line-height: 1;
+          padding: 2px 4px;
+          white-space: nowrap; }
+    END;
 require_once('header.php');
 ?>
 


### PR DESCRIPTION
Fixes the failed keyboard help deployment on https://github.com/keymanapp/help.keyman.com/actions/runs/14653975660/job/41125613577

> PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in ./keyboard/sil_tepehuan/1.1/sil_tepehuan.php on line 28


Screenshot of the key sequences

![image](https://github.com/user-attachments/assets/59076aec-e2ce-406d-bcdf-c098e434de60)


Fixes: keymanapp/keyman#13756