### PR TITLE
[lavanya] Updated backspace handling. Removed support for touch layout

### DIFF
--- a/release/l/lavanya/HISTORY.md
+++ b/release/l/lavanya/HISTORY.md
@@ -1,10 +1,10 @@
 Lavanya Change History
 ====================
 
-1.0 (2025-05-06)
 
 2.0 (2025-06-16)
 - Added backspace handling for vowel matras
 
+1.0 (2025-05-06)
 ----------------
 * Created by Prashanth

--- a/release/l/lavanya/HISTORY.md
+++ b/release/l/lavanya/HISTORY.md
@@ -1,7 +1,6 @@
 Lavanya Change History
 ====================
 
-
 2.0 (2025-06-16)
 - Added backspace handling for vowel matras
 

--- a/release/l/lavanya/HISTORY.md
+++ b/release/l/lavanya/HISTORY.md
@@ -4,8 +4,7 @@ Lavanya Change History
 1.0 (2025-05-06)
 
 2.0 (2025-06-16)
-> Added backspace handling for vowel matras
-> Removed support for touch layout
+- Added backspace handling for vowel matras
 
 ----------------
 * Created by Prashanth

--- a/release/l/lavanya/HISTORY.md
+++ b/release/l/lavanya/HISTORY.md
@@ -2,5 +2,10 @@ Lavanya Change History
 ====================
 
 1.0 (2025-05-06)
+
+2.0 (2025-06-16)
+> Added backspace handling for vowel matras
+> Removed support for touch layout
+
 ----------------
 * Created by Prashanth

--- a/release/l/lavanya/README.md
+++ b/release/l/lavanya/README.md
@@ -3,7 +3,7 @@ Lavanya keyboard
 
 Description
 -----------
-**Lavanya** is a custom transliteration keyboard that converts English input into Telugu text *dynamically* and *phonetically*. Inspired by [Lekhini](https://lekhini.org/), this keyboard retains the intuitive, vowel-explicit input style that made Lekhini accessible to new users. The core implementation builds upon the logic from the [NLCI Telugu Winscript Keyboard](https://keyman.com/keyboards/nlci_telugu_winscript), adapted for local system-wide use via Keyman. The layout was designed by Prashanth in 2025 to help his mother, who is already familiar with Lekhini. Refer to the documentation file for detailed keyboard usage. 
+**Lavanya** is a custom transliteration keyboard that converts English input into Telugu text *dynamically* and *phonetically*. Inspired by [Lekhini](https://lekhini.org/), this keyboard retains the intuitive, vowel-explicit input style that made Lekhini accessible to new users. The core implementation builds upon the logic from the [NLCI Telugu Winscript Keyboard](https://keyman.com/keyboards/nlci_telugu_winscript), adapted for local system-wide use via Keyman. The layout was designed by Prashanth in 2025 to help his mother, who is already familiar with Lekhini. Refer to the documentation file for detailed keyboard usage. While Lavanya offers touch screen support, its not matured yet. Google's Gboard is an excellent keyboard for typing in Telugu on touchscreen devices.
 
 Links
 -----

--- a/release/l/lavanya/source/lavanya.kmn
+++ b/release/l/lavanya/source/lavanya.kmn
@@ -9,7 +9,7 @@ store(&VISUALKEYBOARD) 'lavanya.kvks'
 store(&LAYOUTFILE) 'lavanya.keyman-touch-layout'
 store(&MESSAGE) 'Phonetic based Telugu Keyboard'
 store(&KMW_HELPTEXT) 'Phonetic based Telugu Keyboard'
-store(&TARGETS) 'windows macosx linux web'
+store(&TARGETS) 'any'
 
 begin Unicode > use(main)
 

--- a/release/l/lavanya/source/lavanya.kmn
+++ b/release/l/lavanya/source/lavanya.kmn
@@ -4,12 +4,12 @@ store(&VERSION) '10.0'
 store(&NAME) 'lavanya'
 store(&COPYRIGHT) 'Copyright © Prashanth'
 store(&KEYBOARDVERSION) '1.0'
-store(&TARGETS) 'any'
 store(&BITMAP) 'lavanya.ico'
 store(&VISUALKEYBOARD) 'lavanya.kvks'
 store(&LAYOUTFILE) 'lavanya.keyman-touch-layout'
 store(&MESSAGE) 'Phonetic based Telugu Keyboard'
 store(&KMW_HELPTEXT) 'Phonetic based Telugu Keyboard'
+store(&TARGETS) 'windows macosx linux web'
 
 begin Unicode > use(main)
 
@@ -55,6 +55,9 @@ c MODIFIED BEHAVIOR: consonants now produce consonant + virama by default
 + any(cons_strong_keys_1) > index(cons_strong_chars_1, 1) '్'
 + any(cons_weak_keys_2) > index(cons_weak_chars_2, 1) '్'
 + any(cons_remaining_keys) > index(cons_remaining_chars, 1) '్'
+
+c Add backspace handling for vowel matras
+any(consonants) any(vowelMatras) + [K_BKSP] > context(1) '్'
 
 c Adding vowel after consonant with virama
 c If 'a' key pressed after consonant with virama, remove virama to show inherent vowel

--- a/release/l/lavanya/source/lavanya.kps
+++ b/release/l/lavanya/source/lavanya.kps
@@ -20,8 +20,8 @@
   <Info>
     <Name URL="">Lavanya</Name>
     <Copyright URL="">Copyright © Prashanth</Copyright>
-    <Author URL="mailto:prashanthpentareddy@gmail.com">Prashanth</Author>
-    <Description URL="">This custom Telugu keyboard is inspired by Lekhini, a browser-based transliteration tool. It was created to overcome Lekhini’s limitation of working only within a browser. Most of the character mappings from Lekhini have been faithfully replicated, with a few exceptions.</Description>
+    <Author URL="mailto:prashanthpentareddy@gmail.com">Prashanth Lavinna</Author>
+    <Description URL="">This custom Telugu keyboard is inspired by Lekhini, a browser-based transliteration tool. It was created to overcome Lekhini’s limitation of working only within a browser. Most of the character mappings from Lekhini have been faithfully replicated, with a few exceptions. While Lavanya offers touch screen support, its not matured yet. Google's Gboard is an excellent keyboard for typing in Telugu on touchscreen devices.</Description>
     <Version URL=""></Version>
   </Info>
   <Files>
@@ -82,7 +82,9 @@
   </Files>
   <Keyboards>
     <Keyboard>
+      <Name>lavanya</Name>
       <ID>lavanya</ID>
+      <Version>1.0</Version>
       <OSKFont>..\..\..\shared\fonts\noto\Telu\NotoSerifTelugu-VariableFont_wght.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\noto\Telu\NotoSerifTelugu-VariableFont_wght.ttf</DisplayFont>
       <Languages>

--- a/release/l/lavanya/source/readme.htm
+++ b/release/l/lavanya/source/readme.htm
@@ -15,7 +15,7 @@
 
 <h1>lAvaNya Keyboard</h1>
 
-<p>This custom Telugu keyboard is inspired by Lekhini, a browser-based transliteration tool. It was created to overcome Lekhini’s limitation of working only within a browser. Most of the character mappings from Lekhini have been faithfully replicated, with a few exceptions. The layout was designed by Prashanth in 2025 to help his mother, who is already familiar with Lekhini.</p>
+<p>This custom Telugu keyboard is inspired by Lekhini, a browser-based transliteration tool. It was created to overcome Lekhini’s limitation of working only within a browser. Most of the character mappings from Lekhini have been faithfully replicated, with a few exceptions. The layout was designed by Prashanth in 2025 to help his mother, who is already familiar with Lekhini. While Lavanya offers touch screen support, its not matured yet. Google's Gboard is an excellent keyboard for typing in Telugu on touchscreen devices.</p>
 
 <p>Refer to the doucmentation file for comprehensive reference.</p>
 <h2>Supported Platforms</h2>


### PR DESCRIPTION
1. Updated backspace handling. When using backspace (for example, after typing k+i, if you press backspace on i, it shows క instead of క్). This has been fixed. Now inherent vowel in not maintained even when the backspace is used. 

2. There are better touch layout for phones. Gboard stands out for Telugu. Rather than pushing for an inferior tool, I've decided to remove support touch layout.  