### PR TITLE
GFF Harari Keyboard v1.0.6

### DIFF
--- a/release/gff/gff_harari/HISTORY.md
+++ b/release/gff/gff_harari/HISTORY.md
@@ -1,6 +1,10 @@
 gff_harari Change History
 ==========================
 
+1.0.6 (09 Sep 2025)
+-------------------
+* WashRa fonts are fully retired.
+
 1.0.5 (29 Oct 2024)
 --------------------
 * Abyssinica SIL TypeTuned fonts were renamed.

--- a/release/gff/gff_harari/LICENSE.md
+++ b/release/gff/gff_harari/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023-2024 Geʾez Frontier Foundation
+Copyright (c) 2023-2025 Geʾez Frontier Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/gff/gff_harari/source/gff_harari.kmn
+++ b/release/gff/gff_harari/source/gff_harari.kmn
@@ -13,7 +13,7 @@ c Specification :  http://keyboards.ethiopic.org/specification/
 c Other Info    :  http://keyboards.ethiopic.org/ , http://unicode.org/charts/
 c 
 store(&VERSION) '15.0'
-store(&KEYBOARDVERSION) '1.0.5'
+store(&KEYBOARDVERSION) '1.0.6'
 store(&NAME) 'ሐረሪ (Harari)'
 store(&COPYRIGHT) '© Geʾez Frontier Foundation'
 store(&Message) "This is a Harari language mnemonic input method for Ethiopic script that requires Unicode 3.0 support."

--- a/release/gff/gff_harari/source/gff_harari.kps
+++ b/release/gff/gff_harari/source/gff_harari.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>17.0.330.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>18.0.240.0</KeymanDeveloperVersion>
     <FileVersion>7.0</FileVersion>
   </System>
   <Options>
@@ -100,30 +100,6 @@ a font supporting Ethiopic script under the Unicode 3.0 standard.</Description>
       <Description>Font Free Serif</Description>
       <CopyLocation>0</CopyLocation>
       <FileType>.otf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\washrab.ttf</Name>
-      <Description>Font Ethiopic WashRa Bold</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\washrabsl.ttf</Name>
-      <Description>Font Ethiopic WashRa Bold Slant</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\washrasb.ttf</Name>
-      <Description>Font Ethiopic WashRa SemiBold</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
-    </File>
-    <File>
-      <Name>..\..\..\shared\fonts\geez\washrasbsl.ttf</Name>
-      <Description>Font Ethiopic WashRa SemiBold Slant</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.ttf</FileType>
     </File>
     <File>
       <Name>..\build\gff_harari.js</Name>
@@ -230,9 +206,7 @@ a font supporting Ethiopic script under the Unicode 3.0 standard.</Description>
   </Files>
   <Keyboards>
     <Keyboard>
-      <Name>ሐረሪ (Harari)</Name>
       <ID>gff_harari</ID>
-      <Version>1.0.5</Version>
       <OSKFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</OSKFont>
       <DisplayFont>..\..\..\shared\fonts\sil\abyssinica\AbyssinicaSIL-Regular.ttf</DisplayFont>
       <Languages>


### PR DESCRIPTION
This is a minimal update that fully retires the WashRa fonts in place of the Waldba fonts.