### PR TITLE
fix(sil_yi): remove space from group name

### DIFF
--- a/release/sil/sil_yi/source/sil_yi.kmn
+++ b/release/sil/sil_yi/source/sil_yi.kmn
@@ -15,11 +15,11 @@ store(&KEYBOARDVERSION) '1.3.1'
 store(&VISUALKEYBOARD) 'sil_yi.kvks'
 store(&LAYOUTFILE) 'sil_yi.keyman-touch-layout'
 
-begin Unicode > use(Unicode Group)
+begin Unicode > use(UnicodeGroup)
 
 store(nul) "ABCDEFGHIJKLMNOPQRSTUVWXYZ@$^&" '"'
 
-group(Unicode Group) using keys
+group(UnicodeGroup) using keys
 
 c RULES
 + any(nul) > nul


### PR DESCRIPTION
v19 of kmc will disallow spaces in group names. Pre-emptively tweaking this. As this change has no functional impact, am not bumping the version number or history.

Relates-to: keymanapp/keyman#14746
Relates-to: keymanapp/keyman#14604