### PR TITLE
[amazigh_latin] Link to deprecated keyboards

### DIFF
--- a/legacy/a/amazigh_lat.kmn/DEPRECATED.md
+++ b/legacy/a/amazigh_lat.kmn/DEPRECATED.md
@@ -1,2 +1,1 @@
-This keyboard has been deprecated and replaced by legacy/a/amazigh_lat
-
+This keyboard has been deprecated and replaced by release/a/amazigh_latin

--- a/legacy/a/amazigh_lat/DEPRECATED.md
+++ b/legacy/a/amazigh_lat/DEPRECATED.md
@@ -1,0 +1,1 @@
+This keyboard has been deprecated and replaced by release/a/amazigh_latin.

--- a/release/a/amazigh_latin/source/amazigh_latin.kps
+++ b/release/a/amazigh_latin/source/amazigh_latin.kps
@@ -96,5 +96,9 @@
       </Languages>
     </Keyboard>
   </Keyboards>
+  <RelatedPackages>
+    <RelatedPackage ID="amazigh_lat" Relationship="deprecates"/>
+    <RelatedPackage ID="amazigh_lat.kmn" Relationship="deprecates"/>
+  </RelatedPackages>
   <Strings/>
 </Package>


### PR DESCRIPTION

Does #3781 (release/a/amazigh_latin) deprecate legacy/a/amazigh_lat and legacy/a/amazigh_lat.kmn?

If so, this updates some DEPRECATED.md files so the keyboard search will show the linking

I also wasn't sure if we need to update the legacy/...keyboard_info files