### PR TITLE
GFF Mesobe Fidelat - KPS Description Update for Web Preview.

### DIFF
--- a/release/gff/gff_mesobe_fidelat/source/gff_mesobe_fidelat.kps
+++ b/release/gff/gff_mesobe_fidelat/source/gff_mesobe_fidelat.kps
@@ -47,7 +47,8 @@ for new typists and fits more comfortably on a tablet device than on a
 mobile phone.
 
 ### Mobile Keyboard Preview
-![Mesobe Fidelat Preview](https://raw.githubusercontent.com/keymanapp/keyboards/refs/heads/master/release/gff/gff_mesobe_fidelat/source/help/images/gff_mesobe_fidelat-default-1.jpeg)</Description>
+![Mesobe Fidelat Preview](https://raw.githubusercontent.com/keymanapp/keyboards/15f3976a3ce17b2fa989c793ed96ab8753b3402a/release/gff/gff_mesobe_fidelat/source/help/images/gff_mesobe_fidelat-default-1.jpeg)</Description>
+
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
This update is made to enhance the keyboard's web description at keyman.com as per the issue and discussion here:
https://github.com/keymanapp/keyman.com/issues/589

Markdown text with an image reference has been added to the KPS description field, it is _not_ essential for the KMP file. Accordingly, the keyboard version number remains the same.

The Markdown text has been tested in a separate markdown file and was verified to work. It is assumed to work just as well under the keyman.com website. An adjustment may follow if the web conversion at keyman.com does not appear as expected.  If all goes well, the companion GFF Harege Fidelat keyboard will likewise be updated.