### PR TITLE
chore: try fixing quotes in rsync command

### DIFF
--- a/resources/rsync-tools.sh
+++ b/resources/rsync-tools.sh
@@ -27,7 +27,7 @@ function rsync_to_downloads_keyman_com {
   pushd $source
 
   "$RSYNC" -vtrp --chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r --stats --rsync-path="$REMOTE_RSYNC_PATH" \
-    --rsh="$RSYNC_HOME\\ssh -i $USERPROFILE\\.ssh\\id_rsa -o UserKnownHostsFile=$USERPROFILE\\.ssh\\known_hosts" \
+    "--rsh=$RSYNC_HOME\\ssh -i $USERPROFILE\\.ssh\\id_rsa -o UserKnownHostsFile=$USERPROFILE\\.ssh\\known_hosts" \
     $ignore . "$RSYNC_DEST/$dest"
 
   popd


### PR DESCRIPTION
Follows #3537

We're trying to fix the rsync call to downloads.keyman

I wonder if the  the whole `--rsh` line should be in a set of quotes.