### PR TITLE
[dazaga_gourane_karra] Correct wrong keyboard name

### DIFF
--- a/release/d/dazaga_gourane_karra/HISTORY.md
+++ b/release/d/dazaga_gourane_karra/HISTORY.md
@@ -5,4 +5,8 @@ dazaga_gourane_karra Change History
 ----------------
 * Created by Zacharias van Stek and Henri Schellberg
 
+1.0.1 (2025-05-19)
+------------------
+* Updated keyboard name
+
 

--- a/release/d/dazaga_gourane_karra/README.md
+++ b/release/d/dazaga_gourane_karra/README.md
@@ -1,8 +1,6 @@
 Dazaga Gourane Karra Keyboard
 ==============
 
-Version 1.0.1
-
 Description
 -----------
 This keyboard layout is designed for the Dazaga Gourane Karra language and was developed with

--- a/release/d/dazaga_gourane_karra/README.md
+++ b/release/d/dazaga_gourane_karra/README.md
@@ -1,7 +1,7 @@
 Dazaga Gourane Karra Keyboard
 ==============
 
-Version 1.0
+Version 1.0.1
 
 Description
 -----------

--- a/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kmn
+++ b/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kmn
@@ -1,7 +1,7 @@
 ﻿c dazaga_gourane_karra generated from template at 2023-11-28 21:03:39
 c with name "dazaga_gourane_karra"
 store(&VERSION) '10.0'
-store(&NAME) 'dazaga_gourane_karra'
+store(&NAME) 'Dazaga Gourane Karra'
 store(&COPYRIGHT) '© Zacharias van Stek & Henri Schellberg'
 store(&KEYBOARDVERSION) '1.0.1'
 store(&MnemonicLayout) "1"

--- a/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kmn
+++ b/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kmn
@@ -3,7 +3,7 @@ c with name "dazaga_gourane_karra"
 store(&VERSION) '10.0'
 store(&NAME) 'dazaga_gourane_karra'
 store(&COPYRIGHT) '© Zacharias van Stek & Henri Schellberg'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '1.0.1'
 store(&MnemonicLayout) "1"
 store(&TARGETS) 'any'
 store(&LAYOUTFILE) 'dazaga_gourane_karra.keyman-touch-layout'

--- a/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kps
+++ b/release/d/dazaga_gourane_karra/source/dazaga_gourane_karra.kps
@@ -18,7 +18,7 @@
     <Items/>
   </StartMenu>
   <Info>
-    <Name URL="">Dazaga Gourane</Name>
+    <Name URL="">Dazaga Gourane Karra</Name>
     <Copyright URL="">© 2023-2025 Zacharias van Stek and Henri Schellberg</Copyright>
     <Author URL="">Zacharias van Stek and Henri Schellberg</Author>
     <Version URL=""></Version>


### PR DESCRIPTION
The keyboard page on keyman has the wrong title, because the name tag in the .kps file still had the old name.