### PR TITLE
[sil_tai_dam_typewriter] Fix whitespace in help file

### DIFF
--- a/release/sil/sil_tai_dam_typewriter/source/help/sil_tai_dam_typewriter.php
+++ b/release/sil/sil_tai_dam_typewriter/source/help/sil_tai_dam_typewriter.php
@@ -57,7 +57,7 @@ $pagestyle = <<<END
           top: 3px;
         }
         
-        .key .keycap {          
+        .key .keycap {
           display: block;
         }
         
@@ -66,11 +66,7 @@ $pagestyle = <<<END
         }
         
         .keytext {
-          
-					font:
-						9pt
-							 
-						"Tai Heritage Pro"; 
+          font: 9pt Tai Heritage Pro;
           position: absolute; 
           display: block;
           right: 6px;


### PR DESCRIPTION
Similar to #3458 which fixed deployment of php help file to help.keyman.com

Fixed invalid mix of tab/whitespace in the heredoc CSS syntax.

I had to consolidate the font line here. 
@mcdurdin - is that valid syntax?