### PR TITLE
[gff_amharic] GFF Amharic - Adding Missing CSS Styles for PHP Help Page

### DIFF
--- a/release/gff/gff_amharic/source/help/html.css
+++ b/release/gff/gff_amharic/source/help/html.css
@@ -83,3 +83,52 @@ kbd {
 .etens {
   background: #f3d6ce ;
 }
+
+sup {font-size:xx-small; vertical-align:super;}
+
+table.flat td, table.kb th { border: thin solid #666; text-align: center ; padding: 0.3em }
+table.flat { border-bottom: hidden }
+table.flat { empty-cells: show }
+table.flat th { text-align: center; border: thin solid #666; background-color: #e0dacf }
+table.flat caption { margin: 0.5em 0 0 0 }
+
+   td.divide { border-left: 1px solid black }
+   td.flat-bottom { border-bottom: 1px solid black }
+   td.flat-top { border-top: 1px solid black }
+
+table.kb th, table.kb td { padding: 0.3em }
+table.kb th:first-child { background-color: #e0dacf; }
+table.kb tr:first-child { background-color: #e0dacf; font-weight:bold; }
+table.kb tr:first-child th:first-child { background-color: #ffffff; border-left-color: #ffffff; border-top-color: #ffffff }
+table.kb tr:first-child th:last-child { background-color: #ffffff; border-right-color: #ffffff; border-top-color: #ffffff }
+table.kb th { background-color: #e0dacf; border-left-color: #ffffff }
+table.kb td, table.kb th { border: thin solid #666; text-align: center }
+table.kb th { text-align: center; background-color: #d7d0b9 }
+table.kb { border-bottom: hidden }
+table.kb { empty-cells: show }
+table.kb caption { margin: 0.5em 0 0 0 }
+table.kb tr:last-child { text-align: center; background-color: #d7d0b9; font-weight:bold; }
+table.kb tr:last-child th:first-child { background-color: #ffffff; border-left-color: #ffffff; border-bottom-color: #ffffff }
+dd {margin: 0 0 1em; padding: 0}
+
+table.punct th { font-weight: bold;  padding: 0.3em }
+table.punct td { font-weight: normal; padding: 0.3em }
+table.punct th:first-child { background-color: #e0dacf; }
+table.punct tr:first-child { background-color: #e0dacf; }
+table.punct tr:first-child th:first-child { background-color: #ffffff; border-left-color: #ffffff; border-top-color: #ffffff }
+table.punct th { background-color: #e0dacf; border-left-color: #ffffff }
+table.punct td, table.punct th { border: thin solid #666; text-align: center }
+table.punct th { text-align: center; background-color: #d7d0b9 }
+table.punct { border-bottom: hidden }
+table.punct { empty-cells: show }
+
+table.zaima th { font-weight: bold;  padding: 0.3em }
+table.zaima td { font-weight: normal; padding: 0.3em }
+table.zaima th:first-child { background-color: #e0dacf;}
+table.zaima tr:first-child th  { background-color: #e0dacf; }
+table.zaima tr:first-child th:first-child { background-color: #ffffff; border-left-color: #ffffff; border-top-color: #ffffff }
+table.zaima th { background-color: #e0dacf; border-left-color: #ffffff }
+table.zaima td, table.zaima th { border: thin solid #666; text-align: center }
+table.zaima th { text-align: center; background-color: #d7d0b9 }
+table.zaima { border-bottom: hidden }
+table.zaima { empty-cells: show }


### PR DESCRIPTION
I noticed in the PHP help file that the tables looked broken, they were missing some CSS definitions that were not copied over from the `welcome.htm` .  This update adds the missing CSS to the `html.css` file that the PHP file imports.

Since this is only an update to the online help, it should not impact the keyboard version.