### PR TITLE
[sil_greek_polytonic] fix longpress keys

### DIFF
--- a/release/sil/sil_greek_polytonic/HISTORY.md
+++ b/release/sil/sil_greek_polytonic/HISTORY.md
@@ -1,6 +1,9 @@
 Polytonic Greek (SIL) Keyboard Change History
 =======================
 
+1.8.5 (25 Jul 2025)
+-----------------
+* Fix up some longpress keys
 
 1.8.4 (9 Jun 2025)
 -----------------

--- a/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.keyman-touch-layout
+++ b/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.keyman-touch-layout
@@ -81,83 +81,83 @@
                     "id": "U_03C9"
                   },
                   {
-                    "text": "",
+                    "text": "ὡ",
                     "id": "U_1F61"
                   },
                   {
-                    "text": "",
+                    "text": "ὢ",
                     "id": "U_1F62"
                   },
                   {
-                    "text": "",
+                    "text": "ὣ",
                     "id": "U_1F63"
                   },
                   {
-                    "text": "",
+                    "text": "ὤ",
                     "id": "U_1F64"
                   },
                   {
-                    "text": "",
+                    "text": "ὥ",
                     "id": "U_1F65"
                   },
                   {
-                    "text": "",
+                    "text": "ὦ",
                     "id": "U_1F66"
                   },
                   {
-                    "text": "",
+                    "text": "ὧ",
                     "id": "U_1F67"
                   },
                   {
-                    "text": "",
+                    "text": "ὼ",
                     "id": "U_1F7C"
                   },
                   {
-                    "text": "",
+                    "text": "ώ",
                     "id": "U_1F7D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾠ",
                     "id": "U_1FA0"
                   },
                   {
-                    "text": "",
+                    "text": "ᾡ",
                     "id": "U_1FA1"
                   },
                   {
-                    "text": "",
+                    "text": "ᾢ",
                     "id": "U_1FA2"
                   },
                   {
-                    "text": "",
+                    "text": "ᾣ",
                     "id": "U_1FA3"
                   },
                   {
-                    "text": "",
+                    "text": "ᾤ",
                     "id": "U_1FA4"
                   },
                   {
-                    "text": "",
+                    "text": "ᾥ",
                     "id": "U_1FA5"
                   },
                   {
-                    "text": "",
+                    "text": "ᾦ",
                     "id": "U_1FA6"
                   },
                   {
-                    "text": "",
+                    "text": "ᾧ",
                     "id": "U_1FA7"
                   },
                   {
-                    "text": "",
+                    "text": "ῲ",
                     "id": "U_1FF2"
                   },
                   {
-                    "text": "",
+                    "text": "ῳ",
                     "id": "U_1FF3"
                   },
                   {
-                    "text": "",
+                    "text": "ῴ",
                     "id": "U_1FF4"
                   },
                   {
@@ -243,55 +243,55 @@
                     "id": "U_03CB"
                   },
                   {
-                    "text": "",
+                    "text": "ὑ",
                     "id": "U_1F51"
                   },
                   {
-                    "text": "",
+                    "text": "ὒ",
                     "id": "U_1F52"
                   },
                   {
-                    "text": "",
+                    "text": "ὓ",
                     "id": "U_1F53"
                   },
                   {
-                    "text": "",
+                    "text": "ὔ",
                     "id": "U_1F54"
                   },
                   {
-                    "text": "",
+                    "text": "ὕ",
                     "id": "U_1F55"
                   },
                   {
-                    "text": "",
+                    "text": "ὖ",
                     "id": "U_1F56"
                   },
                   {
-                    "text": "",
+                    "text": "ὗ",
                     "id": "U_1F57"
                   },
                   {
-                    "text": "",
+                    "text": "ὺ",
                     "id": "U_1F7A"
                   },
                   {
-                    "text": "",
+                    "text": "ύ",
                     "id": "U_1F7B"
                   },
                   {
-                    "text": "",
+                    "text": "ῡ",
                     "id": "U_1FE1"
                   },
                   {
-                    "text": "",
+                    "text": "ῢ",
                     "id": "U_1FE2"
                   },
                   {
-                    "text": "",
+                    "text": "ΰ",
                     "id": "U_1FE3"
                   },
                   {
-                    "text": "",
+                    "text": "ῦ",
                     "id": "U_1FE6"
                   },
                   {
@@ -313,55 +313,55 @@
                     "id": "U_03CA"
                   },
                   {
-                    "text": "",
+                    "text": "ἱ",
                     "id": "U_1F31"
                   },
                   {
-                    "text": "",
+                    "text": "ἲ",
                     "id": "U_1F32"
                   },
                   {
-                    "text": "",
+                    "text": "ἳ",
                     "id": "U_1F33"
                   },
                   {
-                    "text": "",
+                    "text": "ἴ",
                     "id": "U_1F34"
                   },
                   {
-                    "text": "",
+                    "text": "ἵ",
                     "id": "U_1F35"
                   },
                   {
-                    "text": "",
+                    "text": "ἶ",
                     "id": "U_1F36"
                   },
                   {
-                    "text": "",
+                    "text": "ἷ",
                     "id": "U_1F37"
                   },
                   {
-                    "text": "",
+                    "text": "ὶ",
                     "id": "U_1F76"
                   },
                   {
-                    "text": "",
+                    "text": "ί",
                     "id": "U_1F77"
                   },
                   {
-                    "text": "",
+                    "text": "ῑ",
                     "id": "U_1FD1"
                   },
                   {
-                    "text": "",
+                    "text": "ῒ",
                     "id": "U_1FD2"
                   },
                   {
-                    "text": "",
+                    "text": "ΐ",
                     "id": "U_1FD3"
                   },
                   {
-                    "text": "",
+                    "text": "ῖ",
                     "id": "U_1FD6"
                   },
                   {
@@ -379,31 +379,31 @@
                     "id": "U_03BF"
                   },
                   {
-                    "text": "",
+                    "text": "ὁ",
                     "id": "U_1F41"
                   },
                   {
-                    "text": "",
+                    "text": "ὂ",
                     "id": "U_1F42"
                   },
                   {
-                    "text": "",
+                    "text": "ὃ",
                     "id": "U_1F43"
                   },
                   {
-                    "text": "",
+                    "text": "ὄ",
                     "id": "U_1F44"
                   },
                   {
-                    "text": "",
+                    "text": "ὅ",
                     "id": "U_1F45"
                   },
                   {
-                    "text": "",
+                    "text": "ὸ",
                     "id": "U_1F78"
                   },
                   {
-                    "text": "",
+                    "text": "ό",
                     "id": "U_1F79"
                   }
                 ]
@@ -475,35 +475,35 @@
                     "id": "U_1F71"
                   },
                   {
-                    "text": "",
+                    "text": "ᾀ",
                     "id": "U_1F80"
                   },
                   {
-                    "text": "",
+                    "text": "ᾁ",
                     "id": "U_1F81"
                   },
                   {
-                    "text": "",
+                    "text": "ᾂ",
                     "id": "U_1F82"
                   },
                   {
-                    "text": "",
+                    "text": "ᾃ",
                     "id": "U_1F83"
                   },
                   {
-                    "text": "",
+                    "text": "ᾄ",
                     "id": "U_1F84"
                   },
                   {
-                    "text": "",
+                    "text": "ᾅ",
                     "id": "U_1F85"
                   },
                   {
-                    "text": "",
+                    "text": "ᾆ",
                     "id": "U_1F86"
                   },
                   {
-                    "text": "",
+                    "text": "ᾇ",
                     "id": "U_1F87"
                   },
                   {
@@ -571,23 +571,23 @@
                     "id": "U_1F21"
                   },
                   {
-                    "text": "",
+                    "text": "ἢ",
                     "id": "U_1F22"
                   },
                   {
-                    "text": "",
+                    "text": "ἣ",
                     "id": "U_1F23"
                   },
                   {
-                    "text": "",
+                    "text": "ἤ",
                     "id": "U_1F24"
                   },
                   {
-                    "text": "",
+                    "text": "ἥ",
                     "id": "U_1F25"
                   },
                   {
-                    "text": "",
+                    "text": "ἦ",
                     "id": "U_1F26"
                   },
                   {
@@ -603,31 +603,31 @@
                     "id": "U_1F75"
                   },
                   {
-                    "text": "",
+                    "text": "ᾐ",
                     "id": "U_1F90"
                   },
                   {
-                    "text": "",
+                    "text": "ᾑ",
                     "id": "U_1F91"
                   },
                   {
-                    "text": "",
+                    "text": "ᾒ",
                     "id": "U_1F92"
                   },
                   {
-                    "text": "",
+                    "text": "ᾓ",
                     "id": "U_1F93"
                   },
                   {
-                    "text": "",
+                    "text": "ᾔ",
                     "id": "U_1F94"
                   },
                   {
-                    "text": "",
-                    "id": "U_1F94"
+                    "text": "ᾕ",
+                    "id": "U_1F95"
                   },
                   {
-                    "text": "",
+                    "text": "ᾖ",
                     "id": "U_1F96"
                   },
                   {
@@ -635,19 +635,19 @@
                     "id": "U_1F97"
                   },
                   {
-                    "text": "",
+                    "text": "ῂ",
                     "id": "U_1FC2"
                   },
                   {
-                    "text": "",
+                    "text": "ῃ",
                     "id": "U_1FC3"
                   },
                   {
-                    "text": "",
+                    "text": "ῄ",
                     "id": "U_1FC4"
                   },
                   {
-                    "text": "",
+                    "text": "ῆ",
                     "id": "U_1FC6"
                   },
                   {
@@ -840,75 +840,75 @@
                     "id": "U_03A9"
                   },
                   {
-                    "text": "",
+                    "text": "Ὡ",
                     "id": "U_1F69"
                   },
                   {
-                    "text": "",
+                    "text": "Ὢ",
                     "id": "U_1F6A"
                   },
                   {
-                    "text": "",
+                    "text": "Ὣ",
                     "id": "U_1F6B"
                   },
                   {
-                    "text": "",
+                    "text": "Ὤ",
                     "id": "U_1F6C"
                   },
                   {
-                    "text": "",
+                    "text": "Ὥ",
                     "id": "U_1F6D"
                   },
                   {
-                    "text": "",
+                    "text": "Ὦ",
                     "id": "U_1F6E"
                   },
                   {
-                    "text": "",
+                    "text": "Ὧ",
                     "id": "U_1F6F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾫ",
                     "id": "U_1FA8"
                   },
                   {
-                    "text": "",
+                    "text": "ᾩ",
                     "id": "U_1FA9"
                   },
                   {
-                    "text": "",
+                    "text": "ᾪ",
                     "id": "U_1FAA"
                   },
                   {
-                    "text": "",
+                    "text": "ᾫ",
                     "id": "U_1FAB"
                   },
                   {
-                    "text": "",
+                    "text": "ᾬ",
                     "id": "U_1FAC"
                   },
                   {
-                    "text": "",
+                    "text": "ᾭ",
                     "id": "U_1FAD"
                   },
                   {
-                    "text": "",
+                    "text": "ᾮ",
                     "id": "U_1FAE"
                   },
                   {
-                    "text": "",
+                    "text": "ᾯ",
                     "id": "U_1FAF"
                   },
                   {
-                    "text": "",
+                    "text": "Ὼ",
                     "id": "U_1FFA"
                   },
                   {
-                    "text": "",
+                    "text": "Ώ",
                     "id": "U_1FFB"
                   },
                   {
-                    "text": "",
+                    "text": "ῼ",
                     "id": "U_1FFC"
                   }
                 ]
@@ -922,37 +922,31 @@
                     "id": "U_0395"
                   },
                   {
-                    "text": "Ἐ",
-                    "id": "U_1F18"
-                  },
-                  {
-                    "text": "",
+                    "text": "Ἑ",
                     "id": "U_1F19"
                   },
                   {
-                    "text": "",
+                    "text": "Ἒ",
                     "id": "U_1F1A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἓ",
                     "id": "U_1F1B"
                   },
                   {
-                    "text": "",
-                    "id": "U_1F1D"
-                  },
-                  {
-                    "text": "",
-                    "id": "U_1F1D"
+                    "text": "Ἔ",
+                    "id": "U_1F1c"
                   },
                   {
                     "text": "Ἕ",
                     "id": "U_1F1D"
                   },
                   {
+                    "text": "Ὲ",
                     "id": "U_1FC8"
                   },
                   {
+                    "text": "Έ",
                     "id": "U_1FC9"
                   }
                 ]
@@ -988,24 +982,31 @@
                     "id": "U_03AB"
                   },
                   {
+                    "text": "Ὑ",
                     "id": "U_1F59"
                   },
                   {
+                    "text": "Ὓ",
                     "id": "U_1F5B"
                   },
                   {
+                    "text": "Ὕ",
                     "id": "U_1F5D"
                   },
                   {
+                    "text": "Ὗ",
                     "id": "U_1F5F"
                   },
                   {
+                    "text": "Ῡ",
                     "id": "U_1FE9"
                   },
                   {
+                    "text": "Ὺ",
                     "id": "U_1FEA"
                   },
                   {
+                    "text": "Ύ",
                     "id": "U_1FEB"
                   }
                 ]
@@ -1023,35 +1024,35 @@
                     "id": "U_03AA"
                   },
                   {
-                    "text": "",
+                    "text": "Ἱ",
                     "id": "U_1F39"
                   },
                   {
-                    "text": "",
+                    "text": "Ἲ",
                     "id": "U_1F3A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἳ",
                     "id": "U_1F3B"
                   },
                   {
-                    "text": "",
+                    "text": "Ἴ",
                     "id": "U_1F3C"
                   },
                   {
-                    "text": "",
+                    "text": "Ἵ",
                     "id": "U_1F3D"
                   },
                   {
-                    "text": "",
+                    "text": "Ἶ",
                     "id": "U_1F3E"
                   },
                   {
-                    "text": "",
+                    "text": "Ἷ",
                     "id": "U_1F3F"
                   },
                   {
-                    "text": "",
+                    "text": "Ῑ",
                     "id": "U_1FD9"
                   },
                   {
@@ -1073,27 +1074,27 @@
                     "id": "U_039F"
                   },
                   {
-                    "text": "",
+                    "text": "Ὁ",
                     "id": "U_1F49"
                   },
                   {
-                    "text": "",
+                    "text": "Ὂ",
                     "id": "U_1F4A"
                   },
                   {
-                    "text": "",
+                    "text": "Ὃ",
                     "id": "U_1F4B"
                   },
                   {
-                    "text": "",
+                    "text": "Ὄ",
                     "id": "U_1F4C"
                   },
                   {
-                    "text": "",
+                    "text": "Ὅ",
                     "id": "U_1F4D"
                   },
                   {
-                    "text": "",
+                    "text": "Ὸ",
                     "id": "U_1FF8"
                   },
                   {
@@ -1165,35 +1166,35 @@
                     "id": "U_1F0F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾈ",
                     "id": "U_1F88"
                   },
                   {
-                    "text": "",
+                    "text": "ᾉ",
                     "id": "U_1F89"
                   },
                   {
-                    "text": "",
+                    "text": "ᾊ",
                     "id": "U_1F8A"
                   },
                   {
-                    "text": "",
+                    "text": "ᾋ",
                     "id": "U_1F8B"
                   },
                   {
-                    "text": "",
+                    "text": "ᾌ",
                     "id": "U_1F8C"
                   },
                   {
-                    "text": "",
+                    "text": "ᾍ",
                     "id": "U_1F8D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾎ",
                     "id": "U_1F8E"
                   },
                   {
-                    "text": "",
+                    "text": "ᾏ",
                     "id": "U_1F8F"
                   },
                   {
@@ -1243,71 +1244,71 @@
                     "id": "U_0397"
                   },
                   {
-                    "text": "",
+                    "text": "Ἡ",
                     "id": "U_1F29"
                   },
                   {
-                    "text": "",
+                    "text": "Ἢ",
                     "id": "U_1F2A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἣ",
                     "id": "U_1F2B"
                   },
                   {
-                    "text": "",
+                    "text": "Ἤ",
                     "id": "U_1F2C"
                   },
                   {
-                    "text": "",
+                    "text": "Ἥ",
                     "id": "U_1F2D"
                   },
                   {
-                    "text": "",
+                    "text": "Ἦ",
                     "id": "U_1F2E"
                   },
                   {
-                    "text": "",
+                    "text": "Ἧ",
                     "id": "U_1F2F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾘ",
                     "id": "U_1F98"
                   },
                   {
-                    "text": "",
+                    "text": "ᾙ",
                     "id": "U_1F99"
                   },
                   {
-                    "text": "",
+                    "text": "ᾚ",
                     "id": "U_1F9A"
                   },
                   {
-                    "text": "",
+                    "text": "ᾛ",
                     "id": "U_1F9B"
                   },
                   {
-                    "text": "",
+                    "text": "ᾜ",
                     "id": "U_1F9C"
                   },
                   {
-                    "text": "",
+                    "text": "ᾝ",
                     "id": "U_1F9D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾞ",
                     "id": "U_1F9E"
                   },
                   {
-                    "text": "",
+                    "text": "ᾟ",
                     "id": "U_1F9F"
                   },
                   {
-                    "text": "",
+                    "text": "Ὴ",
                     "id": "U_1FCA"
                   },
                   {
-                    "text": "",
+                    "text": "Ή",
                     "id": "U_1FCB"
                   },
                   {
@@ -1453,83 +1454,83 @@
                     "id": "U_03C9"
                   },
                   {
-                    "text": "",
+                    "text": "ὡ",
                     "id": "U_1F61"
                   },
                   {
-                    "text": "",
+                    "text": "ὢ",
                     "id": "U_1F62"
                   },
                   {
-                    "text": "",
+                    "text": "ὣ",
                     "id": "U_1F63"
                   },
                   {
-                    "text": "",
+                    "text": "ὤ",
                     "id": "U_1F64"
                   },
                   {
-                    "text": "",
+                    "text": "ὥ",
                     "id": "U_1F65"
                   },
                   {
-                    "text": "",
+                    "text": "ὦ",
                     "id": "U_1F66"
                   },
                   {
-                    "text": "",
+                    "text": "ὧ",
                     "id": "U_1F67"
                   },
                   {
-                    "text": "",
+                    "text": "ὼ",
                     "id": "U_1F7C"
                   },
                   {
-                    "text": "",
+                    "text": "ώ",
                     "id": "U_1F7D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾠ",
                     "id": "U_1FA0"
                   },
                   {
-                    "text": "",
+                    "text": "ᾡ",
                     "id": "U_1FA1"
                   },
                   {
-                    "text": "",
+                    "text": "ᾢ",
                     "id": "U_1FA2"
                   },
                   {
-                    "text": "",
+                    "text": "ᾣ",
                     "id": "U_1FA3"
                   },
                   {
-                    "text": "",
+                    "text": "ᾤ",
                     "id": "U_1FA4"
                   },
                   {
-                    "text": "",
+                    "text": "ᾥ",
                     "id": "U_1FA5"
                   },
                   {
-                    "text": "",
+                    "text": "ᾦ",
                     "id": "U_1FA6"
                   },
                   {
-                    "text": "",
+                    "text": "ᾧ",
                     "id": "U_1FA7"
                   },
                   {
-                    "text": "",
+                    "text": "ῲ",
                     "id": "U_1FF2"
                   },
                   {
-                    "text": "",
+                    "text": "ῳ",
                     "id": "U_1FF3"
                   },
                   {
-                    "text": "",
+                    "text": "ῴ",
                     "id": "U_1FF4"
                   },
                   {
@@ -1615,55 +1616,55 @@
                     "id": "U_03CB"
                   },
                   {
-                    "text": "",
+                    "text": "ὑ",
                     "id": "U_1F51"
                   },
                   {
-                    "text": "",
+                    "text": "ὒ",
                     "id": "U_1F52"
                   },
                   {
-                    "text": "",
+                    "text": "ὓ",
                     "id": "U_1F53"
                   },
                   {
-                    "text": "",
+                    "text": "ὔ",
                     "id": "U_1F54"
                   },
                   {
-                    "text": "",
+                    "text": "ὕ",
                     "id": "U_1F55"
                   },
                   {
-                    "text": "",
+                    "text": "ὖ",
                     "id": "U_1F56"
                   },
                   {
-                    "text": "",
+                    "text": "ὗ",
                     "id": "U_1F57"
                   },
                   {
-                    "text": "",
+                    "text": "ὺ",
                     "id": "U_1F7A"
                   },
                   {
-                    "text": "",
+                    "text": "ύ",
                     "id": "U_1F7B"
                   },
                   {
-                    "text": "",
+                    "text": "ῡ",
                     "id": "U_1FE1"
                   },
                   {
-                    "text": "",
+                    "text": "ῢ",
                     "id": "U_1FE2"
                   },
                   {
-                    "text": "",
+                    "text": "ΰ",
                     "id": "U_1FE3"
                   },
                   {
-                    "text": "",
+                    "text": "ῦ",
                     "id": "U_1FE6"
                   },
                   {
@@ -1685,55 +1686,55 @@
                     "id": "U_03CA"
                   },
                   {
-                    "text": "",
+                    "text": "ἱ",
                     "id": "U_1F31"
                   },
                   {
-                    "text": "",
+                    "text": "ἲ",
                     "id": "U_1F32"
                   },
                   {
-                    "text": "",
-                    "id": "U_1F33"
+                    "text": "ἳ",
+                    "id": "U_1f33"
                   },
                   {
-                    "text": "",
+                    "text": "ἴ",
                     "id": "U_1F34"
                   },
                   {
-                    "text": "",
+                    "text": "ἵ",
                     "id": "U_1F35"
                   },
                   {
-                    "text": "",
+                    "text": "ἶ",
                     "id": "U_1F36"
                   },
                   {
-                    "text": "",
+                    "text": "ἷ",
                     "id": "U_1F37"
                   },
                   {
-                    "text": "",
+                    "text": "ὶ",
                     "id": "U_1F76"
                   },
                   {
-                    "text": "",
+                    "text": "ί",
                     "id": "U_1F77"
                   },
                   {
-                    "text": "",
+                    "text": "ῑ",
                     "id": "U_1FD1"
                   },
                   {
-                    "text": "",
+                    "text": "ῒ",
                     "id": "U_1FD2"
                   },
                   {
-                    "text": "",
+                    "text": "ΐ",
                     "id": "U_1FD3"
                   },
                   {
-                    "text": "",
+                    "text": "ῖ",
                     "id": "U_1FD6"
                   },
                   {
@@ -1751,31 +1752,31 @@
                     "id": "U_03BF"
                   },
                   {
-                    "text": "",
+                    "text": "ὁ",
                     "id": "U_1F41"
                   },
                   {
-                    "text": "",
+                    "text": "ὂ",
                     "id": "U_1F42"
                   },
                   {
-                    "text": "",
+                    "text": "ὃ",
                     "id": "U_1F43"
                   },
                   {
-                    "text": "",
+                    "text": "ὄ",
                     "id": "U_1F44"
                   },
                   {
-                    "text": "",
+                    "text": "ὅ",
                     "id": "U_1F45"
                   },
                   {
-                    "text": "",
+                    "text": "ὸ",
                     "id": "U_1F78"
                   },
                   {
-                    "text": "",
+                    "text": "ό",
                     "id": "U_1F79"
                   }
                 ]
@@ -1834,35 +1835,35 @@
                     "id": "U_1F71"
                   },
                   {
-                    "text": "",
+                    "text": "ᾀ",
                     "id": "U_1F80"
                   },
                   {
-                    "text": "",
+                    "text": "ᾁ",
                     "id": "U_1F81"
                   },
                   {
-                    "text": "",
+                    "text": "ᾂ",
                     "id": "U_1F82"
                   },
                   {
-                    "text": "",
+                    "text": "ᾃ",
                     "id": "U_1F83"
                   },
                   {
-                    "text": "",
+                    "text": "ᾄ",
                     "id": "U_1F84"
                   },
                   {
-                    "text": "",
+                    "text": "ᾅ",
                     "id": "U_1F85"
                   },
                   {
-                    "text": "",
+                    "text": "ᾆ",
                     "id": "U_1F86"
                   },
                   {
-                    "text": "",
+                    "text": "ᾇ",
                     "id": "U_1F87"
                   },
                   {
@@ -1937,23 +1938,23 @@
                     "id": "U_1F21"
                   },
                   {
-                    "text": "",
+                    "text": "ἢ",
                     "id": "U_1F22"
                   },
                   {
-                    "text": "",
+                    "text": "ἣ",
                     "id": "U_1F23"
                   },
                   {
-                    "text": "",
+                    "text": "ἤ",
                     "id": "U_1F24"
                   },
                   {
-                    "text": "",
+                    "text": "ἥ",
                     "id": "U_1F25"
                   },
                   {
-                    "text": "",
+                    "text": "ἦ",
                     "id": "U_1F26"
                   },
                   {
@@ -1969,31 +1970,31 @@
                     "id": "U_1F75"
                   },
                   {
-                    "text": "",
+                    "text": "ᾐ",
                     "id": "U_1F90"
                   },
                   {
-                    "text": "",
+                    "text": "ᾑ",
                     "id": "U_1F91"
                   },
                   {
-                    "text": "",
+                    "text": "ᾒ",
                     "id": "U_1F92"
                   },
                   {
-                    "text": "",
+                    "text": "ᾓ",
                     "id": "U_1F93"
                   },
                   {
-                    "text": "",
+                    "text": "ᾔ",
                     "id": "U_1F94"
                   },
                   {
-                    "text": "",
-                    "id": "U_1F94"
+                    "text": "ᾕ",
+                    "id": "U_1F95"
                   },
                   {
-                    "text": "",
+                    "text": "ᾖ",
                     "id": "U_1F96"
                   },
                   {
@@ -2001,19 +2002,19 @@
                     "id": "U_1F97"
                   },
                   {
-                    "text": "",
+                    "text": "ῂ",
                     "id": "U_1FC2"
                   },
                   {
-                    "text": "",
+                    "text": "ῃ",
                     "id": "U_1FC3"
                   },
                   {
-                    "text": "",
+                    "text": "ῄ",
                     "id": "U_1FC4"
                   },
                   {
-                    "text": "",
+                    "text": "ῆ",
                     "id": "U_1FC6"
                   },
                   {
@@ -2184,75 +2185,75 @@
                     "id": "U_03A9"
                   },
                   {
-                    "text": "",
+                    "text": "Ὡ",
                     "id": "U_1F69"
                   },
                   {
-                    "text": "",
+                    "text": "Ὢ",
                     "id": "U_1F6A"
                   },
                   {
-                    "text": "",
+                    "text": "Ὣ",
                     "id": "U_1F6B"
                   },
                   {
-                    "text": "",
+                    "text": "Ὤ",
                     "id": "U_1F6C"
                   },
                   {
-                    "text": "",
+                    "text": "Ὥ",
                     "id": "U_1F6D"
                   },
                   {
-                    "text": "",
+                    "text": "Ὦ",
                     "id": "U_1F6E"
                   },
                   {
-                    "text": "",
+                    "text": "Ὧ",
                     "id": "U_1F6F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾨ",
                     "id": "U_1FA8"
                   },
                   {
-                    "text": "",
+                    "text": "ᾩ",
                     "id": "U_1FA9"
                   },
                   {
-                    "text": "",
+                    "text": "ᾪ",
                     "id": "U_1FAA"
                   },
                   {
-                    "text": "",
+                    "text": "ᾫ",
                     "id": "U_1FAB"
                   },
                   {
-                    "text": "",
+                    "text": "ᾬ",
                     "id": "U_1FAC"
                   },
                   {
-                    "text": "",
+                    "text": "ᾭ",
                     "id": "U_1FAD"
                   },
                   {
-                    "text": "",
+                    "text": "ᾮ",
                     "id": "U_1FAE"
                   },
                   {
-                    "text": "",
+                    "text": "ᾯ",
                     "id": "U_1FAF"
                   },
                   {
-                    "text": "",
+                    "text": "Ὼ",
                     "id": "U_1FFA"
                   },
                   {
-                    "text": "",
+                    "text": "Ώ",
                     "id": "U_1FFB"
                   },
                   {
-                    "text": "",
+                    "text": "ῼ",
                     "id": "U_1FFC"
                   }
                 ]
@@ -2266,37 +2267,31 @@
                     "id": "U_0395"
                   },
                   {
-                    "text": "Ἐ",
-                    "id": "U_1F18"
-                  },
-                  {
-                    "text": "",
+                    "text": "Ἑ",
                     "id": "U_1F19"
                   },
                   {
-                    "text": "",
+                    "text": "Ἒ",
                     "id": "U_1F1A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἓ",
                     "id": "U_1F1B"
                   },
                   {
-                    "text": "",
-                    "id": "U_1F1D"
-                  },
-                  {
-                    "text": "",
-                    "id": "U_1F1D"
+                    "text": "Ἔ",
+                    "id": "U_1F1C"
                   },
                   {
                     "text": "Ἕ",
                     "id": "U_1F1D"
                   },
                   {
+                    "text": "Ὲ",
                     "id": "U_1FC8"
                   },
                   {
+                    "text": "Έ",
                     "id": "U_1FC9"
                   }
                 ]
@@ -2339,24 +2334,31 @@
                     "id": "U_03AB"
                   },
                   {
+                    "text": "Ὑ",
                     "id": "U_1F59"
                   },
                   {
+                    "text": "Ὓ",
                     "id": "U_1F5B"
                   },
                   {
+                    "text": "Ὕ",
                     "id": "U_1F5D"
                   },
                   {
+                    "text": "Ὗ",
                     "id": "U_1F5F"
                   },
                   {
+                    "text": "Ῡ",
                     "id": "U_1FE9"
                   },
                   {
+                    "text": "Ὺ",
                     "id": "U_1FEA"
                   },
                   {
+                    "text": "Ύ",
                     "id": "U_1FEB"
                   }
                 ]
@@ -2374,35 +2376,35 @@
                     "id": "U_03AA"
                   },
                   {
-                    "text": "",
+                    "text": "Ἱ",
                     "id": "U_1F39"
                   },
                   {
-                    "text": "",
+                    "text": "Ἲ",
                     "id": "U_1F3A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἳ",
                     "id": "U_1F3B"
                   },
                   {
-                    "text": "",
+                    "text": "Ἴ",
                     "id": "U_1F3C"
                   },
                   {
-                    "text": "",
+                    "text": "Ἵ",
                     "id": "U_1F3D"
                   },
                   {
-                    "text": "",
+                    "text": "Ἶ",
                     "id": "U_1F3E"
                   },
                   {
-                    "text": "",
+                    "text": "Ἷ",
                     "id": "U_1F3F"
                   },
                   {
-                    "text": "",
+                    "text": "Ῑ",
                     "id": "U_1FD9"
                   },
                   {
@@ -2424,27 +2426,27 @@
                     "id": "U_039F"
                   },
                   {
-                    "text": "",
+                    "text": "Ὁ",
                     "id": "U_1F49"
                   },
                   {
-                    "text": "",
+                    "text": "Ὂ",
                     "id": "U_1F4A"
                   },
                   {
-                    "text": "",
+                    "text": "Ὃ",
                     "id": "U_1F4B"
                   },
                   {
-                    "text": "",
+                    "text": "Ὄ",
                     "id": "U_1F4C"
                   },
                   {
-                    "text": "",
+                    "text": "Ὅ",
                     "id": "U_1F4D"
                   },
                   {
-                    "text": "",
+                    "text": "Ὸ",
                     "id": "U_1FF8"
                   },
                   {
@@ -2509,35 +2511,35 @@
                     "id": "U_1F0F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾈ",
                     "id": "U_1F88"
                   },
                   {
-                    "text": "",
+                    "text": "ᾉ",
                     "id": "U_1F89"
                   },
                   {
-                    "text": "",
+                    "text": "ᾊ",
                     "id": "U_1F8A"
                   },
                   {
-                    "text": "",
+                    "text": "ᾋ",
                     "id": "U_1F8B"
                   },
                   {
-                    "text": "",
+                    "text": "ᾌ",
                     "id": "U_1F8C"
                   },
                   {
-                    "text": "",
+                    "text": "ᾍ",
                     "id": "U_1F8D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾎ",
                     "id": "U_1F8E"
                   },
                   {
-                    "text": "",
+                    "text": "ᾏ",
                     "id": "U_1F8F"
                   },
                   {
@@ -2587,71 +2589,71 @@
                     "id": "U_0397"
                   },
                   {
-                    "text": "",
+                    "text": "Ἡ",
                     "id": "U_1F29"
                   },
                   {
-                    "text": "",
+                    "text": "Ἢ",
                     "id": "U_1F2A"
                   },
                   {
-                    "text": "",
+                    "text": "Ἣ",
                     "id": "U_1F2B"
                   },
                   {
-                    "text": "",
+                    "text": "Ἤ",
                     "id": "U_1F2C"
                   },
                   {
-                    "text": "",
+                    "text": "Ἥ",
                     "id": "U_1F2D"
                   },
                   {
-                    "text": "",
+                    "text": "Ἦ",
                     "id": "U_1F2E"
                   },
                   {
-                    "text": "",
+                    "text": "Ἧ",
                     "id": "U_1F2F"
                   },
                   {
-                    "text": "",
+                    "text": "ᾘ",
                     "id": "U_1F98"
                   },
                   {
-                    "text": "",
+                    "text": "ᾙ",
                     "id": "U_1F99"
                   },
                   {
-                    "text": "",
+                    "text": "ᾚ",
                     "id": "U_1F9A"
                   },
                   {
-                    "text": "",
+                    "text": "ᾛ",
                     "id": "U_1F9B"
                   },
                   {
-                    "text": "",
+                    "text": "ᾜ",
                     "id": "U_1F9C"
                   },
                   {
-                    "text": "",
+                    "text": "ᾝ",
                     "id": "U_1F9D"
                   },
                   {
-                    "text": "",
+                    "text": "ᾞ",
                     "id": "U_1F9E"
                   },
                   {
-                    "text": "",
+                    "text": "ᾟ",
                     "id": "U_1F9F"
                   },
                   {
-                    "text": "",
+                    "text": "Ὴ",
                     "id": "U_1FCA"
                   },
                   {
-                    "text": "",
+                    "text": "Ή",
                     "id": "U_1FCB"
                   },
                   {
@@ -3033,6 +3035,6 @@
       }
     ],
     "fontsize": "",
-    "font": "Gentium"
+    "font": "Gentium Plus"
   }
 }

--- a/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.kmn
+++ b/release/sil/sil_greek_polytonic/source/sil_greek_polytonic.kmn
@@ -36,7 +36,7 @@ c store(&ETHNOLOGUECODE) 'grc ell'
 c store(&LANGUAGE) 'x0408'
 c store(&WINDOWSLANGUAGES) 'x0408'
 store(&VISUALKEYBOARD) 'sil_greek_polytonic.kvks'
-store(&KEYBOARDVERSION) '1.8.4'
+store(&KEYBOARDVERSION) '1.8.5'
 store(&LAYOUTFILE) 'sil_greek_polytonic.keyman-touch-layout'
 
 begin Unicode > use(MainU)
@@ -637,7 +637,7 @@ any(rRo)             + any(K_Del) > outs(r)                     c r<  + *  r
 any(upVSm_Sm)        + any(K_Del) > index(upVSm,1)              c >A  + *  A
 any(Sm) any(upU)     + any(K_Del) > index(upU,2)                c >U  + *  U
 any(upVSmAc)         + any(K_Del) > index(upVSm_Sm,1)           c >/A + *  /A
-any(upVRo)           + any(K_Del) > index(upV,2)                c <A  + *  A
+any(upVRo)           + any(K_Del) > index(upV,1)                c <A  + *  A
 
 any(upRRo)           + any(K_Del) > outs(upR)                   c <R  + *  R
 


### PR DESCRIPTION
Some longpress keys for vowels (both upper and lower case) had a blank "text" field or the "text" field was missing entirely. This seemed to work in some circumstances (that is, the character was displayed based on the U_xxxx id value), but failed on iOS.

In some cases the base key was repeated as a longpress key. When I noticed that, I deleted the duplication (since there are so many longpress keys on most vowels).

In addition, fixed a bug in the .kmn file, prompted by a compiler warning. Line 640 was:
```
any(upVRo)           + any(K_Del) > index(upV,2)                c <A  + *  A
```
and produced a warning:
"sil_greek_polytonic.kmn:641 - hint KM020B0: The store referenced in index() is longer than the store referenced in any()"
store(upVRo) has seven elements, store(K_Del) has one, store(upV) has seven.
Since the index from any(K_Del) is always 1, index(upV,2) always produces alpha.
[Test: "h" "E" shows upper case epsilon with rough breathing. Typing "*" changes to upper case alpha.]
It seems the index should be "1", not "2", so I changed that accordingly.

There are other compiler warnings about stores of differing lengths. At the end of the longer one there are iota subscript forms of three vowels that will never be reached, but they are not needed in the cases where this store is used.

There's an additional compiler warning about a rule not being used because a previous rule takes precedence. I beleive that is due to `xff` being used as a placeholder in each of the stores that are used in these two rules. 

Not addressed in this PR: There are some lower case characters that don't have a corresponding single upper case character. Would we want to add additional longpress keys (using U_xxxx_yyyy format) to produce the upper case equivalent? If so, we could open a new issue.
