### PR TITLE
[uma_phonetic][engram] change header to indicated deprecated

### DIFF
--- a/release/engram/engram/source/help/engram.php
+++ b/release/engram/engram/source/help/engram.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'Engram Keyboard Help';
+  $pagename = 'Engram (deprecated) Keyboard Help';
   $pagetitle = $pagename;
   // Header we will tidy up later  
   require_once('header.php');

--- a/release/u/uma_phonetic/source/help/uma_phonetic.php
+++ b/release/u/uma_phonetic/source/help/uma_phonetic.php
@@ -1,5 +1,5 @@
 <?php 
-  $pagename = 'Uma Phonetic Keyboard Help';
+  $pagename = 'Uma Phonetic (deprecated) Keyboard Help';
   $pagetitle = $pagename;
   require_once('header.php');
 ?>


### PR DESCRIPTION
I found two more headers for which I had not changed the online help to indicate they were deprecated.