### PR TITLE
chore: disable auto-commenter until fix for PR search algorithm lands

### DIFF
--- a/resources/build/version/build.sh
+++ b/resources/build/version/build.sh
@@ -33,7 +33,7 @@ do_run() {
       ! builder_has_option --build-id; then
     builder_die "Parameters --teamcity-token, --github-token, --build-id are required"
   fi
-  node . run --teamcity-token "$TEAMCITY_TOKEN" --github_token "$GITHUB_TOKEN" --build-id "$BUILD_ID"
+  node . run --teamcity-token "$TEAMCITY_TOKEN" --github-token "$GITHUB_TOKEN" --build-id "$BUILD_ID"
 }
 
 builder_run_action clean      rm -rf build/ node_modules/

--- a/resources/teamcity/keyboards/keyboards-build-deploy.sh
+++ b/resources/teamcity/keyboards/keyboards-build-deploy.sh
@@ -82,8 +82,10 @@ function do_publish() {
 
 function do_report() {
   "${REPO_ROOT}/resources/build/version/build.sh" configure build
-  local BUILD_ID="${BUILD_URL##*/}"
-  "${REPO_ROOT}/resources/build/version/build.sh" run --teamcity-token "$TEAMCITY_TOKEN" --github-token "$GITHUB_TOKEN" --build-id "$BUILD_ID"
+  # TODO: this is not currently working correctly; we need to retrieve the previous commit on master rather than the information from
+  # TeamCity which shows commits on the branch. Disabled for now.
+  # local BUILD_ID="${BUILD_URL##*/}"
+  # "${REPO_ROOT}/resources/build/version/build.sh" run --teamcity-token "$TEAMCITY_TOKEN" --github-token "$GITHUB_TOKEN" --build-id "$BUILD_ID"
 }
 
 cd "${REPO_ROOT}"


### PR DESCRIPTION
Note, also fixes a typo in build.sh _ vs -.

This is not currently working correctly; we need to retrieve the previous commit on master rather than the information from TeamCity which shows commits on the branch.

Test-bot: skip