### PR TITLE
chore: remove redundant servervars reference

### DIFF
--- a/legacy/b/bengali/source/help/bengali.php
+++ b/legacy/b/bengali/source/help/bengali.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             bengali
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Traditional Bengali (deprecated) Keyboard Help';
   $pagetitle = 'Traditional Bengali (deprecated) Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Tavultesoft</p>
 
 <br/>
@@ -43,12 +42,12 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
 <p>
-This keyboard lets you type in Bengali (Bangla).  It is easy to use for people familiar with Bengali and the Inscript keyboard layout.  
+This keyboard lets you type in Bengali (Bangla).  It is easy to use for people familiar with Bengali and the Inscript keyboard layout.
 It includes some characters which are not found on the Inscript keyboard.  It uses a normal English (QWERTY) keyboard.
 </p>
 <p class='keymanweb'>
@@ -93,7 +92,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the 35 normal consonants <span class='lang2' style='font-size:200%'>ক খ গ ঘ ঙ চ ছ জ ঝ ঞ ট ঠ ড ঢ ণ ত থ দ ধ ন প ফ ব ভ ম য় র ল শ ষ স হ য ড় ঢ়</span>, the vowels <span class='lang2' style='font-size:200%'>অ আ ই ঈ উ ঊ ঋ এ ঐ ও ঔ  ্ া ি ী ু ূ ৃ ে ৈ ো ৌ</span>, and the <span class='lang2' style='font-size:200%'>্ ত্ ং ঃ ঁ</span> marks.  To type numbers and some other characters which are used less often, use <span class='keys'>[CA*]</span> or <span class='keys'>[CSA*]</span>.</p>
 
 <p>Bengali vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -152,7 +151,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ঔ</td><td class='lang2' style='font-size:200%'>কৌ</td><td><span class='keys'>kq</span></td>
 	</tr>
-	
+
 </table>
 
 </div>

--- a/legacy/b/bengali_inscript/source/help/chart.php
+++ b/legacy/b/bengali_inscript/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Inscript Bengali Keyboard Help';
   $pagetitle = 'Inscript Bengali Keyboard Help';
   $style = 'lang2 {font-size:250%}';

--- a/legacy/e/ekwbamuni/source/help/chart.php
+++ b/legacy/e/ekwbamuni/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Suratha Bamuni (Bamini) Keyboard Help';
   $pagetitle = 'Suratha Bamuni Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwbamuni/source/help/ekwbamuni.php
+++ b/legacy/e/ekwbamuni/source/help/ekwbamuni.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Suratha Bamuni (Bamini) (deprecated) Keyboard Help';
   $pagetitle = 'Suratha Bamuni (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwbamuni/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwbamuni/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwnewtwuni/source/help/chart.php
+++ b/legacy/e/ekwnewtwuni/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Thamizha New Tamil Typewriter Keyboard Help';
   $pagetitle = 'Thamizha New Tamil Typewriter Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwnewtwuni/source/help/ekwnewtwuni.php
+++ b/legacy/e/ekwnewtwuni/source/help/ekwnewtwuni.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Thamizha New Tamil Typewriter (deprecated) Keyboard Help';
   $pagetitle = 'Thamizha New Tamil Typewriter (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwnewtwuni/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwnewtwuni/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwtamil99uniext/source/help/chart.php
+++ b/legacy/e/ekwtamil99uniext/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil99 Extended Keyboard Help';
   $pagetitle = 'Tamil99 Extended Keyboard Help';
   $style = 'lang2 {font-size:130%}';

--- a/legacy/e/ekwtamil99uniext/source/help/ekwtamil99uniext.php
+++ b/legacy/e/ekwtamil99uniext/source/help/ekwtamil99uniext.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil99 Extended (deprecated) Keyboard Help';
   $pagetitle = 'Tamil99 Extended (deprecated) Keyboard Help';
   $style = 'lang2 {font-size:130%}';

--- a/legacy/e/ekwtamil99uniext/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwtamil99uniext/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwunitamil/source/help/chart.php
+++ b/legacy/e/ekwunitamil/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Anjal Paangu Keyboard Help';
   $pagetitle = 'Tamil Anjal Paangu Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/e/ekwunitamil/source/help/ekwunitamil.php
+++ b/legacy/e/ekwunitamil/source/help/ekwunitamil.php
@@ -1,21 +1,20 @@
 <?php /*
   Name:             keyboard_ekwunitamil
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Anjal Paangu (deprecated) Keyboard Help';
   $pagetitle = 'Tamil Anjal Paangu (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';
@@ -23,8 +22,8 @@
 
   require_once('header.php');
 ?>
-   	
-  
+
+
 <p style='margin:0px'>Keyboard &#169; 2008 thamizha.com and Tavultesoft</p>
 
 
@@ -46,7 +45,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -115,7 +114,7 @@ Most computers will automatically download a special font if needed to display t
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The visible keyboard layout consists of the ten vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஒ ஓ</span> (the vowels <span class='lang2'>ஐ ஔ</span> are typed with two keystrokes), the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the Grantha consonants <span class='lang2'>ஸ ஜ ஹ க்ஷ</span> (<span class='lang2'>ஷ</span> is typed with two keystrokes, and <span class='lang2'>ஸ்ரீ</span> with three) and the Aytham <span class='lang2'>ஃ</span> mark.
@@ -311,8 +310,8 @@ There are two ways of entering this character: <span class='keys'>Sri</span> or 
   </tr>
   </table>
 
-<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.    
-Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>   
+<p style='margin-top: 4px'>The easiest ways to deal with this are to move the cursor and press Backspace to delete the unwanted Pulli mark, or else enable the <span style='font-weight:bold'>Text Services Framework Add-In</span> if you are using Keyman Desktop Professional.
+Disabling <span style='font-style:italic'>Tamil language editing</span> in <span style='font-style:italic'>Microsoft Office Language Settings</span> will also correct the input behaviour, but this is not recommended, as it makes selection of fonts more difficult.</p>
 </div>
 <h4> Fonts</h4>
 <p>This keyboard allows only the standard Tamil characters, so will work with the fonts supplied with Windows.  No further downloads of fonts should be required.</p>

--- a/legacy/e/ekwunitamil/source/help/srii/tamil_srii.php
+++ b/legacy/e/ekwunitamil/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ls/1.0/greek_polytonic_ls.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ls/1.0/greek_polytonic_ls.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic SA';
   $pagetitle = 'Greek Polytonic SA';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ls_ez/1.0/greek_polytonic_ls_ez.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ls_ez/1.0/greek_polytonic_ls_ez.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic LS EZ';
   $pagetitle = 'Greek Polytonic LS EZ';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ls_mt/1.0/greek_polytonic_ls_mt.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ls_mt/1.0/greek_polytonic_ls_mt.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic LS MT';
   $pagetitle = 'Greek Polytonic LS MT';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ms/1.0/greek_polytonic_ms.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ms/1.0/greek_polytonic_ms.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic MS';
   $pagetitle = 'Greek Polytonic MS';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ms_ez/1.0/greek_polytonic_ms_ez.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ms_ez/1.0/greek_polytonic_ms_ez.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic MS EZ';
   $pagetitle = 'Greek Polytonic MS EZ';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_ms_mt/1.0/greek_polytonic_ms_mt.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_ms_mt/1.0/greek_polytonic_ms_mt.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic MS MT';
   $pagetitle = 'Greek Polytonic MS MT';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_sa/1.0/greek_polytonic_sa.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_sa/1.0/greek_polytonic_sa.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic SA';
   $pagetitle = 'Greek Polytonic SA';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_sa_ez/1.0/greek_polytonic_sa_ez.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_sa_ez/1.0/greek_polytonic_sa_ez.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic SA EZ';
   $pagetitle = 'Greek Polytonic SA EZ';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/g/greek polytonic sa/extra/greek_polytonic_sa_mt/1.0/greek_polytonic_sa_mt.php
+++ b/legacy/g/greek polytonic sa/extra/greek_polytonic_sa_mt/1.0/greek_polytonic_sa_mt.php
@@ -1,9 +1,8 @@
 <?php
-  require_once('servervars.php');
   $pagename = 'Greek Polytonic SA MT';
   $pagetitle = 'Greek Polytonic SA MT';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
 ?>
 <style><!--
@@ -286,506 +285,506 @@ ul
 
   <div align="center">
     <table width="80%" border="0" align="center">
-      <tr> 
+      <tr>
         <td><p class=MsoNormal align=center style='text-align:center;line-height:normal'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'><img width=351 height=90
 id="_x0000_i1025" src=Header.gif
 alt="Saint Anthony's Greek Orthodox Monastery-Greek Polytonic SA" border=0></span></font></p>
-          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER 
+          <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><u7:p></u7:p>USER
             MANUAL</span></font></p>
           <p class=MsoTitle><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:12.0pt;mso-ansi-language:
 EN-US;text-decoration:none;text-underline:none'>(Greek Polytonic SA version 1.0)</span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONTENTS"></a>CONTENTS<u7:p></u7:p></span></font></h1>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_BRIEF_INTRODUCTION">Brief Introduction</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_GREEK_POLYTONIC_SA"><b>Greek Polytonic SA</b> Keyboard Package</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l2 level1 lfo1;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TAVULTESOFT_KEYMAN">Tavultesoft Keyman Desktop 7.0</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_INSTALLATION_NOTES">Installation Notes</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
             Windows</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
-href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office 
+href="#_TEXT_SERVICES_FRAMEWORK">Text Services Framework (TSF) – Microsoft® Office
             XP</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l0 level1 lfo3;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_MICROSOFT_WORD_OPTIONS">Important Microsoft® Word Options</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_CONFIGURING_KEYMAN_KEYBOARDS">Configuring Keyman Keyboards</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='color:blue;mso-ansi-language:EN-US'><a
 href="#_KEYBOARD_FEATURES"><b>Greek Polytonic SA</b> - Keyboard Features</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <u><span lang=EN-US style='mso-ansi-language:
 EN-US'><a href="#_KEYBOARD_RULES">Keyboard Rules</a></span></u></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
-EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard 
+EN-US'><a href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard
             Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l6 level1 lfo5;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span></span></span> <span lang=EN-US style='color:blue;mso-ansi-language:
 EN-US'><a href="#_MT_KEYBOARD_CATEGORY">MT Keyboard Category</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_TYPING_POLYTONIC_GREEK">Typing Polytonic Greek</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span lang=EN-US style='mso-ansi-language:EN-US'><a
 href="#_SAVING_POLYTONIC_GREEK">Saving Polytonic Greek Documents</a></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>-</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a> 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a href="#_COPYRIGHT">Copyright</a>
             </span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_BRIEF_INTRODUCTION"></a>BRIEF
             INTRODUCTION</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_POLYTONIC_SA"></a>GREEK
             POLYTONIC SA KEYBOARD PACKAGE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for 
-            efficiently entering Greek Polytonic “Unicode” characters in Microsoft® 
-            Windows (for information on the Unicode Standard 
-            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work 
-            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            <b>Greek Polytonic SA</b> keyboard package contains “keyboards” for
+            efficiently entering Greek Polytonic “Unicode” characters in Microsoft®
+            Windows (for information on the Unicode Standard
+            please visit <a target="_blank" href="http://www.unicode.org/">http://www.unicode.org</a>). The keyboards work
+            under the Tavultesoft "Keyman Desktop 7.0" program which you must have installed
             and running for these keyboards to function.<u7:p></u7:p></span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three 
-            keyboard layouts are available which you can view by clicking on the 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Three
+            keyboard layouts are available which you can view by clicking on the
             links, below:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> – 
-            a simple keyboard layout recommended for those who have never typed 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20SA%20Keyboard%20Layout.gif">SA Keyboard Layout</a> –
+            a simple keyboard layout recommended for those who have never typed
             Greek on their computer before.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> – 
-            a simple keyboard layout which resembles Microsoft’s Greek keyboard 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20MS%20Keyboard%20Layout.gif">MS Keyboard Layout</a> –
+            a simple keyboard layout which resembles Microsoft’s Greek keyboard
             layout, recommended for those who already type monotonic Greek.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> – 
-            an improved replica of Linguist Software’s “US-transliterated” keyboard 
-            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package 
-            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for 
-            more information). This keyboard is NOT recommended for new users, 
-            since the same functionality is provided in the above two, simpler, 
-            keyboard layouts. However, it does provide some extra Ancient Greek 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'><a target="_blank" href="Greek%20Polytonic%20LS%20Keyboard%20Layout.gif">LS Keyboard Layout</a> –
+            an improved replica of Linguist Software’s “US-transliterated” keyboard
+            layout for their “<span class=SpellE>LaserGreek®II</span>” fonts package
+            (see <a target="_blank" href="http://www.linguistsoftware.com/">http://www.linguistsoftware.com</a> for
+            more information). This keyboard is NOT recommended for new users,
+            since the same functionality is provided in the above two, simpler,
+            keyboard layouts. However, it does provide some extra Ancient Greek
             characters and diacritics used for Classical studies.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            three keyboard layouts, above, are further subdivided into the following 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            three keyboard layouts, above, are further subdivided into the following
             three categories, depending on your typing preference:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Default</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout 
+lang=EN-US style='mso-ansi-language:EN-US'> – the default keyboard, for each layout
             described above, allows you to type polytonic Greek characters.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“<span class=SpellE>EZ</span>”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of 
+lang=EN-US style='mso-ansi-language:EN-US'> – further simplifies the typing of
             polytonic Greek by automatically adding a smooth breathing mark (<span
-class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark 
+class=SpellE>psili</span> - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark
             (<span
-class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning 
+class=SpellE>dasia</span> - ῾ ) to η, ι, υ and ρ—when they come at the beginning
             of a word—plus other combinations: <span class=SpellE>αὐ</span>, <span
-class=SpellE>εὐ</span>, etc. Also several common words have been added that are 
-            automatically corrected when the space-bar is pressed (for details 
+class=SpellE>εὐ</span>, etc. Also several common words have been added that are
+            automatically corrected when the space-bar is pressed (for details
             see “<span
 class=SpellE>AutoCorrection</span> of common words” under <a
 href="#_EZ_KEYBOARD_CATEGORY"><span class=SpellE>EZ</span> Keyboard Category</a>).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>“MT”</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
-            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά). 
-            These are two totally different “Unicode” characters which may also 
-            look different, depending on the font. This keyboard is included to 
-            aide those who need to type Greek on the Internet, or other monotonic 
+lang=EN-US style='mso-ansi-language:EN-US'> – same as the default, however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
+            (ά) instead of an alpha with an “<span class=SpellE>oxia</span>” (ά).
+            These are two totally different “Unicode” characters which may also
+            look different, depending on the font. This keyboard is included to
+            aide those who need to type Greek on the Internet, or other monotonic
             Greek programs.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard layouts, shown in “.gif” format, are also available 
-            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high 
-            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard layouts, shown in “.gif” format, are also available
+            in Adobe® Acrobat “.<span class=SpellE>pdf</span>” format, for high
+            quality printing, under Start > Programs > Greek Polytonic SA > Keyboard
             Layouts (.<span
 class=SpellE>pdf</span>).</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TAVULTESOFT_KEYMAN" id="_TAVULTESOFT_KEYMAN"></a>TAVULTESOFT
             KEYMAN DESKTOP 7.0</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Tavultesoft “Keyman Desktop 7.0” program must be installed <b>before </b>you
             can install and use the <b>Greek Polytonic SA</b> keyboard package.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman 
-            fully integrates into Microsoft® Windows, giving the user a flexible 
-            and convenient means for activating and using the installed “keyboards” 
-            in a wide number of applications. These features are completely described 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Keyman
+            fully integrates into Microsoft® Windows, giving the user a flexible
+            and convenient means for activating and using the installed “keyboards”
+            in a wide number of applications. These features are completely described
             in the Help file provided with Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One 
-            of Keyman’s best features is its ability to work with Microsoft’s 
-            Text Services Framework (TSF) which. With TSF enabled, the Keyman program 
-            is constantly aware of the characters around the cursor, which means 
-            you can freely edit a document using a Keyman keyboard. However, when 
-            typing using Keyman’s native typing mode (non-TSF), the Keyman program 
-            keeps track of the characters which you type <b>until</b> you either 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>One
+            of Keyman’s best features is its ability to work with Microsoft’s
+            Text Services Framework (TSF) which. With TSF enabled, the Keyman program
+            is constantly aware of the characters around the cursor, which means
+            you can freely edit a document using a Keyman keyboard. However, when
+            typing using Keyman’s native typing mode (non-TSF), the Keyman program
+            keeps track of the characters which you type <b>until</b> you either
             press an arrow key or click the mouse (which clears Keyman’s memory).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For 
-            the latest version of Keyman Desktop you may visit Tavultesoft’s 
-            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>. 
-            Please note that the Keyman program is covered under a separate 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>For
+            the latest version of Keyman Desktop you may visit Tavultesoft’s
+            Keyman website at <a href="http://www.tavultesoft.com/keyman/">http://www.tavultesoft.com/keyman</a>.
+            Please note that the Keyman program is covered under a separate
             license than the <b>Greek Polytonic SA </b>package.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_INSTALLATION_NOTES"></a>INSTALLATION
             NOTES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_GREEK_MULTILANGUAGE_SUPPORT" id="_GREEK_MULTILANGUAGE_SUPPORT"></a>GREEK/MULTILANGUAGE
             SUPPORT IN MICROSOFT® WINDOWS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It 
-            is not necessary for you to install “Greek” (Multilanguage) support 
-            on your Microsoft® Windows computer to use the <b>Greek Polytonic 
-            SA</b> keyboard package. However, you may wish to install support 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>It
+            is not necessary for you to install “Greek” (Multilanguage) support
+            on your Microsoft® Windows computer to use the <b>Greek Polytonic
+            SA</b> keyboard package. However, you may wish to install support
             for Greek for the following reasons:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate 
-            a Keyman keyboard with any language installed on your computer so 
-            that switching to that language (commonly using the Alt-Shift combination) 
-            will activate the keyboard. The language does not have to be “Greek”, 
-            but it “looks” nicer if you switch to the language that you are actually 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You can associate
+            a Keyman keyboard with any language installed on your computer so
+            that switching to that language (commonly using the Alt-Shift combination)
+            will activate the keyboard. The language does not have to be “Greek”,
+            but it “looks” nicer if you switch to the language that you are actually
             working in.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft® 
-            Office programs, such as Word, “mark” text with the name of the language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>Microsoft®
+            Office programs, such as Word, “mark” text with the name of the language
             being used while you are typing.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most 
-            likely you already have Greek support for your computer, however if 
-            you are unfamiliar with the installing and changing languages in Windows, 
-            please refer to your Microsoft® Window’s Help manual located under 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Most
+            likely you already have Greek support for your computer, however if
+            you are unfamiliar with the installing and changing languages in Windows,
+            please refer to your Microsoft® Window’s Help manual located under
             Start > Help and search using the word “language”.</span></font></p>
           <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><b><span lang=EN-US style='mso-ansi-language:EN-US'>Note:</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language 
-            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then 
-            you must make sure that the underlying “keyboard layout<b>”</b> that 
-            you associate with the language is either “US” or “Greek” for the 
+lang=EN-US style='mso-ansi-language:EN-US'> if you install a particular language
+            that you plan to use with a <b>Greek Polytonic SA </b>keyboard, then
+            you must make sure that the underlying “keyboard layout<b>”</b> that
+            you associate with the language is either “US” or “Greek” for the
             <b>Greek Polytonic SA </b>keyboards to function properly. </span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TEXT_SERVICES_FRAMEWORK"></a>TEXT
             SERVICES FRAMEWORK (TSF) – MICROSOFT® OFFICE</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available. 
-            If not, you can install this feature through your Microsoft® Office 
-            Installation disk by selecting the following installation option: 
-            Office Shared Features, Alternative User Input (note that neither 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you have <b>Microsoft® Word XP</b> or later installed on your computer you should have the “Text Services” menu available.
+            If not, you can install this feature through your Microsoft® Office
+            Installation disk by selecting the following installation option:
+            Office Shared Features, Alternative User Input (note that neither
             Speech nor Handwriting recognition needs to be selected).</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you wish to install TSF at a later time, you will have to run the 
-            Keyman installation program again to install the special <b>Text Services 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you wish to install TSF at a later time, you will have to run the
+            Keyman installation program again to install the special <b>Text Services
             Framework Add-in</b> that comes with Keyman.</span></font></p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MICROSOFT_WORD_OPTIONS"></a>IMPORTANT
             MICROSOFT® WORD OPTIONS</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There 
-            are a few Microsoft® Word options which will cause you much grief 
-            if you do not disable them before using the <b>Greek Polytonic SA</b> 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>There
+            are a few Microsoft® Word options which will cause you much grief
+            if you do not disable them before using the <b>Greek Polytonic SA</b>
             keyboards:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft® 
-            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You 
-            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”. 
-            On the English versions of Microsoft® Word 2000 and XP—believe it 
-            or not—this option enables/disables Microsoft® Word’s automatic correction 
-            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note 
-            that all of the <b>Greek Polytonic SA </b>keyboards already include 
-            this sigma correction feature; however Microsoft® Word’s sigma feature 
-            results in a conflict which will produce frequent typing errors when 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>In Microsoft®
+            Word select the Tools menu, AutoCorrect Options…, AutoFormat As You
+            Type, and <b>uncheck</b> the option labeled “Ordinals (1st) with superscript”.
+            On the English versions of Microsoft® Word 2000 and XP—believe it
+            or not—this option enables/disables Microsoft® Word’s automatic correction
+            of the Greek sigma (σ) to a final sigma (ς). <span class=GramE>Note
+            that all of the <b>Greek Polytonic SA </b>keyboards already include
+            this sigma correction feature; however Microsoft® Word’s sigma feature
+            results in a conflict which will produce frequent typing errors when
             typing polytonic Greek.</span></span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should 
-            also turn off the “Auto-Keyboard switching” option located under Tools, 
-            Options…, Edit. This option may cause the keyboard to switch unexpectedly, 
-            when you hit the backspace key, if your Word document’s default language 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>You should
+            also turn off the “Auto-Keyboard switching” option located under Tools,
+            Options…, Edit. This option may cause the keyboard to switch unexpectedly,
+            when you hit the backspace key, if your Word document’s default language
             is different than the language you are typing in.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_CONFIGURING_KEYMAN_KEYBOARDS"></a>CONFIGURING
             KEYMAN DESKTOP KEYBOARDS<u7:p></u7:p></span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            Keyman Desktop icon in the Taskbar provides all of the necessary functions 
-            you need to setup and use the Keyman program. If it is not already 
-            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            Keyman Desktop icon in the Taskbar provides all of the necessary functions
+            you need to setup and use the Keyman program. If it is not already
+            visible, then you can start Keyman by clicking Start > Programs > Tavultesoft
             Keyman > Keyman.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
-            configure Keyman, click on the “Keyman Configuration” menu item and 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
+            configure Keyman, click on the “Keyman Configuration” menu item and
             follow these recommendations:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard Layouts</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards 
-            that you don’t plan to use. Also, you can assign Windows “hotkeys” 
+lang=EN-US style='mso-ansi-language:EN-US'> tab – here you can “turn off” keyboards
+            that you don’t plan to use. Also, you can assign Windows “hotkeys”
             for a particular keyboard that you plan to use often.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Options
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – the options we recommend
             you enable are:</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Keyboard
             hotkeys toggle keyboard activation</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in;
 mso-list:l4 level1 lfo7;tab-stops:list 1.25in'> <font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-fareast-font-family:"Palatino Linotype";mso-bidi-font-family:
 "Palatino Linotype";mso-ansi-language:EN-US'><span style='mso-list:Ignore'>•<span
-style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start 
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span></span></span> <span lang=EN-US style='mso-ansi-language:EN-US'>Start
             when Windows starts</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Languages
             </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you 
+lang=EN-US style='mso-ansi-language:EN-US'>tab – if you have determined that you
             want to assign the keyboard to a particular language (see <u><a
-href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft® 
-            Windows</a></u>, above) then select a Keyman keyboard for any of the 
-            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic 
-            SA </b>keyboards should only be selected if the <b>Layout</b> is “US” 
+href="#_GREEK_MULTILANGUAGE_SUPPORT">Greek/Multilanguage Support in Microsoft®
+            Windows</a></u>, above) then select a Keyman keyboard for any of the
+            Language/Layout combinations listed. (Note: that the <b>Greek Polytonic
+            SA </b>keyboards should only be selected if the <b>Layout</b> is “US”
             or “Greek”, for correct results)</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click 
-            on <b>OK</b> when you have finished configuring Keyman and the changes 
-            will be saved to your computer. The next section will help you start 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>Click
+            on <b>OK</b> when you have finished configuring Keyman and the changes
+            will be saved to your computer. The next section will help you start
             typing Polytonic Greek on your computer.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_FEATURES"></a>GREEK
             POLYTONIC SA - KEYBOARD FEATURES</span></font></h1>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_KEYBOARD_RULES"></a>KEYBOARD
             RULES</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            following rules apply to all keyboards in the <b>Greek Polytonic SA 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            following rules apply to all keyboards in the <b>Greek Polytonic SA
             </b>keyboard package:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Overstrike
             Keys</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which 
-            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο, 
-            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck 
-            <b>after</b> the letter which you want to add the diacritics, and 
-            they can be combined in any order to produce the desired combination 
-            (i.e. the cursor does not move, but the preceding character is changed 
-            into a new one). Pressing an Overstrike Key after a “space” replaces 
-            the “space” with the diacritic itself. If the resulting character 
-            does not exist in the Unicode Standard, then your computer will produce 
+lang=EN-US style='mso-ansi-language:EN-US'> – are the keys on the keyboard which
+            add the polytonic Greek diacritics to the letters: α, ε, η, ι, ο,
+            υ, ω, ρ and also a “space” character. The Overstrike Keys are struck
+            <b>after</b> the letter which you want to add the diacritics, and
+            they can be combined in any order to produce the desired combination
+            (i.e. the cursor does not move, but the preceding character is changed
+            into a new one). Pressing an Overstrike Key after a “space” replaces
+            the “space” with the diacritic itself. If the resulting character
+            does not exist in the Unicode Standard, then your computer will produce
             a “beep” sound and the original character will remain unchanged.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Late Overstrike</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic 
-            mark over a vowel which is followed by one or two consonants (ex. 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Overstrike Key produces a diacritic
+            mark over a vowel which is followed by one or two consonants (ex.
             “<span
-class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>” 
-            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace 
-            key, immediately following a Late Overstrike, results in the removal 
+class=SpellE>ἁλτ</span>” immediately followed by the “<span class=SpellE>oxia</span>”
+            key results in “<span class=SpellE>ἅλτ</span>”). Striking the Backspace
+            key, immediately following a Late Overstrike, results in the removal
             of the diacritic over the vowel.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining 
-            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the LS keyboard layout has keys designated to produce diacritics 
-            by themselves, normally typed behind a capital vowel. If a capital 
-            vowel is typed after any stand-alone diacritics, they are combined 
-            into one character, if the character exists in the Unicode Standard 
-            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span> 
-            ” followed by the capital omega “Ω” would result in the single character 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Combining
+            Diacritics (LS Keyboard Only)</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the LS keyboard layout has keys designated to produce diacritics
+            by themselves, normally typed behind a capital vowel. If a capital
+            vowel is typed after any stand-alone diacritics, they are combined
+            into one character, if the character exists in the Unicode Standard
+            (ex. <span class=SpellE>psili-oxia</span> <span class=GramE>“ ῎</span>
+            ” followed by the capital omega “Ω” would result in the single character
             “ Ὤ ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoSigma</span></b></span><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ” 
-            is automatically converted to a final sigma “ς” when the following 
-            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span> 
-            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”, 
-            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash 
+lang=EN-US style='mso-ansi-language:EN-US'> – the Greek small letter sigma “σ”
+            is automatically converted to a final sigma “ς” when the following
+            keys are pressed: Spacebar, Enter, Shift-Enter, Tab, Period “.”, <span class=SpellE>Ano-telia</span>
+            “·”, Comma “,”, Colon “:”, Question Mark “;”, Right Parenthesis “)”,
+            Right Bracket “]”, Right Curly Bracket “}”, <span class=SpellE>Em</span>-dash
             “—”, and Right Quotation Marks (», ’, and ”).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoQuotes</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> (SA and MS Keyboards Only) </span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts, 
-            there is a single key assigned to each of the following <b>quotation 
-            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation 
-            marks will be applied when required depending on the preceding character. 
-            In practice, it works almost as well as Microsoft® Word's “smart quotes” 
+lang=EN-US style='mso-ansi-language:EN-US'>– on the SA and MS keyboard layouts,
+            there is a single key assigned to each of the following <b>quotation
+            mark</b> combinations « », “ ”, and ‘ ’. In general, the correct quotation
+            marks will be applied when required depending on the preceding character.
+            In practice, it works almost as well as Microsoft® Word's “smart quotes”
             AutoCorrect feature.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Backspace
             Key</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes 
-            the diacritics over a preceding vowel, if they exist; otherwise the 
-            entire character is erased as is normally expected (ex. the character 
-            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace 
+lang=EN-US style='mso-ansi-language:EN-US'> – this Backspace key first removes
+            the diacritics over a preceding vowel, if they exist; otherwise the
+            entire character is erased as is normally expected (ex. the character
+            “ἄ” becomes “α” when the Backspace key is struck). By using Shift-Backspace
             the entire character is removed regardless of the diacritics.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Breathing
             marks over double “<span class=SpellE>Rhos</span>”</span></b><span lang=EN-US
 style='mso-ansi-language:EN-US'> – pressing the Greek letter <span
-class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span> 
-            “<span class=SpellE>ρρ</span>” results in breathing marks being applied 
+class=SpellE>rho</span> “ρ” a third time after two existing <span class=SpellE>rhos</span>
+            “<span class=SpellE>ρρ</span>” results in breathing marks being applied
             “<span
 class=SpellE>ῤῥ</span>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Greek Apostrophe
             (“<span
 class=SpellE>Koronis</span>”)</span></b><span lang=EN-US style='mso-ansi-language:
-EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended 
-            method is to first type a “space” followed by the “<span class=SpellE>psili</span>” 
-            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard 
-            categories, the character produced is the “<span class=SpellE>koronis</span>” 
-            character (U+1FBD) of the Greek Extended range of the Unicode Standard. 
-            On the MT (monotonic) keyboard category it produces the standard apostrophe 
-            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>” 
-            character was chosen over the “<span class=SpellE>psili</span>” character 
-            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed 
-            more appropriate than the former (in terms of a “standard” character) 
-            but blended in better with the surrounding characters than what the 
-            latter character does. To demonstrate this, compare the two phrases: 
+EN-US'> – to create an apostrophe in <b>Greek Polytonic SA</b>, the recommended
+            method is to first type a “space” followed by the “<span class=SpellE>psili</span>”
+            overstrike key. On the Default and <span class=SpellE>EZ</span> keyboard
+            categories, the character produced is the “<span class=SpellE>koronis</span>”
+            character (U+1FBD) of the Greek Extended range of the Unicode Standard.
+            On the MT (monotonic) keyboard category it produces the standard apostrophe
+            (U+0027). For those who are interested, the “<span class=SpellE>koronis</span>”
+            character was chosen over the “<span class=SpellE>psili</span>” character
+            (U+1FBF) and the “Right Single Quotation Mark” (U+2019) since it seemed
+            more appropriate than the former (in terms of a “standard” character)
+            but blended in better with the surrounding characters than what the
+            latter character does. To demonstrate this, compare the two phrases:
             <span class=SpellE>Δι</span>᾽ <span
 class=SpellE>εὐχῶν</span> (using the <span class=SpellE>koronis</span>) and <span
-class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation 
-            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>” 
+class=SpellE>Δι</span>’ <span class=SpellE>εὐχῶν</span> (using a single quotation
+            mark). None of the keyboards can produce the “<span class=SpellE>psili</span>”
             character by itself.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral 
-            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – the Unicode Standard assigns a special character code to the “Greek 
-            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”. 
-            On the SA and LS keyboards it is located on the Shift-V key, while 
-            on the MS keyboard it is located on the Shift-W key. Pressing these 
-            keys gives one of three results: 1) a Greek Numeral Sign is simply 
-            inserted at the cursor, 2) any diacritics are first removed from the 
-            preceding characters and then the Numeral Sign is inserted (required 
-            when using the <span class=SpellE>EZ</span> keyboard category), and 
-            3) any standard (Arabic) numerals behind the cursor (up to 9999) are 
-            converted to Greek Numerals, followed by the Numeral Sign. For numbers 
-            larger than 999, the “Lower Greek Numeral Sign” (which also has a 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Numeral
+            Key Special Features</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – the Unicode Standard assigns a special character code to the “Greek
+            Numeral Sign” which looks very similar to the “<span class=SpellE>oxia</span>”.
+            On the SA and LS keyboards it is located on the Shift-V key, while
+            on the MS keyboard it is located on the Shift-W key. Pressing these
+            keys gives one of three results: 1) a Greek Numeral Sign is simply
+            inserted at the cursor, 2) any diacritics are first removed from the
+            preceding characters and then the Numeral Sign is inserted (required
+            when using the <span class=SpellE>EZ</span> keyboard category), and
+            3) any standard (Arabic) numerals behind the cursor (up to 9999) are
+            converted to Greek Numerals, followed by the Numeral Sign. For numbers
+            larger than 999, the “Lower Greek Numeral Sign” (which also has a
             key assigned) is automatically inserted for the latter case.</span></font></p>
           <h2><font face="Palatino Linotype, AA Times New Roman"><span class=SpellE><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_EZ_KEYBOARD_CATEGORY"></a>EZ</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'> KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The 
-            above keyboard rules generally apply to all of the keyboards contained 
-            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>The
+            above keyboard rules generally apply to all of the keyboards contained
+            in the <b>Greek Polytonic SA</b> keyboard package, with some exceptions
             noted. The <span
-class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing 
+class=SpellE>EZ</span> keyboard category generally affects polytonic Greek typing
             in the following two ways:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic 
-            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – as mentioned in the introduction, the <span class=SpellE>EZ</span> 
-            keyboard category further simplifies the typing of polytonic Greek 
-            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span> 
-            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span> 
-            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word. 
-            The same also follows for their respective capital letters. As other 
-            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>, 
-            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>, 
-            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding 
-            characters change accordingly. Also striking the Backspace key after 
-            a combination can also have different results: for example <span class=SpellE>αὐ</span> 
-            becomes <span class=SpellE>ἀυ</span>. This feature is not intended 
-            to completely replace user input during the typing of polytonic Greek, 
-            but rather to minimize the use of the breathing mark overstrike keys 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Automatic
+            Breathing Marks</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – as mentioned in the introduction, the <span class=SpellE>EZ</span>
+            keyboard category further simplifies the typing of polytonic Greek
+            by automatically adding a smooth breathing mark (<span class=SpellE>psili</span>
+            - ᾽ ) to α, ε, ο, and ω, and a rough breathing mark (<span class=SpellE>dasia</span>
+            - ῾ ) to η, ι, υ and ρ, when they come at the beginning of a word.
+            The same also follows for their respective capital letters. As other
+            combinations are formed with additional vowels (<span class=SpellE>αὐ</span>,
+            <span class=SpellE>εὐ</span>, etc.) or overstrike keys (<span class=SpellE>ἀϋ</span>,
+            <span class=SpellE>ἀϊ</span>, etc.) in their natural order, the preceding
+            characters change accordingly. Also striking the Backspace key after
+            a combination can also have different results: for example <span class=SpellE>αὐ</span>
+            becomes <span class=SpellE>ἀυ</span>. This feature is not intended
+            to completely replace user input during the typing of polytonic Greek,
+            but rather to minimize the use of the breathing mark overstrike keys
             during normal typing.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing 
-            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'> 
-            – to type a series of capital letters using the <span class=SpellE>EZ</span> 
-            keyboard category, you must activate the Caps Lock key. This prevents 
-            the addition of diacritics to a leading capital letter, as described 
-            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span> 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><b><span lang=EN-US style='mso-ansi-language:EN-US'>Typing
+            Capital Letters</span></b><span lang=EN-US style='mso-ansi-language:EN-US'>
+            – to type a series of capital letters using the <span class=SpellE>EZ</span>
+            keyboard category, you must activate the Caps Lock key. This prevents
+            the addition of diacritics to a leading capital letter, as described
+            in the latter section, if it happens to be a vowel or the letter <span class=SpellE>rho</span>
             “</span>Ρ<span
 lang=EN-US style='mso-ansi-language:EN-US'>”.</span></font></p>
           <p class=stylefirstline025 style='margin-left:.8in;text-indent:-.2in'><font face="Palatino Linotype, AA Times New Roman">-<span
-lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+lang=EN-US style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span class=SpellE><b><span lang=EN-US style='mso-ansi-language:EN-US'>AutoCorrection</span></b></span><b><span
 lang=EN-US style='mso-ansi-language:EN-US'> of common words</span></b><span
-lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following 
-            table are automatically corrected upon striking the Spacebar. The 
-            words shown with an asterisk (*) indicates that a “new word character”—i.e. 
-            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>. 
-            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>, 
-            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span> 
-            the preceding word. Note that the list includes all of the definite 
-            articles, as well as common words such as <span class=SpellE>καὶ</span>, 
+lang=EN-US style='mso-ansi-language:EN-US'> – the words shown in the following
+            table are automatically corrected upon striking the Spacebar. The
+            words shown with an asterisk (*) indicates that a “new word character”—i.e.
+            space, [, (, «, etc.—must precede word for it to be <span class=SpellE>AutoCorrected</span>.
+            Using the Backspace key undoes the <span class=SpellE>AutoCorrection</span>,
+            and Shift-Spacebar adds a space without <span class=SpellE>AutoCorrecting</span>
+            the preceding word. Note that the list includes all of the definite
+            articles, as well as common words such as <span class=SpellE>καὶ</span>,
             <span
 class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></font></p>
-          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp; 
+          <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>&nbsp;
             </span></font></p>
           <table border=0 align="center" cellpadding=0 cellspacing=0 class=MsoNormalTable
  style='border-collapse:collapse;mso-padding-alt:0in 0in 0in 0in'>
-            <tr style='mso-yfti-irow:0'> 
+            <tr style='mso-yfti-irow:0'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὀ=ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
@@ -797,7 +796,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
               <td width=142 valign=top style='width:106.85pt;border:solid windowtext 1.0pt;
   border-left:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*του=τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:1'> 
+            <tr style='mso-yfti-irow:1'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τησ=τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -813,7 +812,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῆ=τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:2'> 
+            <tr style='mso-yfti-irow:2'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τῃ=τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -829,7 +828,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τουσ=τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:3'> 
+            <tr style='mso-yfti-irow:3'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τους=τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -845,7 +844,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*τοις=τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:4'> 
+            <tr style='mso-yfti-irow:4'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*ταισ=ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -861,7 +860,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*των=τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:5'> 
+            <tr style='mso-yfti-irow:5'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*και=καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -877,7 +876,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*για=γιὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:6'> 
+            <tr style='mso-yfti-irow:6'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ὠσ=ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -893,7 +892,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προσ=πρὸς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:7'> 
+            <tr style='mso-yfti-irow:7'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προς=πρὸς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -909,7 +908,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀντι=ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:8'> 
+            <tr style='mso-yfti-irow:8'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀπο=ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -925,7 +924,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*περι=περὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:9'> 
+            <tr style='mso-yfti-irow:9'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*προ=πρὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -941,7 +940,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πλην=πλὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:10'> 
+            <tr style='mso-yfti-irow:10'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*που=ποῦ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -957,7 +956,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">ἀς=ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:11'> 
+            <tr style='mso-yfti-irow:11'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*θα=θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -973,7 +972,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στην=στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:12'> 
+            <tr style='mso-yfti-irow:12'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στο=στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -989,7 +988,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στισ=στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:13'> 
+            <tr style='mso-yfti-irow:13'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στις=στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1005,7 +1004,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*στων=στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:14'> 
+            <tr style='mso-yfti-irow:14'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*πωσ=πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1021,7 +1020,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">*μην=μὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:15'> 
+            <tr style='mso-yfti-irow:15'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὀ=Ὁ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1037,7 +1036,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Του=Τοῦ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:16'> 
+            <tr style='mso-yfti-irow:16'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τησ=Τῆς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1053,7 +1052,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῆ=Τῇ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:17'> 
+            <tr style='mso-yfti-irow:17'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τῃ=Τῇ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1069,7 +1068,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τουσ=Τοὺς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:18'> 
+            <tr style='mso-yfti-irow:18'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τους=Τοὺς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1085,7 +1084,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Τοις=Τοῖς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:19'> 
+            <tr style='mso-yfti-irow:19'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ταισ=Ταῖς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1101,7 +1100,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Των=Τῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:20'> 
+            <tr style='mso-yfti-irow:20'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Και=Καὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1117,7 +1116,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠσ=Ὡς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:21'> 
+            <tr style='mso-yfti-irow:21'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ὠς=Ὡς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1133,7 +1132,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ἐως=Ἕως</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:22'> 
+            <tr style='mso-yfti-irow:22'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Εωσ=Ἕως</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1149,7 +1148,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Κατα=Κατὰ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:23'> 
+            <tr style='mso-yfti-irow:23'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Μετα=Μετὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1165,7 +1164,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Αντι=Ἀντὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:24'> 
+            <tr style='mso-yfti-irow:24'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Απο=Ἀπὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1181,7 +1180,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Επι=Ἐπὶ</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:25'> 
+            <tr style='mso-yfti-irow:25'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Περι=Περὶ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1197,7 +1196,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Συν=Σὺν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:26'> 
+            <tr style='mso-yfti-irow:26'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πλην=Πλὴν</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1213,7 +1212,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ο,τι=Ὅ,τι</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:27'> 
+            <tr style='mso-yfti-irow:27'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Οτι=Ὅτι</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1229,7 +1228,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Ας=Ἂς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:28'> 
+            <tr style='mso-yfti-irow:28'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Θα=Θὰ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1245,7 +1244,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στην=Στὴν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:29'> 
+            <tr style='mso-yfti-irow:29'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στο=Στὸ</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1261,7 +1260,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στισ=Στὶς</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:30'> 
+            <tr style='mso-yfti-irow:30'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στις=Στὶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1277,7 +1276,7 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;
   padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Στων=Στῶν</font></p></td>
             </tr>
-            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'> 
+            <tr style='mso-yfti-irow:31;mso-yfti-lastrow:yes'>
               <td width=142 valign=top style='width:106.8pt;border:solid windowtext 1.0pt;
   border-top:none;padding:0in 5.4pt 0in 5.4pt'> <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman">Πωσ=Πῶς</font></p></td>
               <td width=142 valign=top style='width:106.8pt;border-top:none;border-left:
@@ -1297,118 +1296,118 @@ class=SpellE>γιὰ</span>, <span class=SpellE>ἀντὶ</span>, etc.</span></
             </tr>
           </table>
           <p class=MsoNormal>&nbsp;</p>
-          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT 
+          <h2><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_MT_KEYBOARD_CATEGORY"></a>MT
             KEYBOARD CATEGORY</span></font></h2>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As 
-            stated in the introduction, the MT keyboard category uses the same 
-            keyboard layout as the <span class=GramE>default,</span> however it 
-            produces “monotonic” Greek characters. For example, this keyboard 
-            variation produces an alpha with a “<span class=SpellE>tonos</span>” 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>As
+            stated in the introduction, the MT keyboard category uses the same
+            keyboard layout as the <span class=GramE>default,</span> however it
+            produces “monotonic” Greek characters. For example, this keyboard
+            variation produces an alpha with a “<span class=SpellE>tonos</span>”
             (ά) instead of an alpha with an “<span
-class=SpellE>oxia</span>” (ά), which are two totally different characters according 
-            to the Unicode Standard. The polytonic Greek characters (except for 
-            the <span class=SpellE>oxia</span>) can also be typed using this keyboard, 
-            but it is not recommend, since the monotonic Greek characters don't 
+class=SpellE>oxia</span>” (ά), which are two totally different characters according
+            to the Unicode Standard. The polytonic Greek characters (except for
+            the <span class=SpellE>oxia</span>) can also be typed using this keyboard,
+            but it is not recommend, since the monotonic Greek characters don't
             always blend <span
-class=GramE>in</span> with their polytonic Greek counterparts, depending on the 
-            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>” 
-            keyboard combination results in an “apostrophe” while the polytonic 
-            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This 
-            keyboard is included to aide those who need to type Greek on the Internet, 
-            or other monotonic Greek programs, without their having to change 
+class=GramE>in</span> with their polytonic Greek counterparts, depending on the
+            font. As well, as mentioned above, the “space” plus “<span class=SpellE>psili</span>”
+            keyboard combination results in an “apostrophe” while the polytonic
+            Greek keyboards generate a “<span class=SpellE>koronis</span>”. This
+            keyboard is included to aide those who need to type Greek on the Internet,
+            or other monotonic Greek programs, without their having to change
             keyboard layouts<span
 class=GramE>..</span></span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_TYPING_POLYTONIC_GREEK"></a>TYPING
             POLYTONIC GREEK</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>To
             begin typing polytonic Greek use the following steps as a guide:</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>1.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure 
+lang=EN-US style='mso-ansi-language:EN-US'>Start the Keyman Desktop program and make sure
             the Keyman icon is visible in the Taskbar</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>2.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts 
+lang=EN-US style='mso-ansi-language:EN-US'>Open a text editor program that accepts
             Unicode characters (ex. Microsoft® Word, WordPad, etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>3.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor 
-            to a Unicode font that contains polytonic Greek characters (ex. AA 
-            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available 
+lang=EN-US style='mso-ansi-language:EN-US'>Change the font in your text editor
+            to a Unicode font that contains polytonic Greek characters (ex. AA
+            Times New Roman, Arial Unicode MS, Palatino Linotype, Tahoma [available
             with Windows XP, Service Pack 1], etc.)</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>4.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either: 
+lang=EN-US style='mso-ansi-language:EN-US'>Select a Keyman keyboard by either:
             </span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>a</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in 
+lang=EN-US style='mso-ansi-language:EN-US'>clicking on the Keyman icon in
             the Taskbar and selecting a keyboard,</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>b</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
-lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey” 
+lang=EN-US style='mso-ansi-language:EN-US'>pressing a pre-configured “hotkey”
             (assigned via Keyman Configuration), and/or</span></font></p>
           <p class=stylefirstline025 style='margin-left:1.25in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 class=GramE><span lang=EN-US style='mso-ansi-language:EN-US'>c</span></span><span
 lang=EN-US style='mso-ansi-language:EN-US'>.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to 
-            a Language which has an assigned Keyman keyboard (usually the Alt-Shift 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </span><span lang=EN-US style='mso-ansi-language:EN-US'>changing to
+            a Language which has an assigned Keyman keyboard (usually the Alt-Shift
             keyboard combination).</span></font></p>
           <p class=stylefirstline025 style='margin-left:.75in;text-indent:-.25in'><font face="Palatino Linotype, AA Times New Roman"><span
 lang=EN-US style='mso-ansi-language:EN-US'>5.</span><span lang=EN-US
-style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+style='font-size:7.0pt;mso-ansi-language:EN-US'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             </span><span
 lang=EN-US style='mso-ansi-language:EN-US'>Type polytonic Greek!</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
-          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING 
+          <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_SAVING_POLYTONIC_GREEK"></a>SAVING
             POLYTONIC GREEK DOCUMENTS</span></font></h1>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When 
-            saving a polytonic Greek file, make sure that it is <b>encoded</b> 
-            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7 
-            also works). Saving a polytonic Greek file into any other encoding 
-            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY 
-            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may 
-            be saved as “?” [<span class=GramE>unknown</span>] characters). This 
-            is generally not a problem for Microsoft® Word and other newer text 
-            editors which automatically handle Unicode encoding when saving documents. 
-            However, this is important if you are typing in simpler programs like 
-            Windows <b>Notepad</b>, or if you are using common programs for sending 
-            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions 
-            of Microsoft® Windows) then make sure that the document is saved as 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>When
+            saving a polytonic Greek file, make sure that it is <b>encoded</b>
+            as “Unicode” (most common is UTF-8 encoding standard, although UTF-7
+            also works). Saving a polytonic Greek file into any other encoding
+            scheme (ex. “Windows Greek”, which is only for monotonic text) MAY
+            RESULT IN CORRUPTED TEXT (i.e. the polytonic Greek characters may
+            be saved as “?” [<span class=GramE>unknown</span>] characters). This
+            is generally not a problem for Microsoft® Word and other newer text
+            editors which automatically handle Unicode encoding when saving documents.
+            However, this is important if you are typing in simpler programs like
+            Windows <b>Notepad</b>, or if you are using common programs for sending
+            <b>e-mail</b>. If you are using <b>WordPad</b> (available in all versions
+            of Microsoft® Windows) then make sure that the document is saved as
             <b>Rich Text</b> so the text will be saved correctly.</span></font></p>
-          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If 
-            you are using a text editor that you are not familiar with, first 
-            experiment by typing a few words of polytonic Greek text. Then save 
-            the file, close the text editor, and then reopen the text editor and 
-            the file you just saved. If the text in the reopened file does not 
-            look the same as the text you originally typed, try typing a new text 
+          <p class=stylefirstline025><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'>If
+            you are using a text editor that you are not familiar with, first
+            experiment by typing a few words of polytonic Greek text. Then save
+            the file, close the text editor, and then reopen the text editor and
+            the file you just saved. If the text in the reopened file does not
+            look the same as the text you originally typed, try typing a new text
             string and save it using a different encoding.</span></font></p>
           <p class=MsoNormal><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='font-size:8.0pt;mso-ansi-language:
 EN-US'><a href="#_CONTENTS">(Back to Contents)</a><u7:p></u7:p></span></font></p>
           <h1><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US style='mso-ansi-language:EN-US'><a name="_COPYRIGHT"></a>COPYRIGHT</span></font></h1>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package 
+style='mso-ansi-language:EN-US'>Greek Polytonic SA - Unicode Keyboard Package
             for “Keyman Desktop 7.0”</span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
-style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox 
+style='mso-ansi-language:EN-US'>Copyright© 2004 Saint Anthony’s Greek Orthodox
             Monastery<u7:p></u7:p><u6:p></u6:p></span></font></p>
           <p class=MsoNormal align=center style='text-align:center'><font face="Palatino Linotype, AA Times New Roman"><span lang=EN-US
 style='mso-ansi-language:EN-US'>4784 N. St. Joseph’s Way,<u7:p></u7:p><u6:p></u6:p></span></font></p>

--- a/legacy/h/helabasauni/source/help/helabasauni.php
+++ b/legacy/h/helabasauni/source/help/helabasauni.php
@@ -1,30 +1,29 @@
 <?php /*
   Name:             keyboard_helabasauni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Helabasa Sinhala Keyboard Help';
   $pagetitle = 'Helabasa Sinhala Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   $relatedSites = array("http://www.helabasa.com" => "Sinhala Keyboards Home");
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 MyPC Computer Systems and Tavultesoft</p>
 
 <br/>
@@ -44,7 +43,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -94,7 +93,7 @@ For example, typing <span class='keys'>c</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>On the On Screen Keyboard you can see the 40 consonants <span class='lang2' style='font-size:200%'>ක ඛ ග ඝ ඞ හ ච ඡ ජ ඣ ඤ ට ඨ ඩ ඪ ණ ඬ ත ථ ද ධ න ඳ ප ඵ බ භ ම ඹ ය ර ල ව ළ ශ ෂ ස ඦ ඟ ෆ</span>, the vowels <span class='lang2' style='font-size:200%'>අ ආ ඇ ඈ ඉ ඊ උ ඌ ඍ ඎ එ ඒ ‌ඓ ඔ ඕ ඖ    ා ැ ෑ ි ී ු ූ ෘ ෲ ෙ ේ ෛ ො ෝ ෞ ං ඃ </span>, and the <span class='lang2' style='font-size:200%'>් ෴</span> marks.  There are also numbers and punctuation marks.</p>
 
 <p>When you type a consonant and a vowel part, the computer will automatically combine them to make one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if you typed the vowel before the consonant).
@@ -165,7 +164,7 @@ All the consonants naturally include the vowel sound <span class='highlightExamp
 		<td></td>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'></td><td></td>
 	</tr>
-	
+
 </table>
 
 </div>

--- a/legacy/isis/isis_bangla/source/help/chart.php
+++ b/legacy/isis/isis_bangla/source/help/chart.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_isis_bangla
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'ISIS Bangla Keyboard Help';
   $pagetitle = 'ISIS Bangla Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Gautam Sengupta</p>
 
 <br/>
@@ -43,7 +42,7 @@
 <!-- <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4> -->
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -90,7 +89,7 @@ If a special font is needed for this language, most computers will download it a
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the standalone vowels <span class='lang2' style='font-size:200%'>অ আ ই ঈ উ ঊ এ ঐ ও ঔ</span>, and many of the normal consonants: <span class='lang2' style='font-size:200%'>ক গ চ জ ট ড ণ ত দ ন প ব ম য় র ল ষ স হ ড়</span>.  Other consonants are typed using more than one key.  The keyboard also includes Bengali numbers, as well as punctuation and special characters.</p>
 
 <p>Bengali vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -149,7 +148,7 @@ If a special font is needed for this language, most computers will download it a
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ঔ</td><td class='lang2' style='font-size:200%'>কৌ</td><td><span class='keys'>kO</span></td>
 	</tr>
-	
+
 </table>
 
 </div>
@@ -793,7 +792,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >৯</span><br/><span class='keys'>9</span></td>
 		<td><span class='lang2' >০</span><br/><span class='keys'>0</span></td>
 	</tr>
-	
+
 	<tr style='text-align:center; font-weight:normal; background-color:#ffffff'>
 		<td colspan=13>&nbsp;</td>
 	</tr>
@@ -806,7 +805,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	</tr>
 
-	
+
 </table>
 
 

--- a/legacy/isis/isis_bangla/source/help/isis_bangla.php
+++ b/legacy/isis/isis_bangla/source/help/isis_bangla.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_isis_bangla
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'ISIS Bangla Keyboard Help';
   $pagetitle = 'ISIS Bangla Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Gautam Sengupta</p>
 
 <br/>
@@ -43,7 +42,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -90,7 +89,7 @@ If a special font is needed for this language, most computers will download it a
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the standalone vowels <span class='lang2' style='font-size:200%'>অ আ ই ঈ উ ঊ এ ঐ ও ঔ</span>, and many of the normal consonants: <span class='lang2' style='font-size:200%'>ক গ চ জ ট ড ণ ত দ ন প ব ম য় র ল ষ স হ ড়</span>.  Other consonants are typed using more than one key.  The keyboard also includes Bengali numbers, as well as punctuation and special characters.</p>
 
 <p>Bengali vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -149,7 +148,7 @@ If a special font is needed for this language, most computers will download it a
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ঔ</td><td class='lang2' style='font-size:200%'>কৌ</td><td><span class='keys'>kO</span></td>
 	</tr>
-	
+
 </table>
 
 </div>

--- a/legacy/isis/isis_malayalam/source/help/chart.php
+++ b/legacy/isis/isis_malayalam/source/help/chart.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_isis_malayalam
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'ISIS Malayalam Keyboard Help';
   $pagetitle = 'ISIS Malayalam Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Gautam Sengupta</p>
 
 <br/>
@@ -41,7 +40,7 @@
 <a style='margin-left:20px' href="#Authorship">Authorship</a><br/>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -88,7 +87,7 @@ If a special font is needed for this language, most computers will download it a
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the standalone vowels <span class='lang2' style='font-size:200%'>അ ആ ഇ ഈ ഉ ഊ ഋ എ ഏ ഐ ഒ ഓ ഔ</span>, and many of the normal consonants: <span class='lang2' style='font-size:200%'>ക ഖ ഗ ഘ ങ ച ഛ ജ ഝ ട ഠ ഡ ഢ ണ ത ഥ ദ ധ ന പ ഫ ബ ഭ മ യ ര ല ശ ഷ സ ഹ ള ഴ റ</span>.  Other consonants are typed using more than one key.  The keyboard also includes Malayalam numbers, as well as punctuation and special characters.</p>
 
 <p>Malayalam vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -153,7 +152,7 @@ If a special font is needed for this language, most computers will download it a
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ഔ</td><td class='lang2' style='font-size:200%'>കൌ</td><td><span class='keys'>kO</span></td>
 	</tr>
-	
+
 </table>
 
 </div>
@@ -960,7 +959,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >।</span><br/><span class='keys'>|</span></td>
 	</tr>
 
-	
+
 </table>
 
 

--- a/legacy/isis/isis_malayalam/source/help/isis_malayalam.php
+++ b/legacy/isis/isis_malayalam/source/help/isis_malayalam.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_isis_malayalam
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'ISIS Malayalam Keyboard Help';
   $pagetitle = 'ISIS Malayalam Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Gautam Sengupta</p>
 
 <br/>
@@ -43,7 +42,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -90,7 +89,7 @@ If a special font is needed for this language, most computers will download it a
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the standalone vowels <span class='lang2' style='font-size:200%'>അ ആ ഇ ഈ ഉ ഊ ഋ എ ഏ ഐ ഒ ഓ ഔ</span>, and many of the normal consonants: <span class='lang2' style='font-size:200%'>ക ഖ ഗ ഘ ങ ച ഛ ജ ഝ ട ഠ ഡ ഢ ണ ത ഥ ദ ധ ന പ ഫ ബ ഭ മ യ ര ല ശ ഷ സ ഹ ള ഴ റ</span>.  Other consonants are typed using more than one key.  The keyboard also includes Malayalam numbers, as well as punctuation and special characters.</p>
 
 <p>Malayalam vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -155,7 +154,7 @@ If a special font is needed for this language, most computers will download it a
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ഔ</td><td class='lang2' style='font-size:200%'>കൌ</td><td><span class='keys'>kO</span></td>
 	</tr>
-	
+
 </table>
 
 </div>

--- a/legacy/isis/isis_tamil/source/help/tamil_srii.php
+++ b/legacy/isis/isis_tamil/source/help/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/m/malayalam/source/help/chart.php
+++ b/legacy/m/malayalam/source/help/chart.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_malayalam
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Inscript Malayalam Keyboard Help';
   $pagetitle = 'Inscript Malayalam Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Tavultesoft</p>
 
 <br/>
@@ -41,7 +40,7 @@
 <a style='margin-left:20px' href="#Authorship">Authorship</a><br/>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -90,7 +89,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the 35 normal consonants <span class='lang2' style='font-size:200%'>ക ഖ ഗ ഘ ങ ച ഛ ജ ഝ ഞ ട ഠ ഡ ഢ ണ ത ഥ ദ ധ ന പ ഫ ബ ഭ മ യ ര ല വ ശ ഷ സ ഹ ള ഴ റ</span>, the vowels <span class='lang2' style='font-size:200%'>അ ആ ഇ ഈ ഉ ഊ ഋ എ ഏ ഐ ഒ ഓ ഔ   ാ ി ീ ു ൂ ൃ െ േ ൈ ൊ ോ ൌ ം ഃ</span>, and the <span class='lang2' style='font-size:200%'>്</span> mark.  There are also numbers and punctuation marks.</p>
 
 <p>Malayalam vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -155,7 +154,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ഔ</td><td class='lang2' style='font-size:200%'>കൌ</td><td><span class='keys'>kq</span></td>
 	</tr>
-	
+
 </table>
 
 </div>
@@ -946,7 +945,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<tr style='text-align:center; font-weight:normal; background-color:#ffffff'>
 		<td colspan=17>&nbsp;</td>
 	</tr>
-	
+
 	<tr class='keymanweb' style='text-align:center; font-weight:normal; background-color:#ffffff'>
 		<td style='text-align:left; font-weight:bold; background-color:#dedede' valign=top>Numerals, etc.</td>
 		<td><span class='lang2' >൧</span><br/><span class='keys'>[CA1]</span></td>
@@ -966,7 +965,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >ൡ</span><br/><span class='keys'>[CAR]</span></td>
 		<td><span class='lang2' >ൠ</span><br/><span class='keys'>[CA+]</span></td>
 	</tr>
-	
+
 </table>
 
 <div id="Back">

--- a/legacy/m/malayalam/source/help/malayalam.php
+++ b/legacy/m/malayalam/source/help/malayalam.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_malayalam
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Inscript Malayalam (deprecated) Keyboard Help';
   $pagetitle = 'Inscript Malayalam (deprecated) Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2008 Tavultesoft</p>
 
 <br/>
@@ -43,7 +42,7 @@
 <h4><a target="_blank" href="chart.pdf"><img border=0 style='vertical-align:bottom' src="<?php echo cdn('img/pdficon_small.gif'); ?>" /></a> Download this documentation in <a target="_blank" href="chart.pdf">PDF format</a>.</h4>
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -92,7 +91,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the 35 normal consonants <span class='lang2' style='font-size:200%'>ക ഖ ഗ ഘ ങ ച ഛ ജ ഝ ഞ ട ഠ ഡ ഢ ണ ത ഥ ദ ധ ന പ ഫ ബ ഭ മ യ ര ല വ ശ ഷ സ ഹ ള ഴ റ</span>, the vowels <span class='lang2' style='font-size:200%'>അ ആ ഇ ഈ ഉ ഊ ഋ എ ഏ ഐ ഒ ഓ ഔ   ാ ി ീ ു ൂ ൃ െ േ ൈ ൊ ോ ൌ ം ഃ</span>, and the <span class='lang2' style='font-size:200%'>്</span> mark.  There are also numbers and punctuation marks.</p>
 
 <p>Malayalam vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -157,7 +156,7 @@ For example, typing <span class='keys'>F</span> will produce the vowel <span cla
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ഔ</td><td class='lang2' style='font-size:200%'>കൌ</td><td><span class='keys'>kq</span></td>
 	</tr>
-	
+
 </table>
 
 </div>

--- a/legacy/m/mozhi_1_1_0/source/help/chart.php
+++ b/legacy/m/mozhi_1_1_0/source/help/chart.php
@@ -1,29 +1,28 @@
 <?php /*
   Name:             keyboard_mozhi_1_1_0
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Mozhi Malayalam Keyboard Help';
   $pagetitle = 'Mozhi Malayalam Keyboard Help';
   $style = 'lang2 {font-size:250%}';
-  
+
   require_once('header.php');
   ?>
 
-  
+
 <p style='margin:0px'>Keyboard &#169; 2006 Raj Nair</p>
 
 <br/>
@@ -42,7 +41,7 @@
 
 
 <div id='Overview'>
-		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically 
+		<!-- A brief introduction to the keyboard, including intended users and font/hardware requirements.  This is basically
 the info available on the keyboard download site.  Instructions on using the keyboard DO NOT go here. -->
 
 <h2>Overview</h2>
@@ -91,7 +90,7 @@ For example, typing <span class='keys'>i</span> will produce the vowel <span cla
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The On Screen Keyboard shows the 35 normal consonants <span class='lang2' style='font-size:200%'>ക ഖ ഗ ഘ ങ ച ഛ ജ ഝ ഞ ട ഠ ഡ ഢ ണ ത ഥ ദ ധ ന പ ഫ ബ ഭ മ യ ര ല വ ശ ഷ സ ഹ ള ഴ റ</span>, the vowels <span class='lang2' style='font-size:200%'>അ ആ ഇ ഈ ഉ ഊ ഋ എ ഏ ഐ ഒ ഓ ഔ</span>, and the <span class='lang2' style='font-size:200%'>്</span> mark.  There are also numbers and punctuation marks.</p>
 
 <p>Malayalam vowels and consonants are usually combined, so when you type a consonant and a vowel part, they will be joined into one character.  If you use the arrow keys to move through the text, you only need to press an arrow key once to move past each character.  If you press Delete before (on the left of) a combined consonant and vowel, it will be erased completely, but if you press Backspace after a character, only the vowel part will be erased (even if the vowel part appears before the consonant).
@@ -156,7 +155,7 @@ For example, typing <span class='keys'>i</span> will produce the vowel <span cla
 	<tr style='text-align:center'>
 		<td class='lang2' style='font-size:200%'></td><td class='lang2' style='font-size:200%'>ഔ</td><td class='lang2' style='font-size:200%'>കൌ</td><td><span class='keys'>kau</span></td>
 	</tr>
-	
+
 </table>
 
 </div>
@@ -980,7 +979,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		<td><span class='lang2' >ષ</span><br/><span class='keys'>&lt;</span></td>
 		<td><span class='lang2' >।</span><br/><span class='keys'>&gt;</span></td>
 	</tr>
-	
+
 </table>
 
 

--- a/legacy/t/tamil/source/help/chart.php
+++ b/legacy/t/tamil/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Inscript Keyboard Help';
   $pagetitle = 'Tamil Inscript Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/t/tamil/source/help/srii/tamil_srii.php
+++ b/legacy/t/tamil/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/t/tamil/source/help/tamil.php
+++ b/legacy/t/tamil/source/help/tamil.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Inscript (deprecated) Keyboard Help';
   $pagetitle = 'Tamil Inscript (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_modular/source/help/chart.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Modular (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Modular (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_modular/source/help/srii/tamil_srii.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_modular/source/help/visual_media_tamil_modular.php
+++ b/legacy/v/visual_media_tamil_modular/source/help/visual_media_tamil_modular.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Modular (Visual Media) (deprecated) Keyboard Help';
   $pagetitle = 'Tamil Modular (Visual Media) (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_typewriter/source/help/chart.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $pagetitle = 'Tamil Typewriter (Visual Media) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_typewriter/source/help/srii/tamil_srii.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/legacy/v/visual_media_tamil_typewriter/source/help/visual_media_tamil_typewriter.php
+++ b/legacy/v/visual_media_tamil_typewriter/source/help/visual_media_tamil_typewriter.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Typewriter (Visual Media) (deprecated) Keyboard Help';
   $pagetitle = 'Tamil Typewriter (Visual Media) (deprecated) Keyboard Help';
   $style = '.lang2 {font-size:130%}';

--- a/release/e/ekwtamil99uni/source/help/chart.php
+++ b/release/e/ekwtamil99uni/source/help/chart.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil99 Keyboard Help';
   $pagetitle = 'Tamil99 Keyboard Help';
   $style = 'lang2 {font-size:130%}';

--- a/release/e/ekwtamil99uni/source/help/ekwtamil99uni.php
+++ b/release/e/ekwtamil99uni/source/help/ekwtamil99uni.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'Tamil99 Keyboard Help';
   $pagetitle = 'Tamil99 Keyboard Help';
   $style = 'lang2 {font-size:130%}';

--- a/release/e/ekwtamil99uni/source/help/srii/tamil_srii.php
+++ b/release/e/ekwtamil99uni/source/help/srii/tamil_srii.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Initial version
 */
-  require_once('servervars.php');
   $pagename = 'Tamil Keyboards Help';
   $pagetitle = 'Tamil Keyboards Help';
   $style = '.lang2 {font-size:130%}';

--- a/release/t/thamizha_anjal_paangu/source/help/thamizha_anjal_paangu.php
+++ b/release/t/thamizha_anjal_paangu/source/help/thamizha_anjal_paangu.php
@@ -15,7 +15,6 @@
   Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'அஞ்சல் பாங்கு | Anjal Paangu Keyboard Help';
   $pagetitle = $pagename;
   $style = '.lang2 {font-size:130%}';

--- a/release/t/thamizha_bamini/source/help/thamizha_bamini.php
+++ b/release/t/thamizha_bamini/source/help/thamizha_bamini.php
@@ -1,21 +1,20 @@
 <?php /*
   Name:             keyboard_ekwbamuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Full help
 */
-  require_once('servervars.php');
   $pagename = 'சுரதா-பாமுனி | Suratha Bamini Keyboard Help';
   $pagetitle = $pagename;
   $style = '.lang2 {font-size:130%}';
@@ -34,10 +33,10 @@
 
 
 <p>
-This keyboard, usually known as the Bamini layout, is designed for the Tamil language. 
-It is originally based on a Tamil typewriter keyboard, and is used particularly in 
-Sri Lanka. The keyboard is designed for users who are familiar with both this layout 
-and the Tamil script, as consonants and vowels are typed in written order, and is 
+This keyboard, usually known as the Bamini layout, is designed for the Tamil language.
+It is originally based on a Tamil typewriter keyboard, and is used particularly in
+Sri Lanka. The keyboard is designed for users who are familiar with both this layout
+and the Tamil script, as consonants and vowels are typed in written order, and is
 intended for use with a normal QWERTY (English) keyboard. </p>
 
 
@@ -48,13 +47,13 @@ intended for use with a normal QWERTY (English) keyboard. </p>
 <div id='osk'>
   <h3>Desktop Keyboard layout</h3>
 </div>
-		
+
 
 <div id='Quickstart'>
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>[Sm]</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>m;</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>[Sx]</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>x</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>,
@@ -91,7 +90,7 @@ Short and long vowels appear next to each other.  For example, <span class='high
 <div id="Documentation">
 <h3>Full Documentation</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.</p>
@@ -637,7 +636,7 @@ This keyboard was created by Mugunth (mugunth@gmail.com), Umar (csd_one@yahoo.co
 		<td><span class='lang2' ></span><br/ ><span class='keys'></span></td></td>
 		<td><span class='lang2' ></span><br/ ><span class='keys'></span></td></td>
 		<td><span class='lang2' ></span><br/ ><span class='keys'></span></td></td>
-	</tr> 
+	</tr>
 	</table>
 </div>
 

--- a/release/t/thamizha_new_typewriter/source/help/thamizha_new_typewriter.php
+++ b/release/t/thamizha_new_typewriter/source/help/thamizha_new_typewriter.php
@@ -1,21 +1,20 @@
 <?php /*
   Name:             keyboard_ekwnewtwuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'புதிய தட்டெழுதி | New Typewriter Keyboard Help';
   $pagetitle = $pagename;
   $style = '.lang2 {font-size:130%}';
@@ -47,7 +46,7 @@ For example, the standalone vowel <span class='highlightExample'>இ</span> is e
 </p>
 
 <p>
-Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants. 
+Grantha letters, which are used for typing Sanskrit, appear on the keyboard and are treated as normal consonants.
 </p>
 
 </div>
@@ -82,7 +81,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>The visible keyboard layout consists of the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants and SRii<span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ ஸ்ரீ</span>, eleven vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ</span>, a range of vowel components and combinants characters, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks, as well as various punctuation marks.  The majority of characters are typed using a combination of keystrokes.</p>
 
 <p>Although many Tamil characters are typed using separate keys for consonants and components, the characters that appear on screen will be combinants, which the computer sees as a single character.  This means that while two (or more) keystrokes are required to display most consonant-vowel combinants, when you use the arrow keys to move the cursor through the text, only a single keystroke is needed to move past each character.  Moving the cursor to the left of a combinant character and pressing Delete will erase the whole character, but if you move the cursor to the right of a combinant and press Backspace, only the last-typed component will be erased.
@@ -91,7 +90,7 @@ Grantha letters, which are used for typing Sanskrit, appear on the keyboard and 
 <h4>Vowels and Pulli Marks</h4>
 <p>The standalone vowel characters which are on the keyboard will produce that character and will not combine with consonants.  Long vowels have their own keys.  Vowel-consonant combinant characters are entered either by typing a specific key for that combinant or by typing the consonant and vowel components separately.</p>
 
-<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.  
+<p>Vowel components that combine with consonants are typed either before or after the consonants, depending on whether the vowel component appears to the left or right of the consonant component.
 </p>
 <p>
 Because the consonants contain the implicit vowel <span class='highlightExample'>அ</span>, to produce a pure consonant it is necessary to add the Pulli mark <span class='lang2'>்</span> by typing a semicolon <span class='keys'>;</span> immediately after the consonant.  In every case, a consonant-Pulli mark combinant behaves the same way as a consonant-vowel combinant when you use the arrow, Backspace and Delete keys.  Any vowel component that is typed immediately after typing the Pulli mark will not be combined with the consonant.  Also, typing a semicolon after a standalone vowel or a space will produce a semicolon, not the Pulli mark.
@@ -102,7 +101,7 @@ Because the consonants contain the implicit vowel <span class='highlightExample'
 <h4>The SRii Character <img src='sri.png' style='vertical-align:bottom' /></h4>
 <p>
 This character is entered by typing <span class='keys'>_</span> (Shift+Underscore or Shift+Hyphen).  Currently, some browsers do not display this character correctly.
-</p>	
+</p>
 </div>
 
 <h4>Keystroke Examples</h4>

--- a/release/t/thamizha_tamil99_ext/source/help/thamizha_tamil99_ext.php
+++ b/release/t/thamizha_tamil99_ext/source/help/thamizha_tamil99_ext.php
@@ -1,21 +1,20 @@
 <?php /*
   Name:             keyboard_ekwnewtwuni
   Copyright:        Copyright (C) 2005 Tavultesoft Pty Ltd.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 Sep 2009
 
   Modified Date:    18 Sep 2009
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 Sep 2009 - mcdurdin - Additional help
 */
-  require_once('servervars.php');
   $pagename = 'த99-விரிவு | ta99 Extended Keyboard Help';
   $pagetitle = $pagename;
   $style = '.lang2 {font-size:130%}';
@@ -41,7 +40,7 @@ This keyboard is designed for the Tamil language, and is an extension of the Tam
 <h3>Quickstart</h3>
 		<!-- Basic instructions designed to get users up and running with typing -->
 
-<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key. 
+<p>This keyboard layout was designed for ease of typing.  Characters are arranged on the keyboard according to how frequently they are used.  Grantha letters, which are used for typing Sanskrit, are typed using the <span class='keys'>[S*]</span> key.
 Short and long vowels appear next to each other.  For example, <span class='highlightExample'>ஆ</span> (<span class='keys'>q</span> key) is above <span class='highlightExample'>அ</span> (<span class='keys'>a</span> key) , and <span class='highlightExample'>ஓ</span> (<span class='keys'>x</span> key) is beside <span class='highlightExample'>ஒ</span> (<span class='keys'>c</span> key).  Characters which normally appear together are also close together on the keyboard.</p>
 
 <p>Most of the characters used in Tamil are combinations of consonants and vowels, and these do not appear on the keyboard. Combined consonant-vowel characters are entered by typing the consonant, then the vowel.  To enter <span class='highlightExample'>ஙா</span>, which is a combination of <span class='highlightExample'>ங</span> and <span class='highlightExample'>ஆ</span>,
@@ -72,13 +71,13 @@ Short and long vowels appear next to each other.  For example, <span class='high
 			<td><span class='keys'>lks/f ams[[[[vos</td>
 		</tr>
 	</table>
-		
+
 </div>
 
 <div id="Documentation">
 <h3>Keyboard Details</h3>
 		<!-- The guts of the documentation: reasoning behind the keyboard layout; detailed instructions on typing & editing; instructions on special characters or keyboard behaviour, etc.; complete character/input chart or link to chart; -->
-	
+
 <p>This keyboard uses a consonant-vowel order for text input, so the consonant character is always typed before the vowel, regardless of where (relative to the consonant) the vowel marker symbol appears.  As syllables are typed, the characters entered are automatically converted to the appropriate consonant-vowel combinant.  While only the combinant characters are displayed on screen, the consonant and vowel are both stored, so that pressing Backspace once after a combinant deletes only the vowel component.  This means it is necessary to press Backspace twice to delete a combinant character.  However, pressing the Delete key with the cursor in front of a combinant character removes the whole character with one keystroke.</p>
 
 <p>The full Tamil99 keyboard layout consists of the twelve vowels <span class='lang2'>அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ</span>, the eighteen consonants <span class='lang2'>க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன</span>, the five Grantha consonants <span class='lang2'>ஸ ஷ ஜ ஹ க்ஷ</span>, the SRii consonant <span class='lang2'>ஸ்ரீ</span>, and the Pulli <span class='lang2'>்</span> and Aytham <span class='lang2'>ஃ</span> marks.  This Extended keyboard also includes keys for the characters <span class='lang2'>ஶ</span> and <span class='lang2'>்ரீ</span>.</p>
@@ -225,8 +224,8 @@ This character is entered by typing <span class='keys'>T</span>.  Currently, som
 		<td style='line-height:15px'><span class='keys' >S</span></td>
   </tr>
 </table>
-		<p>The caret mark (<span class='keys'>[S6]</span>) is used to produce various other characters, such as the glyphs used as vowel modifiers.  
-			These can be produced by typing the caret mark <span class='keys'>^</span> and then the corresponding vowel.  
+		<p>The caret mark (<span class='keys'>[S6]</span>) is used to produce various other characters, such as the glyphs used as vowel modifiers.
+			These can be produced by typing the caret mark <span class='keys'>^</span> and then the corresponding vowel.
 			Other characters typed in combination with <span class='keys'>^</span> are given in the table:</p>
 <table>
 	<tr valign="top">


### PR DESCRIPTION
This is just a maintenance cleanup; I noticed that some older .php files had a reference to servervars.php, which is not needed.