### PR TITLE
[geezword_tigrinya] Fix help CSS indentation level

### DIFF
--- a/release/g/geezword_tigrinya/source/help/geezword_tigrinya.php
+++ b/release/g/geezword_tigrinya/source/help/geezword_tigrinya.php
@@ -3,31 +3,31 @@
   $pagename  = $pagetitle;
   $keymanpromourl = 'https://ethiopic.keymankeyboards.com';
   $pagestyle = <<<END
-table { border: 0; cellspacing: 0; cellpadding: 0; border-collapse: collapse; }
-th, td { border: solid #bfbfbf 1.0pt; border-collapse: collapse; }
-th, td { width: 54; text-align: center; }
-th { background: #95DCF7; }
-* {
-  box-sizing: border-box;
-}
+  table { border: 0; cellspacing: 0; cellpadding: 0; border-collapse: collapse; }
+  th, td { border: solid #bfbfbf 1.0pt; border-collapse: collapse; }
+  th, td { width: 54; text-align: center; }
+  th { background: #95DCF7; }
+  * {
+    box-sizing: border-box;
+  }
 
-.row {
-  margin-left:-5px;
-  margin-right:-5px;
-}
-  
-.column {
-  float: left;
-  width: 50%;
-  padding: 5px;
-}
+  .row {
+    margin-left:-5px;
+    margin-right:-5px;
+  }
+    
+  .column {
+    float: left;
+    width: 50%;
+    padding: 5px;
+  }
 
-/* Clearfix (clear floats) */
-.row::after {
-  content: "";
-  clear: both;
-  display: table;
-}
+  /* Clearfix (clear floats) */
+  .row::after {
+    content: "";
+    clear: both;
+    display: table;
+  }
   END;
   
   require_once('header.php');


### PR DESCRIPTION
Fixes CSS indentation of the geezword_tigrinya help file which blocked help deployment on keymanapp/help.keyman.com#2312 and keymanapp/help.keyman.com#2313

> PHP Parse error:  Invalid body indentation level (expecting an indentation level of at least 2) in ./keyboard/geezword_tigrinya/18.0/geezword_tigrinya.php on line 6