### PR TITLE
[mingrelian_phonetic] Fix php help

### DIFF
--- a/experimental/m/mingrelian_phonetic/source/help/mingrelian_phonetic.php
+++ b/experimental/m/mingrelian_phonetic/source/help/mingrelian_phonetic.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
   $pagename = 'Mingrelian Phonetic Keyboard Help';
   $pagetitle = $pagename;
-  
-  $pagestyle = <<<END 
+
+  $pagestyle = <<<END
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
     h2 { font: bold 12pt Tahoma; color: #4444cc; }
@@ -36,8 +36,8 @@
     .georgian-table .empty-cells {
       background-color: #fafafa;
     }
-  END;
-  
+END;
+
   require_once('header.php');
 ?>
 


### PR DESCRIPTION
Follows #4060

Hopefully this fix the keyboard help deployment (CI failing on @keymanapp/help.keyman.com#2613 )

> PHP Parse error:  syntax error, unexpected '<<' (T_SL) in ./keyboard/mingrelian_phonetic/2.0/mingrelian_phonetic.php on line 5
Errors parsing ./keyboard/mingrelian_phonetic/2.0/mingrelian_phonetic.php

Test-bot: skip
