### PR TITLE
maint: remove old servervars.sh references from CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ release/*/*/tests/
 experimental/*/*/build/
 packages/*/build/
 .cache
-servervars.sh
 .DS_Store
 /.project
 .vscode/

--- a/ci.sh
+++ b/ci.sh
@@ -35,7 +35,6 @@ else
   APP7Z="/c/Program Files/7-Zip/7z.exe"
 fi
 
-. "$KEYBOARDROOT/servervars.sh"
 . "$KEYBOARDROOT/resources/util.inc.sh"
 . "$KEYBOARDROOT/resources/rsync-tools.sh"
 

--- a/resources/help-keyman-com.sh
+++ b/resources/help-keyman-com.sh
@@ -65,7 +65,6 @@ CI_CACHE="$KEYBOARDROOT/.cache"
 . "$KEYBOARDROOT/tools/jq.inc.sh"
 keyboards_to_push=0
 
-. "$KEYBOARDROOT/servervars.sh"
 . "$KEYBOARDROOT/resources/util.inc.sh"
 
 echo "Uploading keyboard documentation to help.keyman.com"


### PR DESCRIPTION
After merge of #3604, builds failed because we had references to servervars.sh, a file which is no longer used with the TC scripts in-repo.

Follows: #3604