### PR TITLE
[help_files] Fix spacing on laz_phonetic and add deprecated to titles

### DIFF
--- a/experimental/c/colchis_phonetic/source/help/colchis_phonetic.php
+++ b/experimental/c/colchis_phonetic/source/help/colchis_phonetic.php
@@ -1,5 +1,5 @@
-<?php 
-  $pagename = 'Colchian Phonetic Keyboard Help';
+<?php
+  $pagename = 'Colchian Phonetic (deprecated) Keyboard Help';
   $pagetitle = $pagename;
   // Header we will tidy up later  
   require_once('header.php');

--- a/experimental/k/karambolpoular/source/help/karambolpoular.php
+++ b/experimental/k/karambolpoular/source/help/karambolpoular.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'karambolpoular Keyboard Help';
+  $pagename = 'karambolpoular (deprecated) Keyboard Help';
   $pagetitle = $pagename;
   require_once('header.php');
 ?>

--- a/experimental/l/laz_phonetic/source/help/laz_phonetic.php
+++ b/experimental/l/laz_phonetic/source/help/laz_phonetic.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
   $pagename = 'Laz Phonetic Keyboard Help';
   $pagetitle = $pagename;
 
-  $pagestyle = <<<END 
+  $pagestyle = <<<END
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
     h2 { font: bold 12pt Tahoma; color: #4444cc; }
@@ -37,7 +37,7 @@
       background-color: #fafafa;
     }
   END;
-  
+
   require_once('header.php');
 ?>
 

--- a/release/a/armenian_mnemonic_r/source/help/armenian_mnemonic_r.php
+++ b/release/a/armenian_mnemonic_r/source/help/armenian_mnemonic_r.php
@@ -1,7 +1,6 @@
 <?php
-  $pagename = 'Armenian Mnemonic R Keyboard Help';
-  $pagetitle = 'Armenian Mnemonic R Keyboard Help';
-  
+  $pagename = 'Armenian Mnemonic R (deprecated) Keyboard Help';
+  $pagetitle = $pagename;
   require_once('header.php');
 ?>
 

--- a/release/c/colchis_latin/source/help/colchis_latin.php
+++ b/release/c/colchis_latin/source/help/colchis_latin.php
@@ -1,5 +1,5 @@
-<?php 
-  $pagename = 'Colchis Latin Keyboard Help';
+<?php
+  $pagename = 'Colchis Latin (deprecated) Keyboard Help';
   $pagetitle = $pagename;
   // Header we will tidy up later  
   require_once('header.php');


### PR DESCRIPTION
The laz_phonetic didn't build maybe because of extra spaces.

I forgot that we should add the word "(deprecated)" to help file titles when keyboards are deprecated. That helps this page: https://help.keyman.com/keyboard/ to sort the deprecated keyboards at the bottom of the list.