### PR TITLE
[english_shavian_jafl] Correction to english_shavian_jafl

### DIFF
--- a/release/e/english_shavian_jafl/HISTORY.md
+++ b/release/e/english_shavian_jafl/HISTORY.md
@@ -1,6 +1,10 @@
 Shaw JAFL Change History
 ====================
 
+1.2 (2026-02-13)
+----------------
+* Corrected error in which long press on the $ key in touchscreen layouts produced 𐑹 instead of the £ symbol.
+
 1.1 (2025-06-26)
 ----------------
 * Corrected minor typos in welcome.html

--- a/release/e/english_shavian_jafl/LICENSE.md
+++ b/release/e/english_shavian_jafl/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2025 Shavian.info
+Copyright © 2025-2026 Shavian.info
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/e/english_shavian_jafl/source/english_shavian_jafl.keyman-touch-layout
+++ b/release/e/english_shavian_jafl/source/english_shavian_jafl.keyman-touch-layout
@@ -2054,8 +2054,7 @@
                 "sk": [
                   {
                     "text": "£",
-                    "id": "K_W",
-                    "layer": "shift"
+                    "id": "U_00A3"
                   },
                   {
                     "text": "€",
@@ -5118,8 +5117,7 @@
                 "sk": [
                   {
                     "text": "£",
-                    "id": "K_W",
-                    "layer": "shift"
+                    "id": "U_00A3"
                   },
                   {
                     "text": "€",

--- a/release/e/english_shavian_jafl/source/english_shavian_jafl.kmn
+++ b/release/e/english_shavian_jafl/source/english_shavian_jafl.kmn
@@ -1,9 +1,11 @@
-﻿c shaw_jafl generated from template at 2025-01-13 17:57:51
+﻿c Corrected error in which long press on the $ key in touchscreen layouts produced Shavian letter 'Or' instead of the GBP symbol. 
+c 
+c shaw_jafl generated from template at 2025-01-13 17:57:51
 c with name "Shaw JAFL"
 store(&VERSION) '17.0'
 store(&NAME) 'Shaw JAFL'
 store(&COPYRIGHT) '© Shavian.info'
-store(&KEYBOARDVERSION) '1.1'
+store(&KEYBOARDVERSION) '1.2'
 store(&BITMAP) 'shaw_jafl.ico'
 store(&VISUALKEYBOARD) 'english_shavian_jafl.kvks'
 store(&LAYOUTFILE) 'english_shavian_jafl.keyman-touch-layout'


### PR DESCRIPTION
Corrects error in which long press on the $ key in touchscreen layouts produced 𐑹 instead of the £ symbol.