### PR TITLE
chore(gff_mwangwego): remove isolated .kpj

### DIFF
--- a/experimental/gff/gff_mwangwego/gff_mwangwego.kpj
+++ b/experimental/gff/gff_mwangwego/gff_mwangwego.kpj
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<KeymanDeveloperProject>
-  <Options>
-    <Version>2.0</Version>
-    <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
-    <SkipMetadataFiles>True</SkipMetadataFiles>
-  </Options>
-</KeymanDeveloperProject>


### PR DESCRIPTION
This was breaking the deployment as the deployment was looking for other
files associated with the .kpj.