### PR TITLE
[lavanya] Bump keyboard version

### DIFF
--- a/release/l/lavanya/source/lavanya.kmn
+++ b/release/l/lavanya/source/lavanya.kmn
@@ -3,7 +3,7 @@ c with name "Lavanya"
 store(&VERSION) '10.0'
 store(&NAME) 'lavanya'
 store(&COPYRIGHT) 'Copyright © Prashanth'
-store(&KEYBOARDVERSION) '1.0'
+store(&KEYBOARDVERSION) '2.0'
 store(&BITMAP) 'lavanya.ico'
 store(&VISUALKEYBOARD) 'lavanya.kvks'
 store(&LAYOUTFILE) 'lavanya.keyman-touch-layout'


### PR DESCRIPTION
I did not catch that the keyboard version wasn't bumped. Changes were made in #3574 but did not appear online because the version wasn't bumped.