### PR TITLE
[sil_arabic_phonetic] change Shift + U key to use unicode code point

### DIFF
--- a/release/sil/sil_arabic_phonetic/HISTORY.md
+++ b/release/sil/sil_arabic_phonetic/HISTORY.md
@@ -1,5 +1,8 @@
 # Arabic Phonetic (SIL) Keyboard Change History
 
+## 1.4 (5 Feb 2026)
+* Edit rule `ٖ` to be a Unicode Code Point.
+
 ## 1.3 (27 Jan 2026)
 * Add `ٖ`, `ٗ`, `ٰ` to Shift O, Shift I, and Shift U.
 

--- a/release/sil/sil_arabic_phonetic/source/sil_arabic_phonetic.kmn
+++ b/release/sil/sil_arabic_phonetic/source/sil_arabic_phonetic.kmn
@@ -9,7 +9,7 @@ c store(&LANGUAGE) 'x0401'
 c store(&ETHNOLOGUECODE) 'arb ara aao arq bbz abv shu acy adf avl arz afb ayh acw ayl acm ary ars apc ayp acx aec ayn ssh ajp pga apd acq abh aeb auz'
 store(&BITMAP) 'sil_arabic_phonetic.ico'
 store(&KMW_RTL) '1'
-store(&KEYBOARDVERSION) '1.3'
+store(&KEYBOARDVERSION) '1.4'
 store(&LAYOUTFILE) 'sil_arabic_phonetic.keyman-touch-layout'
 store(&TARGETS) 'any'
 store(&DISPLAYMAP) '../../../shared/fonts/kbd/kbdarab/KbdArab.json'
@@ -87,7 +87,7 @@ c + 'X' > 'ْ'
 + 'W' > dk(none)
 + 'E' > 'ٱ' 
 + 'R' > dk(none)
-+ 'U' > ' ٰ'
++ 'U' > U+0670
 + 'I' > 'ٗ'
 + 'O' > 'ٖ'
 + 'P' > dk(none)


### PR DESCRIPTION
Fix #3870
Fix #3861 

Test-bot: skip

This PR fix the issue of a space output when typing the Superscript alef (key Shift + U). Ready for reviews.

Desktop output:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/10ac86d1-baca-4379-9ea9-1ef67a098c8b" />

Mobile output:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4c247989-dd6f-4a88-8100-c8c58c7e1579" />
